### PR TITLE
Fix provider payload wrapping hook

### DIFF
--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -37,4 +37,13 @@ Update this file frequently during execution.
 - [ ] Add reviewer step in workflow
 - [ ] Test parallel/chain subagent delegation
 
+## Phase 6: Provider Payload Hook Repair
+- [x] Diagnosed pi 0.74 provider errors after skill install: `before_provider_request` returned `{ payload }` instead of the replacement payload directly.
+- [x] Patched `extensions/xai-oauth.ts` so sanitized provider requests are returned in the shape pi expects.
+- [x] Removed the redundant global provider request hook so xAI sanitation stays inside the xAI provider stream path and does not mutate DeepSeek/Codex payloads.
+- [x] Reinstalled the local package, cleared pi's Jiti cache, and verified provider smoke tests:
+  - xAI now reaches the xAI API and returns an account/subscription 403 instead of `missing field input`.
+  - DeepSeek returns `OK` instead of `missing field messages`.
+  - OpenAI Codex returns `OK` instead of rejecting model `None`.
+
 **Current branch:** feature/multi-agent-integration

--- a/extensions/xai-oauth.ts
+++ b/extensions/xai-oauth.ts
@@ -7,7 +7,6 @@ import { createServer, type Server } from "http";
 import { homedir } from "os";
 import { extname, isAbsolute, join, resolve } from "path";
 import { fileURLToPath } from "url";
-import { sanitizeXaiPayload } from "../sanitize";
 
 const XAI_OAUTH_ISSUER = "https://auth.x.ai";
 const XAI_OAUTH_DISCOVERY_URL = `${XAI_OAUTH_ISSUER}/.well-known/openid-configuration`;
@@ -1143,13 +1142,4 @@ Be specific and cite examples where helpful.`;
   }
 
   registerXaiTools();
-
-  // Payload sanitization hook (runs before every provider request)
-  pi.on("before_provider_request", (event) => {
-    const sanitized = sanitizeXaiPayload(event.payload, null as any);
-    if (sanitized !== event.payload) {
-      return { payload: sanitized };
-    }
-  });
 }
-


### PR DESCRIPTION
## Summary
- remove the global before_provider_request payload sanitizer from the xAI extension
- keep xAI request rewriting scoped to the xAI stream path
- update scaffold progress with verification notes

## Verification
- npx tsc --noEmit
- pi --provider deepseek --model deepseek-v4-pro --thinking high --no-skills --no-context-files --no-tools --no-session -p "Reply with OK." -> OK
- pi --provider openai-codex --model gpt-5.5 --thinking high --no-skills --no-context-files --no-tools --no-session -p "Reply with OK." -> OK
- pi --provider xai-auth --model grok-4.3 --thinking high --no-skills --no-context-files --no-tools --no-session -p "Reply with OK." -> reaches xAI API and returns account/subscription 403 instead of missing input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved provider payload shape errors affecting the xAI provider after skill installation
  * Verified functionality and stability across xAI, DeepSeek, and OpenAI Codex providers through comprehensive smoke testing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BlockedPath/pi-xai-oauth/pull/4?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->