### PR TITLE
feat: register grok-build and Composer 2.5 models for xAI OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ pi --model grok-4.3 "Write a poem about Rust"
 | `grok-4.20-0309-reasoning` | Grok 4.20 with automatic reasoning, 2M context. |
 | `grok-4.20-0309-non-reasoning` | Grok 4.20 fast responses, 2M context. |
 | `grok-4.20-multi-agent-0309` | Grok 4.20 multi-agent research model, 2M context. |
+| `grok-build` | Grok Build — xAI's agentic coding model (Grok CLI default), 512k context. |
+| `grok-build-0.1` | Grok Build 0.1 — same family on the public API, 256k context. |
+| `grok-composer-2.5-fast` | Composer 2.5 — fast coding model with automatic reasoning, 200k context. |
 
 From the pi TUI:
 
@@ -169,6 +172,8 @@ From the pi TUI:
 /model grok-4.3
 /model grok-4.20-0309-reasoning
 /model grok-4.20-multi-agent-0309
+/model grok-build
+/model grok-composer-2.5-fast
 ```
 
 From the command line:
@@ -199,7 +204,7 @@ pi --model grok-4.3:low "What's the weather?"
 - **`medium`** — Balanced speed and depth.
 - **`low`** — Fast responses, minimal reasoning. Good for simple Q&A.
 
-`grok-4.20-0309-reasoning` reasons automatically and does not accept a configurable effort parameter. `grok-4.20-multi-agent-0309` uses `medium` for 4 agents and `high` for 16 agents.
+`grok-4.20-0309-reasoning` and `grok-composer-2.5-fast` reason automatically and do not accept a configurable effort parameter. `grok-4.20-multi-agent-0309` uses `medium` for 4 agents and `high` for 16 agents. `grok-build` and `grok-build-0.1` do not accept configurable reasoning effort.
 
 ---
 

--- a/extensions/xai-oauth.ts
+++ b/extensions/xai-oauth.ts
@@ -79,6 +79,33 @@ const MODELS = [
     contextWindow: 2_000_000,
     maxTokens: 131_072,
   },
+  {
+    id: "grok-build",
+    name: "Grok Build",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: { input: 1, output: 2, cacheRead: 0.2, cacheWrite: 0 },
+    contextWindow: 512_000,
+    maxTokens: 131_072,
+  },
+  {
+    id: "grok-build-0.1",
+    name: "Grok Build 0.1",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: { input: 1, output: 2, cacheRead: 0.2, cacheWrite: 0 },
+    contextWindow: 256_000,
+    maxTokens: 131_072,
+  },
+  {
+    id: "grok-composer-2.5-fast",
+    name: "Composer 2.5",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: { input: 1, output: 2, cacheRead: 0.2, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 131_072,
+  },
 ];
 
 const xaiToolRegistrations = new WeakSet<object>();

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -143,6 +143,10 @@ async function main() {
     assert.equal(provider.models.find((model) => model.id === "grok-4.3")?.contextWindow, 1_000_000);
     assert.equal(provider.models.find((model) => model.id === "grok-4.20-0309-reasoning")?.contextWindow, 2_000_000);
     assert.ok(provider.models.some((model) => model.id === "grok-4.20-multi-agent-0309"));
+    assert.equal(provider.models.find((model) => model.id === "grok-build")?.contextWindow, 512_000);
+    assert.equal(provider.models.find((model) => model.id === "grok-build-0.1")?.contextWindow, 256_000);
+    assert.equal(provider.models.find((model) => model.id === "grok-composer-2.5-fast")?.contextWindow, 200_000);
+    assert.equal(provider.models.find((model) => model.id === "grok-composer-2.5-fast")?.reasoning, true);
 
     await verifyOAuthCallbackState(provider);
 


### PR DESCRIPTION
## Description

Register three new xAI OAuth models in the provider:

- `grok-build` — Grok CLI default agentic coding model (512k context)
- `grok-build-0.1` — public API variant (256k context)
- `grok-composer-2.5-fast` — Composer 2.5 fast coding model (200k context)

Model metadata aligns with Grok CLI `models_cache.json` and xAI docs. README updated with model table, TUI examples, and reasoning-effort notes.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] `npx tsc --noEmit`
- [x] `node scripts/verify-extension.js`
- [x] Live OAuth smoke test against `https://api.x.ai/v1/responses` with `~/.grok/auth.json` — `grok-build` and `grok-composer-2.5-fast` returned HTTP 200
- [x] Manual pi session test via symlinked local package (`pi --model grok-build`, `pi --model grok-composer-2.5-fast`)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if appropriate)

N/A

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for three new models: `grok-build`, `grok-build-0.1`, and `grok-composer-2.5-fast`.

* **Documentation**
  * Updated model switching documentation with new model options and clarified reasoning effort configuration for available models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->