### PR TITLE
feat: add grok-build-0.1 support (fast agentic coding model)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 npx pi-xai-oauth
 ```
 
-This package adds **Grok 4.3** as a fully-integrated provider in pi, with proper OAuth login, automatic token refresh, and a suite of custom tools (`xai_generate_text`, `xai_web_search`, `xai_x_search`, etc.).
+This package adds **Grok models** (including Grok 4.3 and Grok Build 0.1 for agentic coding) as a fully-integrated provider in pi, with proper OAuth login, automatic token refresh, and a suite of custom tools (`xai_generate_text`, `xai_web_search`, `xai_x_search`, etc.).
 
 ---
 
@@ -144,6 +144,7 @@ pi --model grok-4.3 "Write a poem about Rust"
 
 | Model ID | Description |
 |----------|-------------|
+| `grok-build-0.1` | **Fast coding model** for agentic software engineering. 256K context, native tool calling + structured outputs + vision. |
 | `grok-4.3` | **Default.** Full reasoning, 1M context. |
 | `grok-4.20-0309-reasoning` | Legacy Grok 4.2 with reasoning. |
 | `grok-4.20-0309-non-reasoning` | Legacy Grok 4.2, fast responses. |

--- a/extensions/xai-oauth.ts
+++ b/extensions/xai-oauth.ts
@@ -43,7 +43,8 @@ const MODELS = [
     name: "Grok Build 0.1",
     reasoning: true,
     input: ["text", "image"],
-    cost: { input: 1, output: 2, cacheRead: 0.2, cacheWrite: 0.5 },
+    // xAI bills cached prompt tokens at the cached input rate.
+    cost: { input: 1, output: 2, cacheRead: 0.2, cacheWrite: 0.2 },
     contextWindow: 256_000,
     maxTokens: 256_000,
   },
@@ -444,7 +445,7 @@ function extractResponsesText(data: any): string {
 
 function grokSupportsReasoningEffort(modelId: string): boolean {
   const normalized = (modelId || "").toLowerCase().split("/").pop() || "";
-  return normalized.startsWith("grok-3-mini") || normalized.startsWith("grok-4.20-multi-agent") || normalized.startsWith("grok-4.3");
+  return normalized.startsWith("grok-build") || normalized.startsWith("grok-3-mini") || normalized.startsWith("grok-4.20-multi-agent") || normalized.startsWith("grok-4.3");
 }
 
 function textFromResponsesContent(content: unknown): string {

--- a/extensions/xai-oauth.ts
+++ b/extensions/xai-oauth.ts
@@ -39,6 +39,15 @@ type CallbackResult = {
 
 const MODELS = [
   {
+    id: "grok-build-0.1",
+    name: "Grok Build 0.1",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: { input: 1, output: 2, cacheRead: 0.2, cacheWrite: 0.5 },
+    contextWindow: 256_000,
+    maxTokens: 256_000,
+  },
+  {
     id: "grok-4.3",
     name: "Grok 4.3",
     reasoning: true,

--- a/extensions/xai-oauth.ts
+++ b/extensions/xai-oauth.ts
@@ -41,7 +41,8 @@ const MODELS = [
   {
     id: "grok-build-0.1",
     name: "Grok Build 0.1",
-    reasoning: true,
+    // Grok Build can reason internally, but xAI currently rejects controllable reasoning effort.
+    reasoning: false,
     input: ["text", "image"],
     // xAI bills cached prompt tokens at the cached input rate.
     cost: { input: 1, output: 2, cacheRead: 0.2, cacheWrite: 0.2 },
@@ -445,7 +446,8 @@ function extractResponsesText(data: any): string {
 
 function grokSupportsReasoningEffort(modelId: string): boolean {
   const normalized = (modelId || "").toLowerCase().split("/").pop() || "";
-  return normalized.startsWith("grok-build") || normalized.startsWith("grok-3-mini") || normalized.startsWith("grok-4.20-multi-agent") || normalized.startsWith("grok-4.3");
+  // Keep grok-build excluded: xAI returns 400 for controllable reasoning effort on grok-build-0.1.
+  return normalized.startsWith("grok-3-mini") || normalized.startsWith("grok-4.20-multi-agent") || normalized.startsWith("grok-4.3");
 }
 
 function textFromResponsesContent(content: unknown): string {


### PR DESCRIPTION
## Description

Adds `grok-build-0.1` — xAI's fast coding model for agentic software engineering workflows (released May 2026, currently in early access).

### Changes
- **`extensions/xai-oauth.ts`**: New model entry in `MODELS` array — `grok-build-0.1` with reasoning + vision + tool calling + structured outputs, 256K context window
- **`README.md`**: Updated intro (Grok models, not just 4.3) + added `grok-build-0.1` to the switching models table

### Specs (from OpenRouter xAI provider page)

| Property | Value |
|----------|-------|
| Context window | 256K |
| Max output | 256K (no hard limit) |
| Input | Text + Image |
| Reasoning | Yes (adjustable) |
| Pricing (≤200K) | $1/1M input, $2/1M output, $0.20/1M cache read |
| Pricing (>200K) | $2/1M input, $4/1M output, $0.40/1M cache read |

Uses the existing `xai-responses` streaming + OAuth flow — no new auth or API changes needed.

Ref: https://openrouter.ai/x-ai/grok-build-0.1

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] TypeScript compiles without errors (`npx tsc --noEmit` passes)
- [x] Model definition follows existing pattern (id, name, reasoning, input, cost, contextWindow, maxTokens)
- [x] Pricing matches OpenRouter xAI provider published rates

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Grok Build 0.1 — fast coding model with 256K context, native tool calling, structured outputs, and vision; includes OAuth integration, automatic token refresh, and custom tool support.
* **Enhancements**
  * Improved reasoning support and model handling for grok-build models.
* **Documentation**
  * README updated to describe Grok Build 0.1 and model-switching table.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BlockedPath/pi-xai-oauth/pull/6?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->