### PR TITLE
Add Composer 2.5 and Grok CLI tool shims

### DIFF
--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -82,4 +82,17 @@ Update this file frequently during execution.
 - [x] Initialized real git repo, switched to feature branch, updated docs
 - [x] Working tree clean, up-to-date with `origin/main`
 
-**Current branch:** feature/xai-tools-all-verified
+**Current branch:** feature/add-composer-2-5-models
+
+## Phase 9: Add Composer 2.5 model selection
+- [x] Created branch `feature/add-composer-2-5-models`.
+- [x] Added `grok-composer-2.5-fast` and `grok-build` to the `xai-auth` provider model catalog.
+- [x] Routed Grok CLI-only models through `https://cli-chat-proxy.grok.com/v1` with Grok CLI OAuth headers while keeping Grok 4.3/default models on `https://api.x.ai/v1`.
+- [x] Updated custom tool request routing so `xai_generate_text` can use Composer 2.5/Grok Build model IDs.
+- [x] Updated README/setup copy and verification coverage.
+- [x] Added local `typescript` dev dependency so `npm run typecheck` resolves the real compiler and passes consistently.
+- [x] Verified with `npm test`, `npm run typecheck`, `node bin/setup.js --help`, `git diff --check`, `npm pack --dry-run`, and `pi install .`.
+- [x] Added README troubleshooting/updating guidance for duplicate npm/local/worktree installs causing `xai_*` tool conflicts.
+- [x] Added Cursor/Grok CLI tool shims (`Read`, `Write`, `StrReplace`, `Edit`, `Delete`, `LS`, `Grep`, `Glob`, `Shell`, `WebSearch`) for Composer 2.5/Grok Build and model-scoped activation.
+- [x] Added verification for shim registration, activation/deactivation, argument normalization, and Grep/Glob/Read/Write/StrReplace/Shell/Delete execution.
+- [x] Documented Composer/Grok Build tool compatibility in README.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 npx pi-xai-oauth
 ```
 
-This package adds **Grok 4.3** as a fully-integrated provider in pi, with proper OAuth login, automatic token refresh, and a suite of custom tools (`xai_generate_text`, `xai_web_search`, `xai_x_search`, etc.).
+This package adds **Grok 4.3**, **Grok Build**, and **Composer 2.5** as fully-integrated xAI OAuth models in pi, with proper OAuth login, automatic token refresh, and a suite of custom tools (`xai_generate_text`, `xai_web_search`, `xai_x_search`, etc.).
 
 ---
 
@@ -45,9 +45,10 @@ This package adds **Grok 4.3** as a fully-integrated provider in pi, with proper
 - **Token refresh** — refresh tokens are stored and rotated automatically before expiry
 - **Reuses existing credentials** — auto-detects `~/.grok/auth.json` from the official Grok CLI
 - **1M context window** — Grok 4.3's full context, no truncation
+- **Coding models** — Grok Build and Composer 2.5 Fast are available from the same `xai-auth` provider
 - **Reasoning support** — configurable thinking levels: `low` / `medium` / `high`
 - **Custom xAI tools** — generate text, web search, X/Twitter search, multi-agent research, code analysis
-- **Modern API** — uses OpenAI's `responses` API format via `https://api.x.ai/v1`
+- **Modern API** — uses OpenAI's `responses` API format via `https://api.x.ai/v1`, with Grok CLI endpoint routing for CLI-only models
 
 > **✅ Verified (May 2026)**: All custom xAI tools (`xai_generate_text`, `xai_x_search`, `xai_web_search`, `xai_code_execution`, `xai_critique`, `xai_multi_agent`, `xai_deep_research`, image tools, etc.) have been tested end-to-end after the OAuth + payload repair. The provider now correctly handles mixed-model requests and native xAI tool shapes.
 
@@ -99,16 +100,29 @@ Then optionally configure it as default:
 }
 ```
 
-> **⚠️ Important: Local Development vs Published Package**
-> 
-> If you have **both** `npm:pi-xai-oauth` and a local path installed (`pi list` will show both), pi will refuse to load the local version because the tool names conflict.
-> 
-> **Fix:**
+> **⚠️ Important: install only one copy**
+>
+> `pi-xai-oauth` registers fixed tool names such as `xai_generate_text`, `xai_web_search`, and `xai_x_search`. If you install more than one copy — for example `npm:pi-xai-oauth` plus a local checkout, or two different local checkouts — pi will fail to start with `Tool "xai_generate_text" conflicts with ...` errors.
+>
+> Check with:
+> ```bash
+> pi list
+> ```
+>
+> For local development, keep only this checkout:
 > ```bash
 > pi remove npm:pi-xai-oauth
+> pi remove /path/to/other/pi-xai-oauth-copy
 > pi install .
 > ```
-> Then restart pi. The local path should now be the only one listed.
+>
+> For the published npm package, remove local checkouts:
+> ```bash
+> pi remove /path/to/local/pi-xai-oauth-copy
+> pi install npm:pi-xai-oauth
+> ```
+>
+> Use the exact package spec/path shown by `pi list` when removing duplicates.
 
 ---
 
@@ -159,6 +173,8 @@ pi --model grok-4.3 "Write a poem about Rust"
 | Model ID | Description |
 |----------|-------------|
 | `grok-4.3` | **Default.** Full reasoning, 1M context. |
+| `grok-build` | Grok Build coding model via the Grok CLI OAuth endpoint, 512K context. |
+| `grok-composer-2.5-fast` | Composer 2.5 Fast coding model via the Grok CLI OAuth endpoint, 200K context. |
 | `grok-4.20-0309-reasoning` | Grok 4.20 with automatic reasoning, 2M context. |
 | `grok-4.20-0309-non-reasoning` | Grok 4.20 fast responses, 2M context. |
 | `grok-4.20-multi-agent-0309` | Grok 4.20 multi-agent research model, 2M context. |
@@ -167,6 +183,8 @@ From the pi TUI:
 
 ```
 /model grok-4.3
+/model grok-build
+/model grok-composer-2.5-fast
 /model grok-4.20-0309-reasoning
 /model grok-4.20-multi-agent-0309
 ```
@@ -175,6 +193,8 @@ From the command line:
 
 ```bash
 pi --model grok-4.3 "Your prompt here"
