### PR TITLE
Refresh npm README compatibility note

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ npx pi-xai-oauth
 
 This package adds **Grok 4.3**, **Grok Build**, and **Composer 2.5** as fully-integrated xAI OAuth models in pi, with proper OAuth login, automatic token refresh, and a suite of custom tools (`xai_generate_text`, `xai_web_search`, `xai_x_search`, etc.).
 
+> **Latest compatibility note:** `pi-xai-oauth` 1.2.4+ supports pi 0.79.8+'s OpenAI Responses API guard for Grok/xAI streaming. Existing npm installs should run `pi update npm:pi-xai-oauth`; local checkout installs should keep only one copy installed with `pi remove npm:pi-xai-oauth && pi install .`.
+
 ---
 
 ## Table of Contents

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-xai-oauth",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-xai-oauth",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "MIT",
       "bin": {
         "pi-xai-oauth": "bin/setup.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-xai-oauth",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "One-command installer for xAI OAuth provider + Grok, Grok Build, and Composer models in pi",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
## Summary
- add a top-level npm README compatibility note for pi 0.79.8+ API guard support
- bump package to 1.2.5 so npm can publish the README refresh

## Verification
- `npm test`
- `npm run typecheck`
- `npm pack --dry-run`
- `git diff --check`

## Publish note
`npm publish` was attempted but is blocked by npm OTP/browser authentication. After completing npm auth, publish 1.2.5 to update the npm README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added compatibility notes detailing OpenAI Responses API guard support for Grok/xAI streaming, including upgrade and installation guidance.

* **Chores**
  * Released version 1.2.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->