### PR TITLE
fix: replace deprecated size with aspect_ratio and resolution for image generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,9 +304,13 @@ Generate images with xAI's current image generation model.
 ```json
 {
   "prompt": "A clean product diagram of an OAuth flow",
-  "model": "grok-imagine-image-quality"
+  "model": "grok-imagine-image-quality",
+  "aspect_ratio": "16:9",
+  "resolution": "2k"
 }
 ```
+
+> **Note:** xAI's image API no longer accepts OpenAI-style `size` values like `1024x1024`. Use `aspect_ratio` and `resolution` instead. The deprecated `size` parameter is still accepted for backward compatibility and mapped to the closest `aspect_ratio`.
 
 ### `xai_analyze_image`
 Analyze an image URL, data URL, or local `.png` / `.jpg` path with Grok vision.

--- a/extensions/xai/images.ts
+++ b/extensions/xai/images.ts
@@ -48,6 +48,52 @@ function resolveLocalImagePath(value: string): string | undefined {
   return candidates.find((candidate) => existsSync(candidate));
 }
 
+const LEGACY_SIZE_TO_ASPECT_RATIO: Record<string, string> = {
+  "1024x1024": "1:1",
+  "1792x1024": "16:9",
+  "1024x1792": "9:16",
+  "1536x1024": "3:2",
+  "1024x1536": "2:3",
+};
+
+export type XaiImageGenerationParams = {
+  prompt?: string;
+  model?: string;
+  aspect_ratio?: string;
+  resolution?: string;
+  /** @deprecated Use aspect_ratio instead. */
+  size?: string;
+  n?: number;
+};
+
+/** Map deprecated OpenAI-style size strings to xAI aspect ratios. */
+export function legacySizeToAspectRatio(size: string): string | undefined {
+  return LEGACY_SIZE_TO_ASPECT_RATIO[size.trim().toLowerCase()];
+}
+
+/** Build the JSON body for xAI /images/generations requests. */
+export function buildXaiImageGenerationBody(
+  params: XaiImageGenerationParams,
+  defaultModel: string,
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    model: params.model || defaultModel,
+    prompt: params.prompt,
+    n: params.n || 1,
+  };
+
+  const aspectRatio =
+    params.aspect_ratio ||
+    (params.size ? legacySizeToAspectRatio(params.size) ?? "auto" : undefined);
+  if (aspectRatio) body.aspect_ratio = aspectRatio;
+
+  if (params.resolution === "1k" || params.resolution === "2k") {
+    body.resolution = params.resolution;
+  }
+
+  return body;
+}
+
 /** Normalize an image URL/path into an xAI-compatible URL or data URI. */
 export function normalizeXaiImageInput(value: unknown): string | undefined {
   if (typeof value !== "string" || !value.trim()) return undefined;

--- a/extensions/xai/tools/custom-tools.ts
+++ b/extensions/xai/tools/custom-tools.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { resolveXaiAuthToken } from "../auth";
 import { DEFAULT_XAI_IMAGE_MODEL, DEFAULT_XAI_MODEL, XAI_IMAGES_GENERATIONS_URL } from "../constants";
-import { normalizeXaiImageInput } from "../images";
+import { buildXaiImageGenerationBody, normalizeXaiImageInput, type XaiImageGenerationParams } from "../images";
 import { grokSupportsReasoningEffort } from "../models";
 import { createXaiResponse, postXaiJson } from "../responses";
 import { extractResponsesText, messageFromError, statusFromError } from "../text";
@@ -267,24 +267,36 @@ Be specific and cite examples where helpful.`;
         properties: {
           prompt: { type: "string", description: "Detailed description of the image to generate" },
           model: { type: "string", description: "Image model to use", default: DEFAULT_XAI_IMAGE_MODEL },
-          size: { type: "string", description: "Image size (e.g. 1024x1024, 1792x1024)", default: "1024x1024" },
-          n: { type: "number", description: "Number of images to generate (1-4)", default: 1 }
+          aspect_ratio: {
+            type: "string",
+            description: "Aspect ratio (1:1, 16:9, 9:16, 4:3, 3:4, auto, etc.)",
+          },
+          resolution: {
+            type: "string",
+            description: "Output resolution",
+            enum: ["1k", "2k"],
+          },
+          size: {
+            type: "string",
+            description: "Deprecated. Use aspect_ratio instead (e.g. 1024x1024 maps to 1:1).",
+          },
+          n: { type: "number", description: "Number of images to generate (1-4)", default: 1 },
         },
         required: ["prompt"],
       },
-      execute: async (_toolCallId: string, params: { prompt?: string; model?: string; size?: string; n?: number }, _signal: any, _onUpdate: any, ctx: any) => {
+      execute: async (_toolCallId: string, params: XaiImageGenerationParams, _signal: any, _onUpdate: any, ctx: any) => {
         const apiKey = await resolveXaiAuthToken(ctx);
         if (!apiKey) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { prompt: params?.prompt });
         }
         let data: any;
         try {
-          data = await postXaiJson(apiKey, XAI_IMAGES_GENERATIONS_URL, {
-            model: params.model || DEFAULT_XAI_IMAGE_MODEL,
-            prompt: params.prompt,
-            n: params.n || 1,
-            size: params.size || "1024x1024"
-          }, _signal);
+          data = await postXaiJson(
+            apiKey,
+            XAI_IMAGES_GENERATIONS_URL,
+            buildXaiImageGenerationBody(params, DEFAULT_XAI_IMAGE_MODEL),
+            _signal,
+          );
         } catch (error) {
           const status = statusFromError(error);
           return xaiToolError(`xAI Image API Error${status ? ` ${status}` : ""}: ${messageFromError(error)}`, { error: true, status, prompt: params.prompt });

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "scaffold": "node bin/setup.js --scaffold",
     "setup": "node bin/setup.js",
     "test": "node scripts/verify-extension.js",
+    "test:image-live": "bash scripts/test-image-generation-live.sh",
     "typecheck": "npx tsc --noEmit"
   },
   "pi": {

--- a/scripts/test-image-generation-live.js
+++ b/scripts/test-image-generation-live.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * Live smoke test for xAI image generation payload changes.
+ * Compares deprecated `size` vs new aspect_ratio/resolution bodies.
+ */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+const LEGACY_SIZE_TO_ASPECT_RATIO = {
+  "1024x1024": "1:1",
+  "1792x1024": "16:9",
+  "1024x1792": "9:16",
+  "1536x1024": "3:2",
+  "1024x1536": "2:3",
+};
+
+function buildXaiImageGenerationBody(params, defaultModel) {
+  const body = {
+    model: params.model || defaultModel,
+    prompt: params.prompt,
+    n: params.n || 1,
+  };
+
+  const aspectRatio =
+    params.aspect_ratio ||
+    (params.size ? LEGACY_SIZE_TO_ASPECT_RATIO[params.size.trim().toLowerCase()] ?? "auto" : undefined);
+  if (aspectRatio) body.aspect_ratio = aspectRatio;
+
+  if (params.resolution === "1k" || params.resolution === "2k") {
+    body.resolution = params.resolution;
+  }
+
+  return body;
+}
+
+const XAI_IMAGES_GENERATIONS_URL = "https://api.x.ai/v1/images/generations";
+const DEFAULT_MODEL = "grok-imagine-image-quality";
+const PROMPT = "A minimal blue circle on a white background, flat vector icon";
+
+function loadAccessToken() {
+  const authPath = join(homedir(), ".pi", "agent", "auth.json");
+  const auth = JSON.parse(readFileSync(authPath, "utf8"));
+  const access = auth?.["xai-auth"]?.access;
+  if (!access) throw new Error("No xai-auth access token in ~/.pi/agent/auth.json — run: pi /login xai-auth");
+  return access;
+}
+
+async function postImageGeneration(token, body) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 120_000);
+  let response;
+  try {
+    response = await fetch(XAI_IMAGES_GENERATIONS_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  const text = await response.text();
+  let json;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    json = { raw: text };
+  }
+
+  return { ok: response.ok, status: response.status, body: json, sent: body };
+}
+
+function hasImageUrl(result) {
+  const urls = (result.body?.data || []).map((item) => item?.url).filter(Boolean);
+  return urls.length > 0;
+}
+
+async function main() {
+  const token = loadAccessToken();
+
+  console.log("1) Deprecated payload with size (expected to fail)...");
+  const legacyDirect = await postImageGeneration(token, {
+    model: DEFAULT_MODEL,
+    prompt: PROMPT,
+    n: 1,
+    size: "1024x1024",
+  });
+  assert.equal(legacyDirect.ok, false, `size payload should fail, got ${legacyDirect.status}`);
+  console.log(`   FAIL as expected (${legacyDirect.status})`);
+
+  console.log("2) New minimal payload (model + prompt only)...");
+  const minimal = await postImageGeneration(
+    token,
+    buildXaiImageGenerationBody({ prompt: PROMPT, n: 1 }, DEFAULT_MODEL),
+  );
+  assert.equal(minimal.ok, true, `minimal payload failed: ${minimal.status} ${JSON.stringify(minimal.body)}`);
+  assert.equal(minimal.sent.size, undefined);
+  assert.ok(hasImageUrl(minimal), "minimal payload should return image URL");
+  console.log("   OK");
+
+  console.log("3) New payload with aspect_ratio + resolution...");
+  const configured = await postImageGeneration(
+    token,
+    buildXaiImageGenerationBody(
+      { prompt: PROMPT, aspect_ratio: "1:1", resolution: "1k", n: 1 },
+      DEFAULT_MODEL,
+    ),
+  );
+  assert.equal(configured.ok, true, `configured payload failed: ${configured.status} ${JSON.stringify(configured.body)}`);
+  assert.equal(configured.sent.aspect_ratio, "1:1");
+  assert.equal(configured.sent.resolution, "1k");
+  assert.equal(configured.sent.size, undefined);
+  assert.ok(hasImageUrl(configured), "configured payload should return image URL");
+  console.log("   OK");
+
+  console.log("4) Legacy size param mapped to aspect_ratio...");
+  const mapped = await postImageGeneration(
+    token,
+    buildXaiImageGenerationBody({ prompt: PROMPT, size: "1024x1024", n: 1 }, DEFAULT_MODEL),
+  );
+  assert.equal(mapped.ok, true, `mapped payload failed: ${mapped.status} ${JSON.stringify(mapped.body)}`);
+  assert.equal(mapped.sent.aspect_ratio, "1:1");
+  assert.equal(mapped.sent.size, undefined);
+  assert.ok(hasImageUrl(mapped), "mapped payload should return image URL");
+  console.log("   OK");
+
+  console.log("\nLive image generation test: all checks passed.");
+}
+
+main().catch((error) => {
+  console.error("\nLive image generation test: FAILED");
+  console.error(error?.message || error);
+  process.exit(1);
+});

--- a/scripts/test-image-generation-live.sh
+++ b/scripts/test-image-generation-live.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AUTH_FILE="${HOME}/.pi/agent/auth.json"
+URL="https://api.x.ai/v1/images/generations"
+MODEL="grok-imagine-image-quality"
+PROMPT="A minimal blue circle on a white background, flat vector icon"
+
+if [[ ! -f "${AUTH_FILE}" ]]; then
+  echo "Missing ${AUTH_FILE}. Run: pi /login xai-auth" >&2
+  exit 1
+fi
+
+TOKEN="$(node -e "const auth=require('${AUTH_FILE//\'/\\\'}'); console.log(auth['xai-auth']?.access || '')")"
+if [[ -z "${TOKEN}" ]]; then
+  echo "No xai-auth access token in ${AUTH_FILE}" >&2
+  exit 1
+fi
+
+post_json() {
+  local label="$1"
+  local payload="$2"
+  local expect_code="$3"
+  echo "${label}"
+  local response=""
+  local attempt
+  for attempt in 1 2 3 4 5; do
+    set +e
+    response="$(curl -4 -sS --connect-timeout 30 --max-time 180 \
+      -w $'\n__HTTP__%{http_code}' \
+      -X POST "${URL}" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer ${TOKEN}" \
+      -d "${payload}" 2>&1)"
+    local curl_status=$?
+    set -e
+    if [[ "${curl_status}" -eq 0 && "${response}" == *$'\n__HTTP__'* ]]; then
+      break
+    fi
+    if [[ "${attempt}" -eq 5 ]]; then
+      echo "  curl failed after 5 attempts: ${response}" >&2
+      exit 1
+    fi
+    echo "  retrying (${attempt}/5)..."
+    sleep 3
+  done
+  local body="${response%%$'\n__HTTP__'*}"
+  local code="${response##*$'\n__HTTP__'}"
+  echo "  HTTP ${code}"
+  if [[ "${code}" != "${expect_code}" ]]; then
+    echo "  Body: ${body}" >&2
+    exit 1
+  fi
+  if [[ "${expect_code}" == "200" ]]; then
+    node -e "const body=JSON.parse(process.argv[1]); if(!(body.data||[]).some(x=>x.url)) process.exit(1)" "${body}"
+    echo "  OK (image URL returned)"
+  else
+    echo "  OK (expected failure)"
+  fi
+}
+
+post_json "1) Deprecated payload with size (expect 400)" \
+  "{\"model\":\"${MODEL}\",\"prompt\":\"${PROMPT}\",\"n\":1,\"size\":\"1024x1024\"}" \
+  "400"
+
+post_json "2) New minimal payload (expect 200)" \
+  "{\"model\":\"${MODEL}\",\"prompt\":\"${PROMPT}\",\"n\":1}" \
+  "200"
+
+post_json "3) aspect_ratio + resolution (expect 200)" \
+  "{\"model\":\"${MODEL}\",\"prompt\":\"${PROMPT}\",\"n\":1,\"aspect_ratio\":\"16:9\",\"resolution\":\"1k\"}" \
+  "200"
+
+post_json "4) Legacy size mapped to aspect_ratio (expect 200)" \
+  "{\"model\":\"${MODEL}\",\"prompt\":\"${PROMPT}\",\"n\":1,\"aspect_ratio\":\"1:1\"}" \
+  "200"
+
+echo
+echo "Live image generation test: all checks passed."

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -394,6 +394,26 @@ async function main() {
 
     const { body: imageGenBody } = await runTool(tools, "xai_generate_image", { prompt: "a crisp diagram" }, /Generated 1 image/);
     assert.equal(imageGenBody.model, "grok-imagine-image-quality");
+    assert.equal(imageGenBody.size, undefined);
+
+    const { body: imageGenWideBody } = await runTool(
+      tools,
+      "xai_generate_image",
+      { prompt: "a banner", aspect_ratio: "16:9", resolution: "2k" },
+      /Generated 1 image/,
+    );
+    assert.equal(imageGenWideBody.aspect_ratio, "16:9");
+    assert.equal(imageGenWideBody.resolution, "2k");
+    assert.equal(imageGenWideBody.size, undefined);
+
+    const { body: legacyImageGenBody } = await runTool(
+      tools,
+      "xai_generate_image",
+      { prompt: "square icon", size: "1024x1024" },
+      /Generated 1 image/,
+    );
+    assert.equal(legacyImageGenBody.aspect_ratio, "1:1");
+    assert.equal(legacyImageGenBody.size, undefined);
 
     const { body: multiAgentBody, result: multiAgentResult } = await runTool(tools, "xai_multi_agent", { query: "latest xAI tools", num_agents: 4 });
     assert.equal(multiAgentBody.model, "grok-4.20-multi-agent-0309");


### PR DESCRIPTION
## Problem

`xai_generate_image` always sent OpenAI-style `size` (default `1024x1024`) to `POST /v1/images/generations`. xAI no longer supports this parameter and returns:

```json
{"code":"400","error":"Argument not supported: size"}
```

The current API uses `aspect_ratio` and `resolution` instead.

Ref: https://docs.x.ai/developers/model-capabilities/images/generation

## Changes

- Remove hardcoded `size` from the image generation API payload
- Add `aspect_ratio` and `resolution` tool parameters
- Map legacy `size` values to the closest supported `aspect_ratio` for backward compatibility
- Add `buildXaiImageGenerationBody()` helper in `extensions/xai/images.ts`
- Extend `verify-extension` assertions
- Add `npm run test:image-live` for real API smoke testing

## Testing

```bash
npm test                 # verify-extension: ok
npm run test:image-live  # live api.x.ai checks
```

Live API results (account `tianheil3` environment):

| Case | Payload | Result |
|------|---------|--------|
| Deprecated `size` | `size: "1024x1024"` | HTTP 400 — `Argument not supported: size` |
| New minimal | `model + prompt` | HTTP 200 — image URL returned |
| New params | `aspect_ratio: "16:9"`, `resolution: "1k"` | HTTP 200 — image URL returned |
| Legacy mapping | `aspect_ratio: "1:1"` (mapped from `size`) | HTTP 200 — image URL returned |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `aspect_ratio` and `resolution` parameters for xAI image generation API
  * Maintained backward compatibility with legacy `size` parameter, automatically mapped to `aspect_ratio`

* **Documentation**
  * Updated README with examples using new image generation parameters

* **Tests**
  * Added live smoke tests to validate image generation payloads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->