+pi --model grok-build "Implement this feature"
+pi --model grok-composer-2.5-fast "Refactor this module"
 pi --model grok-4.20-0309-non-reasoning "Quick answer"
 ```
 
@@ -199,7 +219,25 @@ pi --model grok-4.3:low "What's the weather?"
 - **`medium`** — Balanced speed and depth.
 - **`low`** — Fast responses, minimal reasoning. Good for simple Q&A.
 
-`grok-4.20-0309-reasoning` reasons automatically and does not accept a configurable effort parameter. `grok-4.20-multi-agent-0309` uses `medium` for 4 agents and `high` for 16 agents.
+`grok-build` and `grok-composer-2.5-fast` are routed through xAI's Grok CLI OAuth endpoint using the same X account OAuth token. `grok-composer-2.5-fast` does not accept configurable reasoning effort. `grok-4.20-0309-reasoning` reasons automatically and does not accept a configurable effort parameter. `grok-4.20-multi-agent-0309` uses `medium` for 4 agents and `high` for 16 agents.
+
+### Composer / Grok Build Tool Compatibility
+
+Composer 2.5 and Grok Build are trained against Cursor/Grok CLI-style tool names. When either `grok-composer-2.5-fast` or `grok-build` is selected, this package automatically enables compatibility shims that map those tool calls onto pi's built-in tools:
+
+| Cursor/Grok CLI tool | pi tool used underneath |
+|----------------------|-------------------------|
+| `Read` | `read` |
+| `Write` | `write` |
+| `StrReplace` / `Edit` | `edit` |
+| `Delete` | workspace-safe file delete |
+| `LS` | `ls` |
+| `Grep` | `grep` |
+| `Glob` | `find` |
+| `Shell` | `bash` |
+| `WebSearch` | xAI native web search |
+
+The shims also normalize common Cursor argument names, such as `file_path`, `contents`, `old_string` / `new_string`, `query`, `include`, `glob_filter`, and `cmd`. They are disabled again when you switch back to non-Grok-CLI models such as `grok-4.3`.
 
 ---
 
@@ -378,20 +416,40 @@ If you have the official Grok CLI installed and authenticated (`~/.grok/auth.jso
 
 ### "What model am I using?"
 
-### `pi list` shows both npm package and local path
-
-This is normal during development when you have run `pi install .` alongside the published npm package. The local path takes precedence. To clean up:
-
-```bash
-pi remove npm:pi-xai-oauth
-pi install npm:pi-xai-oauth
-```
-
 In the pi TUI, the current model is shown in the status bar. You can also check with:
 
 ```
 /model
 ```
+
+### `Tool "xai_generate_text" conflicts with ...` or `pi list` shows duplicate copies
+
+You have more than one copy of this extension installed. This commonly happens when updating from npm to a local checkout, or when switching between two local worktrees. pi refuses to load duplicate tool names.
+
+First inspect installed packages:
+
+```bash
+pi list
+```
+
+Then remove every duplicate `pi-xai-oauth` entry except the one you want to use.
+
+For local development from this checkout:
+
+```bash
+pi remove npm:pi-xai-oauth
+pi remove /path/to/old/pi-xai-oauth-copy
+pi install .
+```
+
+For normal npm usage:
+
+```bash
+pi remove /path/to/local/pi-xai-oauth-copy
+pi install npm:pi-xai-oauth
+```
+
+Restart pi after cleanup. `pi list` should show only one `pi-xai-oauth` entry.
 
 ---
 
