### PR TITLE
fix: remove unsupported size parameter from xai_generate_image

### DIFF
--- a/extensions/xai/tools/custom-tools.ts
+++ b/extensions/xai/tools/custom-tools.ts
@@ -267,12 +267,11 @@ Be specific and cite examples where helpful.`;
         properties: {
           prompt: { type: "string", description: "Detailed description of the image to generate" },
           model: { type: "string", description: "Image model to use", default: DEFAULT_XAI_IMAGE_MODEL },
-          size: { type: "string", description: "Image size (e.g. 1024x1024, 1792x1024)", default: "1024x1024" },
           n: { type: "number", description: "Number of images to generate (1-4)", default: 1 }
         },
         required: ["prompt"],
       },
-      execute: async (_toolCallId: string, params: { prompt?: string; model?: string; size?: string; n?: number }, _signal: any, _onUpdate: any, ctx: any) => {
+      execute: async (_toolCallId: string, params: { prompt?: string; model?: string; n?: number }, _signal: any, _onUpdate: any, ctx: any) => {
         const apiKey = await resolveXaiAuthToken(ctx);
         if (!apiKey) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { prompt: params?.prompt });
@@ -282,8 +281,7 @@ Be specific and cite examples where helpful.`;
           data = await postXaiJson(apiKey, XAI_IMAGES_GENERATIONS_URL, {
             model: params.model || DEFAULT_XAI_IMAGE_MODEL,
             prompt: params.prompt,
-            n: params.n || 1,
-            size: params.size || "1024x1024"
+            n: params.n || 1
           }, _signal);
         } catch (error) {
           const status = statusFromError(error);


### PR DESCRIPTION
Hey,

Was running into 400 errors when trying to generate images with `xai_generate_image`.

Turns out the `size` parameter is no longer supported by the xAI backend (it started returning 400). Removed it from both the request payload and the tool parameter definition.

Image generation with the tool is now working again.

(No video generation changes — the repo currently has no video tool.)

Let me know if this looks good.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Image generation tool no longer supports the `size` parameter. Tool configuration now only includes `prompt`, `model`, and `n` parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->