### PR TITLE
Fix xAI image generation request parameters

### DIFF
--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -127,6 +127,16 @@ Update this file frequently during execution.
 
 **Current branch:** feature/issue-19-api-guard
 
+## Phase 14: Issue 25 image parameter repair
+- [x] Created isolated worktree on `codex/fix-issue-25-image-params` from `origin/main`.
+- [x] Confirmed `xai_generate_image` always sent the unsupported `size` field and injected `n: 1` when omitted.
+- [x] Removed `size` from the tool schema, rejected legacy explicit `size` calls locally, and made `n` opt-in.
+- [x] Added regression coverage for default payload omission, explicit `n`, and no-request rejection of `size`.
+- [x] Addressed reviewer feedback by enforcing the documented integer range for `n` in the schema and direct execution path.
+- [x] Final verification passed: `npm test`, `npm run typecheck`, and `git diff --check`.
+
+**Current branch:** codex/fix-issue-25-image-params
+
 ## Phase 13: Issue 19 real-package verification and 1.2.4 release staging
 - [x] Staged docs for the `pi-xai-oauth` 1.2.4 update path covering published npm installs and local checkout reinstalls.
 - [x] Recorded that the issue 19 verification work now targets the real pi 0.79.x API guard instead of a mocked guard.

--- a/extensions/xai/tools/custom-tools.ts
+++ b/extensions/xai/tools/custom-tools.ts
@@ -267,24 +267,39 @@ Be specific and cite examples where helpful.`;
         properties: {
           prompt: { type: "string", description: "Detailed description of the image to generate" },
           model: { type: "string", description: "Image model to use", default: DEFAULT_XAI_IMAGE_MODEL },
-          size: { type: "string", description: "Image size (e.g. 1024x1024, 1792x1024)", default: "1024x1024" },
-          n: { type: "number", description: "Number of images to generate (1-4)", default: 1 }
+          n: { type: "number", minimum: 1, maximum: 4, description: "Number of images to generate (1-4)" }
         },
         required: ["prompt"],
       },
       execute: async (_toolCallId: string, params: { prompt?: string; model?: string; size?: string; n?: number }, _signal: any, _onUpdate: any, ctx: any) => {
+        if (params?.size !== undefined) {
+          return xaiToolError("Error: The xAI image API does not support the 'size' parameter. Omit it from the request.", {
+            error: true,
+            prompt: params.prompt,
+          });
+        }
+        if (params?.n !== undefined && (!Number.isInteger(params.n) || params.n < 1 || params.n > 4)) {
+          return xaiToolError("Error: The 'n' parameter must be an integer from 1 to 4.", {
+            error: true,
+            prompt: params.prompt,
+          });
+        }
+
         const apiKey = await resolveXaiAuthToken(ctx);
         if (!apiKey) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { prompt: params?.prompt });
         }
+        const body: Record<string, any> = {
+          model: params.model || DEFAULT_XAI_IMAGE_MODEL,
+          prompt: params.prompt,
+        };
+        if (params.n !== undefined) {
+          body.n = params.n;
+        }
+
         let data: any;
         try {
-          data = await postXaiJson(apiKey, XAI_IMAGES_GENERATIONS_URL, {
-            model: params.model || DEFAULT_XAI_IMAGE_MODEL,
-            prompt: params.prompt,
-            n: params.n || 1,
-            size: params.size || "1024x1024"
-          }, _signal);
+          data = await postXaiJson(apiKey, XAI_IMAGES_GENERATIONS_URL, body, _signal);
         } catch (error) {
           const status = statusFromError(error);
           return xaiToolError(`xAI Image API Error${status ? ` ${status}` : ""}: ${messageFromError(error)}`, { error: true, status, prompt: params.prompt });

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -490,6 +490,43 @@ async function main() {
 
     const { body: imageGenBody } = await runTool(tools, "xai_generate_image", { prompt: "a crisp diagram" }, /Generated 1 image/);
     assert.equal(imageGenBody.model, "grok-imagine-image-quality");
+    const imageTool = tools.get("xai_generate_image");
+    assert.equal(Object.hasOwn(imageGenBody, "size"), false, "image generation should not send unsupported size defaults");
+    assert.equal(Object.hasOwn(imageGenBody, "n"), false, "image generation should not send n unless explicitly requested");
+    assert.equal(imageTool.parameters.properties.size, undefined, "image tool schema should not advertise unsupported size");
+    assert.equal(imageTool.parameters.properties.n.default, undefined, "image tool schema should not inject n when omitted");
+    assert.equal(imageTool.parameters.properties.n.minimum, 1, "image tool schema should reject image counts below one");
+    assert.equal(imageTool.parameters.properties.n.maximum, 4, "image tool schema should reject image counts above four");
+
+    const { body: imageBatchBody } = await runTool(
+      tools,
+      "xai_generate_image",
+      { prompt: "three crisp diagrams", n: 3 },
+      /Generated 1 image/,
+    );
+    assert.equal(imageBatchBody.n, 3, "image generation should forward an explicit n value");
+    assert.equal(Object.hasOwn(imageBatchBody, "size"), false, "explicit n requests should still omit size");
+
+    const requestsBeforeUnsupportedSize = requests.length;
+    const unsupportedSizeResult = await imageTool.execute(
+      "call_unsupported_size",
+      { prompt: "a crisp diagram", size: "1024x1024" },
+      undefined,
+      () => {},
+      authContext(),
+    );
+    assert.match(unsupportedSizeResult.content[0].text, /does not support the 'size' parameter/);
+    assert.equal(requests.length, requestsBeforeUnsupportedSize, "unsupported size should fail before sending a request");
+
+    const invalidCountResult = await imageTool.execute(
+      "call_invalid_image_count",
+      { prompt: "a crisp diagram", n: 0 },
+      undefined,
+      () => {},
+      authContext(),
+    );
+    assert.match(invalidCountResult.content[0].text, /must be an integer from 1 to 4/);
+    assert.equal(requests.length, requestsBeforeUnsupportedSize, "invalid n should fail before sending a request");
 
     const { body: multiAgentBody, result: multiAgentResult } = await runTool(tools, "xai_multi_agent", { query: "latest xAI tools", num_agents: 4 });
     assert.equal(multiAgentBody.model, "grok-4.20-multi-agent-0309");


### PR DESCRIPTION
## Summary

- remove the unsupported `size` parameter from `xai_generate_image`
- omit `n` unless callers explicitly request multiple images
- reject legacy `size` and invalid `n` values before making an xAI request
- add regression coverage for the request payload and local validation paths

## Root cause

The image tool always injected `size: "1024x1024"`, including when callers omitted `size`. The xAI image generation endpoint rejects that unsupported parameter, so every invocation failed with HTTP 400.

Closes #25.

## Validation

- `npm test`
- `npm run typecheck`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image generation so unsupported image size values are rejected with clear errors.
  * Tightened image count handling to accept only valid values from 1 to 4.
  * Removed unsupported default behavior from image generation requests, helping calls match service expectations.
* **Tests**
  * Added coverage for valid and invalid image-generation parameter handling, including error responses and request validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->