@@ -402,6 +460,8 @@ pi update npm:pi-xai-oauth
 ```
 
 This pulls the latest version from npm and updates your installed extension.
+
+If you previously installed a local checkout with `pi install .`, `pi update npm:pi-xai-oauth` will not replace that local copy. Run `pi list` and make sure only one `pi-xai-oauth` entry is installed. Remove duplicate npm/local/worktree copies before restarting pi.
 
 ---
 

--- a/bin/setup.js
+++ b/bin/setup.js
@@ -28,8 +28,8 @@ function color(text, c) {
 }
 
 function printHeader() {
-  console.log(`\n${color("🚀  pi-xai-oauth", "cyan")} — ${color("xAI Grok 4.3 + OAuth for pi", "bold")}\n`);
-  console.log("   One-command setup for Grok 4.3 (1M context) with clean OAuth login.\n");
+  console.log(`\n${color("🚀  pi-xai-oauth", "cyan")} — ${color("xAI Grok + OAuth for pi", "bold")}\n`);
+  console.log("   One-command setup for Grok 4.3, Grok Build, and Composer 2.5 with clean OAuth login.\n");
 }
 
 function checkPi() {
@@ -133,10 +133,10 @@ function printNextSteps(nonInteractive = false) {
     console.log(`   ${color("2.", "bold")} Start chatting with Grok 4.3 (already set as default)`);
     console.log(`      ${color("pi", "cyan")}\n`);
   } else {
-    console.log("Grok 4.3 + xAI OAuth is now configured and ready.\n");
+    console.log("Grok 4.3, Grok Build, Composer 2.5 + xAI OAuth are now configured and ready.\n");
   }
 
-  console.log("You now have access to powerful reasoning + 1M context!\n");
+  console.log("You now have access to powerful reasoning, coding models, and 1M context!\n");
   console.log("Bonus tools available:");
   console.log("   • xai_generate_text     — Generate text with full reasoning");
   console.log("   • xai_multi_agent       — Multi-agent research with web/X tools");

--- a/extensions/xai-oauth.ts
+++ b/extensions/xai-oauth.ts
@@ -1,11 +1,21 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+  createBashToolDefinition,
+  createEditToolDefinition,
+  createFindToolDefinition,
+  createGrepToolDefinition,
+  createLsToolDefinition,
+  createReadToolDefinition,
+  createWriteToolDefinition,
+} from "@earendil-works/pi-coding-agent";
 import type { Api, Context, Model, OAuthCredentials, OAuthLoginCallbacks, SimpleStreamOptions } from "@earendil-works/pi-ai";
 import { streamSimpleOpenAIResponses } from "@earendil-works/pi-ai";
 import { createHash, randomBytes, randomUUID } from "crypto";
 import { existsSync, readFileSync } from "fs";
+import { rm } from "fs/promises";
 import { createServer, type Server } from "http";
 import { homedir } from "os";
-import { extname, isAbsolute, join, resolve } from "path";
+import { extname, isAbsolute, join, relative, resolve } from "path";
 import { fileURLToPath } from "url";
 
 const XAI_OAUTH_ISSUER = "https://auth.x.ai";
@@ -16,8 +26,12 @@ const XAI_OAUTH_REDIRECT_HOST = "127.0.0.1";
 const XAI_OAUTH_REDIRECT_PORT = 56121;
 const XAI_OAUTH_REDIRECT_PATH = "/callback";
 const XAI_OAUTH_REFRESH_SKEW_MS = 2 * 60 * 1000;
+const XAI_API_BASE_URL = "https://api.x.ai/v1";
+const XAI_CLI_BASE_URL = "https://cli-chat-proxy.grok.com/v1";
 const XAI_RESPONSES_URL = "https://api.x.ai/v1/responses";
+const XAI_CLI_RESPONSES_URL = "https://cli-chat-proxy.grok.com/v1/responses";
 const XAI_IMAGES_GENERATIONS_URL = "https://api.x.ai/v1/images/generations";
+const XAI_GROK_CLIENT_VERSION = "0.2.16";
 const DEFAULT_XAI_MODEL = "grok-4.3";
 const DEFAULT_XAI_IMAGE_MODEL = "grok-imagine-image-quality";
 
@@ -53,6 +67,32 @@ const MODELS = [
     maxTokens: 131_072,
   },
   {
+    id: "grok-build",
+    name: "Grok Build",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: { input: 1, output: 2, cacheRead: 0.2, cacheWrite: 0.2 },
+    contextWindow: 512_000,
+    maxTokens: 30_000,
+  },
+  {
+    id: "grok-composer-2.5-fast",
+    name: "Composer 2.5 Fast",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: { input: 3, output: 15, cacheRead: 0.5, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 30_000,
+    thinkingLevelMap: {
+      off: "none",
+      minimal: null,
+      low: null,
+      medium: null,
+      high: null,
+      xhigh: null,
+    },
+  },
+  {
     id: "grok-4.20-0309-reasoning",
     name: "Grok 4.20 Reasoning",
     reasoning: true,
@@ -82,6 +122,8 @@ const MODELS = [
 ];
 
 const xaiToolRegistrations = new WeakSet<object>();
+
+const XAI_CURSOR_TOOL_NAMES = ["Read", "Write", "StrReplace", "Edit", "Delete", "LS", "Grep", "Glob", "Shell", "WebSearch"];
 
 const XAI_GROK_CLI_AUTH_SCOPE_KEY = `${XAI_OAUTH_ISSUER}::${XAI_OAUTH_CLIENT_ID}`;
 const XAI_GROK_CLI_LEGACY_AUTH_SCOPE_KEY = "https://accounts.x.ai/sign-in";
@@ -480,18 +522,53 @@ function extractResponsesText(data: any): string {
 
 function xaiModelForRequest(modelId?: string): Model<Api> {
   const id = modelId || DEFAULT_XAI_MODEL;
-  const model = MODELS.find((candidate) => candidate.id === id) || MODELS[0];
+  const model =
+    MODELS.find((candidate) => candidate.id === id) ||
+    MODELS.find((candidate) => candidate.id === DEFAULT_XAI_MODEL) ||
+    MODELS[0];
   return {
     ...model,
     id,
     provider: "xai-auth",
     api: "xai-responses",
-    baseUrl: "https://api.x.ai/v1",
+    baseUrl: xaiBaseUrlForModel(id),
   } as any;
 }
 
+function normalizedXaiModelId(modelId: string): string {
+  return (modelId || "").toLowerCase().split("/").pop() || "";
+}
+
+function isGrokCliProxyModel(modelId: string): boolean {
+  const normalized = normalizedXaiModelId(modelId);
+  return normalized === "grok-build" || normalized === "grok-composer-2.5-fast";
+}
+
+function xaiBaseUrlForModel(modelId: string): string {
+  return isGrokCliProxyModel(modelId) ? XAI_CLI_BASE_URL : XAI_API_BASE_URL;
+}
+
+function xaiResponsesUrlForModel(modelId: string): string {
+  return isGrokCliProxyModel(modelId) ? XAI_CLI_RESPONSES_URL : XAI_RESPONSES_URL;
+}
+
+function grokCliProxyHeaders(modelId: string, sessionId?: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    "x-grok-client-identifier": "pi-xai-oauth",
+    "x-grok-client-version": XAI_GROK_CLIENT_VERSION,
+    "x-xai-token-auth": "xai-grok-cli",
+    "x-grok-model-override": normalizedXaiModelId(modelId),
+  };
+  if (sessionId) headers["x-grok-conv-id"] = sessionId;
+  return headers;
+}
+
+function xaiModelRequestHeaders(modelId: string, sessionId?: string): Record<string, string> {
+  return isGrokCliProxyModel(modelId) ? grokCliProxyHeaders(modelId, sessionId) : {};
+}
+
 function grokSupportsReasoningEffort(modelId: string): boolean {
-  const normalized = (modelId || "").toLowerCase().split("/").pop() || "";
+  const normalized = normalizedXaiModelId(modelId);
   return (
     normalized.startsWith("grok-3-mini") ||
     normalized.startsWith("grok-4.20-multi-agent") ||
@@ -604,21 +681,37 @@ function normalizeXaiResponsesInput(input: unknown[], model: Model<Api>): unknow
 function rewriteXaiResponsesPayload(payload: unknown, model: Model<Api>, options?: SimpleStreamOptions): unknown {
   if (!payload || typeof payload !== "object") return payload;
   const body: Record<string, any> = { ...(payload as Record<string, any>) };
+  const modelId = String(body.model || model.id);
+  const usesGrokCliProxy = isGrokCliProxyModel(modelId);
 
   // xAI's Responses API matches the OpenAI surface but has a few stricter
   // edges than pi's generic OpenAI Responses serializer. Hermes solves the
   // same Grok OAuth path with top-level instructions; xAI also rejects
   // image arrays in function_call_output.output, so normalize those here.
   if (Array.isArray(body.input)) {
-    const input = normalizeXaiResponsesInput([...body.input], model) as Record<string, any>[];
+    let input = normalizeXaiResponsesInput([...body.input], model) as Record<string, any>[];
     const instructionParts: string[] = [];
-    while (input.length > 0) {
-      const first = input[0];
-      if (!first || typeof first !== "object" || (first.role !== "developer" && first.role !== "system")) break;
-      const text = textFromResponsesContent(first.content).trim();
-      if (text) instructionParts.push(text);
-      input.shift();
+
+    if (usesGrokCliProxy) {
+      input = input.filter((item) => {
+        if (!item || typeof item !== "object") return true;
+        if (item.type === "reasoning") return false;
+        if (typeof item.content === "string" && item.content.length === 0) return false;
+        if (item.role !== "developer" && item.role !== "system") return true;
+        const text = textFromResponsesContent(item.content).trim();
+        if (text) instructionParts.push(text);
+        return false;
+      });
+    } else {
+      while (input.length > 0) {
+        const first = input[0];
+        if (!first || typeof first !== "object" || (first.role !== "developer" && first.role !== "system")) break;
+        const text = textFromResponsesContent(first.content).trim();
+        if (text) instructionParts.push(text);
+        input.shift();
+      }
     }
+
     if (instructionParts.length > 0) {
       body.instructions = [body.instructions, ...instructionParts].filter((part) => typeof part === "string" && part).join("\n\n");
     }
@@ -634,11 +727,16 @@ function rewriteXaiResponsesPayload(payload: unknown, model: Model<Api>, options
 
   if (body.reasoning && typeof body.reasoning === "object") {
     const effort = body.reasoning.effort;
-    if (typeof effort === "string" && effort !== "none" && grokSupportsReasoningEffort(String(body.model || model.id))) {
+    if (typeof effort === "string" && effort !== "none" && grokSupportsReasoningEffort(modelId)) {
       body.reasoning = { effort: effort === "minimal" ? "low" : effort };
     } else {
       delete body.reasoning;
     }
+  }
+
+  if (usesGrokCliProxy && Array.isArray(body.include)) {
+    body.include = body.include.filter((item: unknown) => item !== "reasoning.encrypted_content");
+    if (body.include.length === 0) delete body.include;
   }
 
   // xAI doesn't implement OpenAI's prompt_cache_retention knob. Keep the
@@ -657,6 +755,183 @@ function xaiToolError(message: string, details: Record<string, unknown> = {}) {
   return { content: [{ type: "text", text: message }], details };
 }
 
+function objectFromCursorArgs(value: unknown): Record<string, any> {
+  if (!value) return {};
+  if (typeof value === "object" && !Array.isArray(value)) return value as Record<string, any>;
+  if (typeof value !== "string") return {};
+  const trimmed = value.trim();
+  if (!trimmed) return {};
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed as Record<string, any>;
+  } catch {
+    // Plain string arguments are common in hand-written tool calls; callers
+    // decide whether that string should be treated as a path, pattern, command, etc.
+  }
+  return { value: trimmed };
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  return undefined;
+}
+
+function firstNumber(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "string" && value.trim()) {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  return undefined;
+}
+
+function firstBoolean(...values: unknown[]): boolean | undefined {
+  for (const value of values) {
+    if (typeof value === "boolean") return value;
+    if (typeof value === "string" && value.trim()) {
+      const normalized = value.trim().toLowerCase();
+      if (["true", "1", "yes", "y"].includes(normalized)) return true;
+      if (["false", "0", "no", "n"].includes(normalized)) return false;
+    }
+  }
+  return undefined;
+}
+
+function cursorPath(params: Record<string, any>): string | undefined {
+  return firstString(params.path, params.file_path, params.filePath, params.target_file, params.targetFile, params.value);
+}
+
+function cursorContent(params: Record<string, any>): string | undefined {
+  return firstString(params.content, params.contents, params.text, params.value);
+}
+
+function cursorOldText(params: Record<string, any>): string | undefined {
+  return firstString(params.oldText, params.old_text, params.old_string, params.oldString, params.old, params.target);
+}
+
+function cursorNewText(params: Record<string, any>): string | undefined {
+  return firstString(params.newText, params.new_text, params.new_string, params.newString, params.new, params.replacement);
+}
+
+function cursorSearchPattern(params: Record<string, any>): string | undefined {
+  return firstString(params.pattern, params.query, params.regex, params.substring, params.value);
+}
+
+function cursorGlob(params: Record<string, any>): string | undefined {
+  return firstString(params.glob, params.include, params.glob_pattern, params.globPattern, params.glob_filter, params.globFilter, params.filter);
+}
+
+function uniqueToolNames(toolNames: string[]): string[] {
+  return [...new Set(toolNames)];
+}
+
+function syncCursorToolShimsForModel(ctx: any, model?: Model<Api>) {
+  if (typeof ctx?.getActiveTools !== "function" || typeof ctx?.setActiveTools !== "function") return;
+
+  const activeTools = Array.isArray(ctx.getActiveTools()) ? (ctx.getActiveTools() as string[]) : [];
+  const withoutCursorShims = activeTools.filter((toolName) => !XAI_CURSOR_TOOL_NAMES.includes(toolName));
+  const shouldEnableCursorShims = model?.provider === "xai-auth" && isGrokCliProxyModel(model.id);
+  const nextTools = shouldEnableCursorShims ? uniqueToolNames([...withoutCursorShims, ...XAI_CURSOR_TOOL_NAMES]) : withoutCursorShims;
+
+  if (nextTools.length !== activeTools.length || nextTools.some((toolName, index) => toolName !== activeTools[index])) {
+    ctx.setActiveTools(nextTools);
+  }
+}
+
+function normalizeReadArgs(args: unknown) {
+  const params = objectFromCursorArgs(args);
+  return {
+    path: cursorPath(params) || "",
+    offset: firstNumber(params.offset, params.start_line, params.startLine),
+    limit: firstNumber(params.limit, params.max_lines, params.maxLines),
+  };
+}
+
+function normalizeWriteArgs(args: unknown) {
+  const params = objectFromCursorArgs(args);
+  return {
+    path: cursorPath(params) || "",
+    content: cursorContent(params) ?? "",
+  };
+}
+
+function normalizeEditArgs(args: unknown) {
+  const params = objectFromCursorArgs(args);
+  if (Array.isArray(params.edits)) {
+    return {
+      path: cursorPath(params) || "",
+      edits: params.edits.map((edit: unknown) => {
+        const item = objectFromCursorArgs(edit);
+        return { oldText: cursorOldText(item) || "", newText: cursorNewText(item) ?? "" };
+      }),
+    };
+  }
+  return {
+    path: cursorPath(params) || "",
+    edits: [{ oldText: cursorOldText(params) || "", newText: cursorNewText(params) ?? "" }],
+  };
+}
+
+function normalizeGrepArgs(args: unknown) {
+  const params = objectFromCursorArgs(args);
+  return {
+    pattern: cursorSearchPattern(params) || "",
+    path: firstString(params.path, params.directory, params.dir, params.folder, params.file_path, params.filePath),
+    glob: cursorGlob(params),
+    ignoreCase: firstBoolean(params.ignoreCase, params.ignore_case, params.case_insensitive, params.caseInsensitive),
+    literal: firstBoolean(params.literal, params.fixed_strings, params.fixedStrings),
+    context: firstNumber(params.context, params.context_lines, params.contextLines),
+    limit: firstNumber(params.limit, params.max_results, params.maxResults),
+  };
+}
+
+function normalizeGlobArgs(args: unknown) {
+  const params = objectFromCursorArgs(args);
+  return {
+    pattern: firstString(params.pattern, params.glob, params.glob_pattern, params.globPattern, params.query, params.value) || "**/*",
+    path: firstString(params.path, params.directory, params.dir, params.folder),
+    limit: firstNumber(params.limit, params.max_results, params.maxResults),
+  };
+}
+
+function normalizeLsArgs(args: unknown) {
+  const params = objectFromCursorArgs(args);
+  return {
+    path: cursorPath(params),
+    limit: firstNumber(params.limit, params.max_results, params.maxResults),
+  };
+}
+
+function normalizeShellArgs(args: unknown) {
+  const params = objectFromCursorArgs(args);
+  return {
+    command: firstString(params.command, params.cmd, params.value) || "",
+    timeout: firstNumber(params.timeout, params.timeout_ms, params.timeoutMs),
+  };
+}
+
+function normalizeDeleteArgs(args: unknown) {
+  const params = objectFromCursorArgs(args);
+  return {
+    path: cursorPath(params) || "",
+    recursive: firstBoolean(params.recursive, params.directory, params.dir),
+  };
+}
+
+function safeWorkspacePath(cwd: string, requestedPath: string): string {
+  const resolved = isAbsolute(requestedPath) ? resolve(requestedPath) : resolve(cwd, requestedPath);
+  const workspace = resolve(cwd);
+  const workspaceRelativePath = relative(workspace, resolved);
+  if (workspaceRelativePath.startsWith("..") || isAbsolute(workspaceRelativePath)) {
+    throw new Error(`Refusing to operate outside the workspace: ${requestedPath}`);
+  }
+  return resolved;
+}
+
 async function resolveXaiAuthToken(ctx: any): Promise<string | null> {
   const registryModel = ctx?.modelRegistry?.find?.("xai-auth", DEFAULT_XAI_MODEL);
   if (registryModel && typeof ctx?.modelRegistry?.getApiKeyAndHeaders === "function") {
@@ -672,12 +947,19 @@ async function resolveXaiAuthToken(ctx: any): Promise<string | null> {
   return (await ensureFreshXaiCredentials(credentials)).access;
 }
 
-async function postXaiJson(apiKey: string, url: string, body: Record<string, any>, signal?: AbortSignal): Promise<any> {
+async function postXaiJson(
+  apiKey: string,
+  url: string,
+  body: Record<string, any>,
+  signal?: AbortSignal,
+  headers: Record<string, string> = {},
+): Promise<any> {
   const response = await fetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${apiKey}`,
+      ...headers,
     },
     body: JSON.stringify(body),
     signal,
@@ -696,7 +978,17 @@ async function postXaiJson(apiKey: string, url: string, body: Record<string, any
 async function createXaiResponse(apiKey: string, body: Record<string, any>, signal?: AbortSignal): Promise<any> {
   const model = xaiModelForRequest(typeof body.model === "string" ? body.model : undefined);
   const payload = rewriteXaiResponsesPayload(body, model) as Record<string, any>;
-  return postXaiJson(apiKey, XAI_RESPONSES_URL, payload, signal);
+  const usesGrokCliProxy = isGrokCliProxyModel(model.id);
+  const grokCliSessionId = usesGrokCliProxy
+    ? (typeof body.previous_response_id === "string" && body.previous_response_id) || randomUUID()
+    : undefined;
+  return postXaiJson(
+    apiKey,
+    xaiResponsesUrlForModel(model.id),
+    payload,
+    signal,
+    xaiModelRequestHeaders(model.id, grokCliSessionId),
+  );
 }
 
 function statusFromError(error: unknown): number | undefined {
@@ -708,15 +1000,24 @@ function messageFromError(error: unknown): string {
 }
 
 function streamSimpleXaiResponses(model: Model<Api>, context: Context, options?: SimpleStreamOptions) {
+  const grokCliSessionId = options?.sessionId || (isGrokCliProxyModel(model.id) ? randomUUID() : undefined);
+  const streamModel = {
+    ...model,
+    baseUrl: xaiBaseUrlForModel(model.id),
+    headers: {
+      ...(model as any).headers,
+      ...xaiModelRequestHeaders(model.id, grokCliSessionId),
+    },
+  };
   const headers = { ...(options?.headers || {}) };
-  if (options?.sessionId && !headers["x-grok-conv-id"]) headers["x-grok-conv-id"] = options.sessionId;
+  if (grokCliSessionId && !headers["x-grok-conv-id"]) headers["x-grok-conv-id"] = grokCliSessionId;
 
-  return streamSimpleOpenAIResponses(model as Model<"openai-responses">, context, {
+  return streamSimpleOpenAIResponses(streamModel as Model<"openai-responses">, context, {
     ...options,
     headers,
     async onPayload(payload, payloadModel) {
-      const rewritten = rewriteXaiResponsesPayload(payload, payloadModel, options);
-      const userRewritten = await options?.onPayload?.(rewritten, payloadModel);
+      const rewritten = rewriteXaiResponsesPayload(payload, streamModel, options);
+      const userRewritten = await options?.onPayload?.(rewritten, streamModel);
       return userRewritten === undefined ? rewritten : userRewritten;
     },
   });
@@ -838,6 +1139,234 @@ export default function (pi: ExtensionAPI) {
   function registerXaiTools() {
     if (xaiToolRegistrations.has(pi as object)) return;
     xaiToolRegistrations.add(pi as object);
+
+    pi.registerTool({
+      name: "Read",
+      label: "Read",
+      description: "Cursor/Grok CLI compatibility shim for pi's read tool. Reads a file by path/file_path with optional offset and limit.",
+      promptSnippet: "Cursor-style alias for read; accepts path/file_path plus optional offset/limit",
+      parameters: {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "Path to read" },
+          file_path: { type: "string", description: "Cursor-style alias for path" },
+          offset: { type: "number", description: "1-indexed line offset" },
+          limit: { type: "number", description: "Maximum lines to read" },
+        },
+      },
+      prepareArguments: normalizeReadArgs,
+      execute: async (toolCallId: string, params: any, signal: any, onUpdate: any, ctx: any) => {
+        return createReadToolDefinition(ctx.cwd).execute(toolCallId, normalizeReadArgs(params) as any, signal, onUpdate, ctx);
+      },
+    } as any);
+
+    pi.registerTool({
+      name: "Write",
+      label: "Write",
+      description: "Cursor/Grok CLI compatibility shim for pi's write tool. Writes content/contents to path/file_path.",
+      promptSnippet: "Cursor-style alias for write; accepts path/file_path and content/contents",
+      parameters: {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "Path to write" },
+          file_path: { type: "string", description: "Cursor-style alias for path" },
+          content: { type: "string", description: "Content to write" },
+          contents: { type: "string", description: "Cursor-style alias for content" },
+        },
+      },
+      prepareArguments: normalizeWriteArgs,
+      execute: async (toolCallId: string, params: any, signal: any, onUpdate: any, ctx: any) => {
+        return createWriteToolDefinition(ctx.cwd).execute(toolCallId, normalizeWriteArgs(params) as any, signal, onUpdate, ctx);
+      },
+    } as any);
+
+    pi.registerTool({
+      name: "StrReplace",
+      label: "StrReplace",
+      description: "Cursor/Grok CLI compatibility shim for exact string replacement. Accepts old_string/new_string or oldText/newText.",
+      promptSnippet: "Cursor-style exact string replacement; accepts old_string/new_string",
+      parameters: {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "Path to edit" },
+          file_path: { type: "string", description: "Cursor-style alias for path" },
+          old_string: { type: "string", description: "Text to replace" },
+          new_string: { type: "string", description: "Replacement text" },
+          oldText: { type: "string", description: "pi-style alias for old_string" },
+          newText: { type: "string", description: "pi-style alias for new_string" },
+        },
+      },
+      prepareArguments: normalizeEditArgs,
+      execute: async (toolCallId: string, params: any, signal: any, onUpdate: any, ctx: any) => {
+        return createEditToolDefinition(ctx.cwd).execute(toolCallId, normalizeEditArgs(params) as any, signal, onUpdate, ctx);
+      },
+    } as any);
+
+    pi.registerTool({
+      name: "Edit",
+      label: "Edit",
+      description: "Cursor/Grok CLI compatibility shim for pi's edit tool. Accepts edits or old_string/new_string aliases.",
+      promptSnippet: "Cursor-style alias for edit; accepts edits or old_string/new_string",
+      parameters: {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "Path to edit" },
+          file_path: { type: "string", description: "Cursor-style alias for path" },
+          edits: { type: "array", description: "Array of { oldText/old_string, newText/new_string } replacements" },
+          old_string: { type: "string", description: "Text to replace" },
+          new_string: { type: "string", description: "Replacement text" },
+        },
+      },
+      prepareArguments: normalizeEditArgs,
+      execute: async (toolCallId: string, params: any, signal: any, onUpdate: any, ctx: any) => {
+        return createEditToolDefinition(ctx.cwd).execute(toolCallId, normalizeEditArgs(params) as any, signal, onUpdate, ctx);
+      },
+    } as any);
+
+    pi.registerTool({
+      name: "Delete",
+      label: "Delete",
+      description: "Cursor/Grok CLI compatibility shim for deleting a workspace file. Directories require recursive=true.",
+      promptSnippet: "Cursor-style delete for workspace files; directories require recursive=true",
+      parameters: {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "Path to delete" },
+          file_path: { type: "string", description: "Cursor-style alias for path" },
+          recursive: { type: "boolean", description: "Allow recursive directory deletion" },
+        },
+      },
+      prepareArguments: normalizeDeleteArgs,
+      execute: async (_toolCallId: string, params: any, signal: any, _onUpdate: any, ctx: any) => {
+        if (signal?.aborted) throw new Error("Operation aborted");
+        const { path, recursive } = normalizeDeleteArgs(params);
+        if (!path) throw new Error("Delete requires a path");
+        const absolutePath = safeWorkspacePath(ctx.cwd, path);
+        await rm(absolutePath, { recursive: !!recursive, force: false });
+        return { content: [{ type: "text", text: `Deleted ${path}` }], details: undefined };
+      },
+    } as any);
+
+    pi.registerTool({
+      name: "LS",
+      label: "LS",
+      description: "Cursor/Grok CLI compatibility shim for pi's ls tool. Lists files under path.",
+      promptSnippet: "Cursor-style alias for ls; lists files under path",
+      parameters: {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "Directory or file path" },
+          limit: { type: "number", description: "Maximum entries to return" },
+        },
+      },
+      prepareArguments: normalizeLsArgs,
+      execute: async (toolCallId: string, params: any, signal: any, onUpdate: any, ctx: any) => {
+        return createLsToolDefinition(ctx.cwd).execute(toolCallId, normalizeLsArgs(params) as any, signal, onUpdate, ctx);
+      },
+    } as any);
+
+    pi.registerTool({
+      name: "Grep",
+      label: "Grep",
+      description: "Cursor/Grok CLI compatibility shim for pi's grep tool. Accepts pattern/query plus include/glob filters.",
+      promptSnippet: "Cursor-style alias for grep; accepts pattern/query and include/glob filters",
+      parameters: {
+        type: "object",
+        properties: {
+          pattern: { type: "string", description: "Regex or literal search pattern" },
+          query: { type: "string", description: "Cursor-style alias for pattern" },
+          path: { type: "string", description: "Directory or file to search" },
+          include: { type: "string", description: "Glob filter, e.g. *.ts" },
+          glob: { type: "string", description: "Glob filter, e.g. *.ts" },
+          glob_filter: { type: "string", description: "Cursor-style alias for glob" },
+          ignoreCase: { type: "boolean", description: "Case-insensitive search" },
+          limit: { type: "number", description: "Maximum matches" },
+        },
+      },
+      prepareArguments: normalizeGrepArgs,
+      execute: async (toolCallId: string, params: any, signal: any, onUpdate: any, ctx: any) => {
+        return createGrepToolDefinition(ctx.cwd).execute(toolCallId, normalizeGrepArgs(params) as any, signal, onUpdate, ctx);
+      },
+    } as any);
+
+    pi.registerTool({
+      name: "Glob",
+      label: "Glob",
+      description: "Cursor/Grok CLI compatibility shim for pi's find tool. Finds files matching pattern/glob.",
+      promptSnippet: "Cursor-style alias for find; accepts pattern/glob",
+      parameters: {
+        type: "object",
+        properties: {
+          pattern: { type: "string", description: "Glob pattern, e.g. **/*.ts" },
+          glob: { type: "string", description: "Cursor-style alias for pattern" },
+          path: { type: "string", description: "Directory to search" },
+          limit: { type: "number", description: "Maximum results" },
+        },
+      },
+      prepareArguments: normalizeGlobArgs,
+      execute: async (toolCallId: string, params: any, signal: any, onUpdate: any, ctx: any) => {
+        return createFindToolDefinition(ctx.cwd).execute(toolCallId, normalizeGlobArgs(params) as any, signal, onUpdate, ctx);
+      },
+    } as any);
+
+    pi.registerTool({
+      name: "Shell",
+      label: "Shell",
+      description: "Cursor/Grok CLI compatibility shim for pi's bash tool. Executes command/cmd in the workspace shell.",
+      promptSnippet: "Cursor-style alias for bash; executes command/cmd in the workspace shell",
+      parameters: {
+        type: "object",
+        properties: {
+          command: { type: "string", description: "Shell command to execute" },
+          cmd: { type: "string", description: "Alias for command" },
+          timeout: { type: "number", description: "Timeout in milliseconds" },
+        },
+      },
+      prepareArguments: normalizeShellArgs,
+      execute: async (toolCallId: string, params: any, signal: any, onUpdate: any, ctx: any) => {
+        return createBashToolDefinition(ctx.cwd).execute(toolCallId, normalizeShellArgs(params) as any, signal, onUpdate, ctx);
+      },
+    } as any);
+
+    pi.registerTool({
+      name: "WebSearch",
+      label: "WebSearch",
+      description: "Cursor/Grok CLI compatibility shim for xAI web search. Searches the web with xAI's native web_search tool.",
+      promptSnippet: "Cursor-style web search backed by xAI native web_search",
+      parameters: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Search query" },
+          search_term: { type: "string", description: "Alias for query" },
+        },
+      },
+      prepareArguments: (args: unknown) => {
+        const params = objectFromCursorArgs(args);
+        return { query: firstString(params.query, params.search_term, params.value) || "" };
+      },
+      execute: async (_toolCallId: string, params: any, _signal: any, _onUpdate: any, ctx: any) => {
+        const query = firstString(params?.query, params?.search_term, params?.value);
+        if (!query) return xaiToolError("Error: WebSearch requires a query.");
+        const apiKey = await resolveXaiAuthToken(ctx);
+        if (!apiKey) return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.");
+
+        try {
+          const data = await createXaiResponse(
+            apiKey,
+            {
+              model: DEFAULT_XAI_MODEL,
+              input: `Search the web for: ${query}\n\nSummarize the key results with sources where available.`,
+              tools: [{ type: "web_search", enable_image_understanding: true }],
+            },
+            _signal,
+          );
+          return { content: [{ type: "text", text: extractResponsesText(data) }], details: { response_id: data.id } };
+        } catch (error) {
+          const status = statusFromError(error);
+          return xaiToolError(`xAI API Error${status ? ` ${status}` : ""}: ${messageFromError(error)}`, { error: true, status });
+        }
+      },
+    } as any);
 
     pi.registerTool({
       name: "xai_generate_text",
@@ -1232,4 +1761,10 @@ Be specific and cite examples where helpful.`;
   }
 
   registerXaiTools();
+
+  if (typeof (pi as any).on === "function") {
+    (pi as any).on("session_start", (_event: any, ctx: any) => syncCursorToolShimsForModel(ctx, ctx?.model));
+    (pi as any).on("model_select", (event: any, ctx: any) => syncCursorToolShimsForModel(ctx, event?.model));
+    (pi as any).on("before_agent_start", (_event: any, ctx: any) => syncCursorToolShimsForModel(ctx, ctx?.model));
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "pi-xai-oauth": "bin/setup.js"
       },
       "devDependencies": {
-        "@types/node": "^25.8.0"
+        "@types/node": "^25.8.0",
+        "typescript": "^6.0.3"
       },
       "peerDependencies": {
         "@earendil-works/pi-ai": "*",
@@ -1797,6 +1798,20 @@
       "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/undici": {
       "version": "7.25.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-xai-oauth",
   "version": "1.2.1",
-  "description": "One-command installer for xAI (Grok) OAuth provider + Grok 4.3 in pi",
+  "description": "One-command installer for xAI OAuth provider + Grok, Grok Build, and Composer models in pi",
   "keywords": [
     "pi-package",
     "xai",
@@ -37,6 +37,7 @@
     "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@types/node": "^25.8.0"
+    "@types/node": "^25.8.0",
+    "typescript": "^6.0.3"
   }
 }

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -2,6 +2,7 @@
 
 const assert = require("assert");
 const path = require("path");
+const fs = require("fs/promises");
 const { createJiti } = require("jiti");
 
 const repoRoot = path.resolve(__dirname, "..");
@@ -56,18 +57,35 @@ function restoreFetchMock() {
   global.fetch = originalFetch;
 }
 
+function headerValue(headers, name) {
+  if (!headers) return undefined;
+  if (typeof headers.get === "function") return headers.get(name);
+  return headers[name] || headers[name.toLowerCase()];
+}
+
 function loadExtension() {
   const providers = new Map();
   const tools = new Map();
+  const handlers = new Map();
+  let activeTools = ["read", "bash", "edit", "write"];
   extension({
+    on(event, handler) {
+      handlers.set(event, handler);
+    },
     registerProvider(name, config) {
       providers.set(name, config);
     },
     registerTool(tool) {
       tools.set(tool.name, tool);
     },
+    getActiveTools() {
+      return activeTools;
+    },
+    setActiveTools(toolNames) {
+      activeTools = toolNames;
+    },
   });
-  return { providers, tools };
+  return { providers, tools, handlers, getActiveTools: () => activeTools, setActiveTools: (toolNames) => { activeTools = toolNames; } };
 }
 
 function authContext() {
@@ -83,20 +101,103 @@ function authContext() {
   };
 }
 
-async function runTool(tools, name, params = {}, expectedText = "OK") {
+async function runTool(tools, name, params = {}, expectedText = "OK", requestPrefix = "https://api.x.ai") {
   const controller = new AbortController();
   const before = requests.length;
   const result = await tools.get(name).execute("call_test", params, controller.signal, () => {}, authContext());
-  const request = requests.slice(before).find((entry) => entry.url?.startsWith("https://api.x.ai"));
+  const request = requests.slice(before).find((entry) => entry.url?.startsWith(requestPrefix));
   if (expectedText instanceof RegExp) {
     assert.match(result.content[0].text, expectedText, `${name} should surface mocked xAI text`);
   } else {
     assert.equal(result.content[0].text, expectedText, `${name} should surface mocked xAI text`);
   }
   assert.ok(request, `${name} should send a request`);
-  assert.equal(request.headers.Authorization, "Bearer oauth-token", `${name} should use OAuth token from pi model registry`);
+  assert.equal(headerValue(request.headers, "Authorization"), "Bearer oauth-token", `${name} should use OAuth token from pi model registry`);
   assert.strictEqual(request.signal, controller.signal, `${name} should pass the pi cancellation signal`);
-  return { body: request.body, result };
+  return { body: request.body, request, result };
+}
+
+async function runCursorTool(tools, name, params = {}, ctx = {}) {
+  const controller = new AbortController();
+  return tools.get(name).execute("call_cursor", params, controller.signal, () => {}, { cwd: repoRoot, ...ctx });
+}
+
+async function verifyCursorToolShims(tools) {
+  for (const name of ["Read", "Write", "StrReplace", "Edit", "Delete", "LS", "Grep", "Glob", "Shell", "WebSearch"]) {
+    assert.ok(tools.has(name), `${name} Cursor/Grok CLI shim should be registered`);
+  }
+
+  const grepResult = await runCursorTool(tools, "Grep", { query: "DEFAULT_XAI_MODEL", include: "*.ts", path: "extensions", limit: 5 });
+  assert.match(grepResult.content[0].text, /xai-oauth\.ts/, "Grep shim should map query/include to pi grep pattern/glob");
+
+  const globResult = await runCursorTool(tools, "Glob", { glob: "extensions/*.ts" });
+  assert.match(globResult.content[0].text, /extensions\/xai-oauth\.ts/, "Glob shim should map to pi find");
+
+  const readResult = await runCursorTool(tools, "Read", { file_path: "package.json", limit: 3 });
+  assert.match(readResult.content[0].text, /"name": "pi-xai-oauth"/, "Read shim should map file_path to pi read path");
+
+  const tmpDir = path.join(repoRoot, ".tmp-shim-tests");
+  const tmpFile = path.join(tmpDir, "cursor-shim.txt");
+  await fs.mkdir(tmpDir, { recursive: true });
+  try {
+    const writeResult = await runCursorTool(tools, "Write", { file_path: ".tmp-shim-tests/cursor-shim.txt", contents: "hello old" });
+    assert.match(writeResult.content[0].text, /Successfully wrote/, "Write shim should map contents to pi write content");
+
+    const replaceResult = await runCursorTool(tools, "StrReplace", {
+      file_path: ".tmp-shim-tests/cursor-shim.txt",
+      old_string: "hello old",
+      new_string: "hello new",
+    });
+    assert.match(replaceResult.content[0].text, /Successfully replaced/, "StrReplace shim should map old_string/new_string to pi edit");
+
+    const shellResult = await runCursorTool(tools, "Shell", { cmd: "printf shim-ok" });
+    assert.match(shellResult.content[0].text, /shim-ok/, "Shell shim should map cmd to pi bash command");
+
+    const deleteResult = await runCursorTool(tools, "Delete", { file_path: ".tmp-shim-tests/cursor-shim.txt" });
+    assert.match(deleteResult.content[0].text, /Deleted/, "Delete shim should remove files inside the workspace");
+  } finally {
+    await fs.rm(tmpFile, { force: true }).catch(() => {});
+    await fs.rm(tmpDir, { force: true, recursive: true }).catch(() => {});
+  }
+}
+
+async function verifyCursorToolActivation(loadResult) {
+  const { handlers, getActiveTools } = loadResult;
+  const ctx = {
+    getActiveTools,
+    setActiveTools: loadResult.setActiveTools,
+  };
+
+  await handlers.get("model_select")?.({ model: { provider: "xai-auth", id: "grok-composer-2.5-fast" } }, ctx);
+  assert.ok(getActiveTools().includes("Grep"), "Cursor shims should be enabled for Composer 2.5");
+
+  await handlers.get("model_select")?.({ model: { provider: "xai-auth", id: "grok-4.3" } }, ctx);
+  assert.ok(!getActiveTools().includes("Grep"), "Cursor shims should be disabled for non-Grok-CLI xAI models");
+}
+
+async function verifyCliModelStreamRouting(provider) {
+  const composer = provider.models.find((model) => model.id === "grok-composer-2.5-fast");
+  const model = {
+    ...composer,
+    provider: "xai-auth",
+    api: provider.api,
+    baseUrl: provider.baseUrl,
+  };
+  const before = requests.length;
+  const stream = provider.streamSimple(
+    model,
+    { messages: [{ role: "user", content: "hello", timestamp: Date.now() }] },
+    { apiKey: "oauth-token", sessionId: "session-test" },
+  );
+  await stream.result();
+  const request = requests.slice(before).find((entry) => entry.url?.startsWith("https://cli-chat-proxy.grok.com"));
+  assert.ok(request, "Composer 2.5 provider streams should route to the Grok CLI endpoint");
+  assert.equal(request.body.model, "grok-composer-2.5-fast");
+  assert.equal(request.body.reasoning, undefined, "Composer 2.5 provider streams should not send reasoning effort");
+  assert.equal(headerValue(request.headers, "Authorization"), "Bearer oauth-token");
+  assert.equal(headerValue(request.headers, "x-xai-token-auth"), "xai-grok-cli");
+  assert.equal(headerValue(request.headers, "x-grok-model-override"), "grok-composer-2.5-fast");
+  assert.equal(headerValue(request.headers, "x-grok-conv-id"), "session-test");
 }
 
 async function verifyOAuthCallbackState(provider) {
@@ -134,15 +235,23 @@ async function main() {
   installFetchMock();
 
   try {
-    const { providers, tools } = loadExtension();
+    const firstLoad = loadExtension();
+    const { providers, tools } = firstLoad;
     const secondLoad = loadExtension();
     const provider = providers.get("xai-auth");
     assert.ok(provider, "xai-auth provider should be registered");
     assert.equal(secondLoad.tools.size, tools.size, "extension reloads should register tools on the new pi API object");
     assert.equal(provider.api, "xai-responses");
     assert.equal(provider.models.find((model) => model.id === "grok-4.3")?.contextWindow, 1_000_000);
+    assert.equal(provider.models.find((model) => model.id === "grok-build")?.contextWindow, 512_000);
+    assert.equal(provider.models.find((model) => model.id === "grok-composer-2.5-fast")?.contextWindow, 200_000);
+    assert.equal(provider.models.find((model) => model.id === "grok-composer-2.5-fast")?.reasoning, false);
     assert.equal(provider.models.find((model) => model.id === "grok-4.20-0309-reasoning")?.contextWindow, 2_000_000);
     assert.ok(provider.models.some((model) => model.id === "grok-4.20-multi-agent-0309"));
+
+    await verifyCliModelStreamRouting(provider);
+    await verifyCursorToolActivation(firstLoad);
+    await verifyCursorToolShims(tools);
 
     await verifyOAuthCallbackState(provider);
 
@@ -152,6 +261,30 @@ async function main() {
       },
     });
     assert.match(noAuthResult.content[0].text, /No xAI OAuth credentials/, "tools should not fall back to XAI_API_KEY");
+
+    const { body: composerBody, request: composerRequest } = await runTool(
+      tools,
+      "xai_generate_text",
+      { prompt: "hi", model: "grok-composer-2.5-fast", reasoning_effort: "high" },
+      "OK",
+      "https://cli-chat-proxy.grok.com",
+    );
+    assert.equal(composerBody.model, "grok-composer-2.5-fast");
+    assert.equal(composerBody.reasoning, undefined, "Composer 2.5 should not send reasoning effort");
+    assert.equal(headerValue(composerRequest.headers, "x-xai-token-auth"), "xai-grok-cli");
+    assert.equal(headerValue(composerRequest.headers, "x-grok-model-override"), "grok-composer-2.5-fast");
+    assert.ok(headerValue(composerRequest.headers, "x-grok-conv-id"), "Composer 2.5 tool calls should include a Grok conversation id");
+
+    const { body: buildBody, request: buildRequest } = await runTool(
+      tools,
+      "xai_generate_text",
+      { prompt: "hi", model: "grok-build" },
+      "OK",
+      "https://cli-chat-proxy.grok.com",
+    );
+    assert.equal(buildBody.model, "grok-build");
+    assert.equal(headerValue(buildRequest.headers, "x-grok-model-override"), "grok-build");
+    assert.ok(headerValue(buildRequest.headers, "x-grok-conv-id"), "Grok Build tool calls should include a Grok conversation id");
 
     const { body: webBody } = await runTool(tools, "xai_web_search", { query: "xAI docs" });
     assert.deepEqual(webBody.tools, [{ type: "web_search", enable_image_understanding: true }]);


### PR DESCRIPTION
## Summary
- add Grok Build and Composer 2.5 Fast as selectable xai-auth models
- route Grok CLI-only models through cli-chat-proxy.grok.com with required Grok CLI OAuth headers
- add Cursor/Grok CLI compatibility shims for Read, Write, StrReplace, Edit, Delete, LS, Grep, Glob, Shell, and WebSearch
- document duplicate-install cleanup and Composer/Grok Build tool compatibility

## Verification
- npm test
- npm run typecheck
- git diff --check
- npm pack --dry-run
- pi install .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Grok Build and Composer 2.5 models with OAuth authentication support.
  * Added Cursor/Grok CLI-compatible tools: Read, Write, StrReplace, Delete, LS, Grep, Glob, Shell, and WebSearch.

* **Documentation**
  * Expanded README with model selection examples, installation guidance, and troubleshooting sections.
  * Added clarification on resolving duplicate extension conflicts.

* **Chores**
  * Added TypeScript dev dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->