### PR TITLE
feat: add Grok 4.5 as default + Grep/cache hardening

### DIFF
--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -149,3 +149,15 @@ Update this file frequently during execution.
 - [ ] `npm publish` is blocked by npm one-time-password authentication; rerun after completing npm CLI auth.
 
 **Current branch:** feature/issue-19-api-guard
+
+## Phase 15: Add Grok 4.5 model catalog support
+- [x] Created branch `feature/add-grok-4-5`.
+- [x] Researched official xAI Grok 4.5 docs, pricing, reasoning, launch notes, and card/paper availability.
+- [x] Added `grok-4.5` to `extensions/xai/models.ts` with text+image input, reasoning support, 500K context, and $2/$0.50 cached/$6 pricing.
+- [x] Made `grok-4.5` the default model in constants, setup, and README showcase.
+- [x] Hardened Grep Cursor shim: TypeBox required `pattern`, clearer errors, query alias mapping.
+- [x] Improved Responses `prompt_cache_key` / `x-grok-conv-id` routing per xAI caching docs.
+- [x] Updated README, setup copy, package description, and verification coverage for Grok 4.5.
+- [x] Verified with `npm test`, `npm run typecheck`.
+
+**Current branch:** feature/add-grok-4-5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 > **For AI coding agents only.** Keep this file machine-readable and concise. Human-facing docs live in README.md.
 
 ## Project Overview
-pi-xai-oauth is a pi-package that registers the xAI OAuth provider ("xai-auth") and Grok models (including grok-4.3 with 1M context + reasoning) for the pi coding agent framework.
+pi-xai-oauth is a pi-package that registers the xAI OAuth provider ("xai-auth") and Grok models (including grok-4.5 and grok-4.3 with reasoning) for the pi coding agent framework.
 
 Core flow: `bin/setup.js` → `pi install` → provider registration in `extensions/xai-oauth.ts` → OAuth PKCE login in `extensions/xai/oauth.ts` → streaming via xAI API helpers in `extensions/xai/responses.ts`.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 npx pi-xai-oauth
 ```
 
-### ✨ New: Grok 4.5
+## ✨ New: Grok 4.5
 
 | | |
 |---|---|
@@ -41,6 +41,7 @@ This package adds **Grok 4.5** (default), **Grok 4.3**, **Grok Build**, and **Co
 
 ## Table of Contents
 
+- [✨ New: Grok 4.5](#-new-grok-45)
 - [Features](#features)
 - [How It Works](#how-it-works)
 - [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -9,12 +9,29 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-Ready-blue)](https://www.typescriptlang.org/)
 [![pi compatible](https://img.shields.io/badge/pi-Compatible-blueviolet)](https://pi.dev)
 
-**xAI (Grok) OAuth provider for pi** — 1M context, reasoning, and custom xAI tools.
+**xAI (Grok) OAuth provider for pi** — now with **Grok 4.5**, reasoning, long context, and custom xAI tools.
+
 ```bash
 npx pi-xai-oauth
 ```
 
-This package adds **Grok 4.3**, **Grok Build**, and **Composer 2.5** as fully-integrated xAI OAuth models in pi, with proper OAuth login, automatic token refresh, and a suite of custom tools (`xai_generate_text`, `xai_web_search`, `xai_x_search`, etc.).
+### ✨ New: Grok 4.5
+
+| | |
+|---|---|
+| **Model ID** | `grok-4.5` |
+| **Role** | xAI flagship for coding, agentic tasks, and knowledge work |
+| **Context** | 500K tokens |
+| **Input** | text + image |
+| **Reasoning** | `low` / `medium` / `high` (defaults to **high**; cannot be disabled) |
+| **Pricing** | $2 / $6 per 1M input/output · $0.50 cache read |
+
+```bash
+pi --model grok-4.5 "Ship this feature end-to-end"
+pi --model grok-4.5:high "Review this architecture for failure modes"
+```
+
+This package adds **Grok 4.5** (default), **Grok 4.3**, **Grok Build**, and **Composer 2.5** as fully-integrated xAI OAuth models in pi, with proper OAuth login, automatic token refresh, and a suite of custom tools (`xai_generate_text`, `xai_web_search`, `xai_x_search`, etc.).
 
 > **Latest compatibility note:** `pi-xai-oauth` 1.2.4+ supports pi 0.79.8+'s OpenAI Responses API guard for Grok/xAI streaming. Existing npm installs should run `pi update npm:pi-xai-oauth`; local checkout installs should keep only one copy installed with `pi remove npm:pi-xai-oauth && pi install .`.
 
@@ -46,7 +63,8 @@ This package adds **Grok 4.3**, **Grok Build**, and **Composer 2.5** as fully-in
 - **Automatic browser open** — pi opens your default browser automatically; fall back to manual paste if needed
 - **Token refresh** — refresh tokens are stored and rotated automatically before expiry
 - **Reuses existing credentials** — auto-detects `~/.grok/auth.json` from the official Grok CLI
-- **1M context window** — Grok 4.3's full context, no truncation
+- **Grok 4.5 flagship (default)** — xAI's newest model for coding, agentic tasks, and knowledge work; 500K context, text+image input, high reasoning by default
+- **Long-context option** — Grok 4.3 still available with a full 1M context window
 - **Coding models** — Grok Build and Composer 2.5 Fast are available from the same `xai-auth` provider
 - **Reasoning support** — configurable thinking levels: `low` / `medium` / `high`
 - **Custom xAI tools** — generate text, web search, X/Twitter search, multi-agent research, code analysis
@@ -82,7 +100,7 @@ npx pi-xai-oauth
 This runs the setup script which:
 1. Installs `npm:pi-xai-oauth` into pi
 2. Sets `xai-auth` as your default provider
-3. Sets `grok-4.3` as your default model
+3. Sets `grok-4.5` as your default model
 4. Enables `high` thinking level by default
 
 ### Manual install
@@ -97,7 +115,7 @@ Then optionally configure it as default:
 # In ~/.pi/agent/settings.json:
 {
   "defaultProvider": "xai-auth",
-  "defaultModel": "grok-4.3",
+  "defaultModel": "grok-4.5",
   "defaultThinkingLevel": "high"
 }
 ```
@@ -167,14 +185,15 @@ pi "Explain quantum computing like I'm 5"
 Or use a specific model:
 
 ```bash
-pi --model grok-4.3 "Write a poem about Rust"
+pi --model grok-4.5 "Write a poem about Rust"
 ```
 
 ### Switching Models
 
 | Model ID | Description |
 |----------|-------------|
-| `grok-4.3` | **Default.** Full reasoning, 1M context. |
+| `grok-4.5` | **Default.** xAI flagship for coding, agentic tasks, and knowledge work; reasoning low/medium/high, 500K context, text+image. |
+| `grok-4.3` | Full reasoning, 1M context. |
 | `grok-build` | Grok Build coding model via the Grok CLI OAuth endpoint, 512K context. |
 | `grok-composer-2.5-fast` | Composer 2.5 Fast coding model via the Grok CLI OAuth endpoint, 200K context. |
 | `grok-4.20-0309-reasoning` | Grok 4.20 with automatic reasoning, 2M context. |
@@ -184,6 +203,7 @@ pi --model grok-4.3 "Write a poem about Rust"
 From the pi TUI:
 
 ```
+/model grok-4.5
 /model grok-4.3
 /model grok-build
 /model grok-composer-2.5-fast
@@ -194,7 +214,8 @@ From the pi TUI:
 From the command line:
 
 ```bash
-pi --model grok-4.3 "Your prompt here"
+pi --model grok-4.5 "Your prompt here"
+pi --model grok-4.3 "Use the 1M-context model"
 pi --model grok-build "Implement this feature"
 pi --model grok-composer-2.5-fast "Refactor this module"
 pi --model grok-4.20-0309-non-reasoning "Quick answer"
@@ -202,7 +223,7 @@ pi --model grok-4.20-0309-non-reasoning "Quick answer"
 
 ### Reasoning / Thinking Levels
 
-Grok 4.3 supports configurable thinking levels:
+Grok 4.5 and Grok 4.3 support configurable thinking levels:
 
 ```
 /think high
@@ -213,15 +234,26 @@ Grok 4.3 supports configurable thinking levels:
 Or via CLI:
 
 ```bash
-pi --model grok-4.3:high "Solve a complex math problem"
-pi --model grok-4.3:low "What's the weather?"
+pi --model grok-4.5:high "Solve a complex math problem"
+pi --model grok-4.5:low "What's the weather?"
 ```
 
 - **`high`** — Deep reasoning, longer deliberation. Best for complex code, math, analysis.
 - **`medium`** — Balanced speed and depth.
 - **`low`** — Fast responses, minimal reasoning. Good for simple Q&A.
 
-`grok-build` and `grok-composer-2.5-fast` are routed through xAI's Grok CLI OAuth endpoint using the same X account OAuth token. `grok-composer-2.5-fast` does not accept configurable reasoning effort. `grok-4.20-0309-reasoning` reasons automatically and does not accept a configurable effort parameter. `grok-4.20-multi-agent-0309` uses `medium` for 4 agents and `high` for 16 agents.
+`grok-4.5` defaults to high reasoning when no effort is specified; reasoning cannot be disabled. `grok-build` and `grok-composer-2.5-fast` are routed through xAI's Grok CLI OAuth endpoint using the same X account OAuth token. `grok-composer-2.5-fast` does not accept configurable reasoning effort. `grok-4.20-0309-reasoning` reasons automatically and does not accept a configurable effort parameter. `grok-4.20-multi-agent-0309` uses `medium` for 4 agents and `high` for 16 agents.
+
+### Grok 4.5 source notes
+
+Official xAI sources used for this catalog update:
+
+- [Grok 4.5 guide](https://docs.x.ai/developers/grok-4-5) — model ID, API usage, reasoning levels, tools, and availability notes.
+- [Grok 4.5 model details](https://docs.x.ai/developers/models/grok-4.5) — text+image input, 500K context window, cached input pricing, regions, and rate-limit snapshot.
+- [Reasoning docs](https://docs.x.ai/developers/model-capabilities/text/reasoning) — `low` / `medium` / `high` reasoning effort, default `high`, and non-disableable reasoning.
+- [Launch announcement](https://x.ai/news/grok-4-5) — coding/agentic benchmark notes, Grok Build/Cursor availability, and EU availability caveat.
+
+No Grok 4.5-specific model card, label card, system card, paper, or official max-output-token limit was found in the xAI docs/news/data sources during this update. The package keeps the existing Grok Responses max-token ceiling as a placeholder until xAI publishes official model metadata for that field.
 
 ### Composer / Grok Build Tool Compatibility
 
@@ -239,7 +271,7 @@ Composer 2.5 and Grok Build are trained against Cursor/Grok CLI-style tool names
 | `Shell` | `bash` |
 | `WebSearch` | xAI native web search |
 
-The shims also normalize common Cursor argument names, such as `file_path`, `contents`, `old_string` / `new_string`, `query`, `include`, `glob_filter`, and `cmd`. They are disabled again when you switch back to non-Grok-CLI models such as `grok-4.3`.
+The shims also normalize common Cursor argument names, such as `file_path`, `contents`, `old_string` / `new_string`, `query`, `include`, `glob_filter`, and `cmd`. They are disabled again when you switch back to non-Grok-CLI models such as `grok-4.5` or `grok-4.3`.
 
 ---
 
@@ -257,7 +289,7 @@ Generate text with full reasoning and stateful conversations.
 ```json
 {
   "prompt": "Explain neural networks",
-  "model": "grok-4.3",
+  "model": "grok-4.5",
   "reasoning_effort": "high"
 }
 ```
@@ -287,7 +319,7 @@ Search X (Twitter) using xAI's native `x_search` tool.
 
 ```json
 {
-  "query": "grok 4.3"
+  "query": "grok 4.5"
 }
 ```
 
@@ -355,7 +387,7 @@ Research a topic with Grok reasoning plus native web and X search tools.
 | Update | `pi update npm:pi-xai-oauth` |
 | Remove | `pi remove npm:pi-xai-oauth` |
 | List packages | `pi list` |
-| Set default model | `/model grok-4.3` (in TUI) |
+| Set default model | `/model grok-4.5` (in TUI) |
 | Set thinking level | `/think high` (in TUI) |
 
 ---
@@ -586,4 +618,4 @@ PRs welcome! If you find issues or want to improve the OAuth flow, feel free to 
 
 ---
 
-*Powered by Grok 4.3 — 1M context, reasoning, and the full xAI API.*
+*Powered by Grok 4.5 — flagship reasoning, agentic coding, and the full xAI API.*

--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ npx pi-xai-oauth
 | **Context** | 500K tokens |
 | **Input** | text + image |
 | **Reasoning** | `low` / `medium` / `high` (defaults to **high**; cannot be disabled) |
+| **Fast mode** | Same model with **`low`** reasoning effort — not a separate model ID |
 | **Pricing** | $2 / $6 per 1M input/output · $0.50 cache read |
 
 ```bash
 pi --model grok-4.5 "Ship this feature end-to-end"
 pi --model grok-4.5:high "Review this architecture for failure modes"
+pi --model grok-4.5:low "Quick status check"   # fast mode
 ```
 
 This package adds **Grok 4.5** (default), **Grok 4.3**, **Grok Build**, and **Composer 2.5** as fully-integrated xAI OAuth models in pi, with proper OAuth login, automatic token refresh, and a suite of custom tools (`xai_generate_text`, `xai_web_search`, `xai_x_search`, etc.).
@@ -64,6 +66,7 @@ This package adds **Grok 4.5** (default), **Grok 4.3**, **Grok Build**, and **Co
 - **Token refresh** — refresh tokens are stored and rotated automatically before expiry
 - **Reuses existing credentials** — auto-detects `~/.grok/auth.json` from the official Grok CLI
 - **Grok 4.5 flagship (default)** — xAI's newest model for coding, agentic tasks, and knowledge work; 500K context, text+image input, high reasoning by default
+- **Grok 4.5 fast mode** — same model with `low` reasoning effort (`/think low` or `grok-4.5:low`); not a separate model ID
 - **Long-context option** — Grok 4.3 still available with a full 1M context window
 - **Coding models** — Grok Build and Composer 2.5 Fast are available from the same `xai-auth` provider
 - **Reasoning support** — configurable thinking levels: `low` / `medium` / `high`
@@ -192,7 +195,7 @@ pi --model grok-4.5 "Write a poem about Rust"
 
 | Model ID | Description |
 |----------|-------------|
-| `grok-4.5` | **Default.** xAI flagship for coding, agentic tasks, and knowledge work; reasoning low/medium/high, 500K context, text+image. |
+| `grok-4.5` | **Default.** xAI flagship for coding, agentic tasks, and knowledge work; reasoning low (**fast**) / medium / high (default), 500K context, text+image. |
 | `grok-4.3` | Full reasoning, 1M context. |
 | `grok-build` | Grok Build coding model via the Grok CLI OAuth endpoint, 512K context. |
 | `grok-composer-2.5-fast` | Composer 2.5 Fast coding model via the Grok CLI OAuth endpoint, 200K context. |
@@ -223,26 +226,29 @@ pi --model grok-4.20-0309-non-reasoning "Quick answer"
 
 ### Reasoning / Thinking Levels
 
-Grok 4.5 and Grok 4.3 support configurable thinking levels:
+Grok 4.5 and Grok 4.3 support configurable thinking levels via pi's `/think` command or `model:effort` syntax. There is **no separate `grok-4.5-fast` model** — on Grok 4.5, “fast mode” is **`reasoning_effort: "low"`** on the same model ID.
 
 ```
 /think high
 /think medium
-/think low
+/think low      # Grok 4.5 fast mode
 ```
 
 Or via CLI:
 
 ```bash
 pi --model grok-4.5:high "Solve a complex math problem"
-pi --model grok-4.5:low "What's the weather?"
+pi --model grok-4.5:medium "Summarize this design doc"
+pi --model grok-4.5:low "What's the weather?"   # fast / latency-sensitive
 ```
 
-- **`high`** — Deep reasoning, longer deliberation. Best for complex code, math, analysis.
-- **`medium`** — Balanced speed and depth.
-- **`low`** — Fast responses, minimal reasoning. Good for simple Q&A.
+| Effort | Grok 4.5 behavior (per xAI docs) | Best for |
+|--------|-----------------------------------|----------|
+| **`high`** (default) | More reasoning tokens, deeper thinking | Hard coding, complex math, multi-step logic |
+| **`medium`** | Balanced thinking vs latency | Analysis and longer-context work |
+| **`low`** (**fast mode**) | Some reasoning, still fast | Latency-sensitive agents and simple tool calling |
 
-`grok-4.5` defaults to high reasoning when no effort is specified; reasoning cannot be disabled. `grok-build` and `grok-composer-2.5-fast` are routed through xAI's Grok CLI OAuth endpoint using the same X account OAuth token. `grok-composer-2.5-fast` does not accept configurable reasoning effort. `grok-4.20-0309-reasoning` reasons automatically and does not accept a configurable effort parameter. `grok-4.20-multi-agent-0309` uses `medium` for 4 agents and `high` for 16 agents.
+`grok-4.5` defaults to **high** when no effort is specified; reasoning **cannot be disabled** (`/think off` is not supported for this model). `grok-build` and `grok-composer-2.5-fast` are routed through xAI's Grok CLI OAuth endpoint using the same X account OAuth token. `grok-composer-2.5-fast` does not accept configurable reasoning effort. `grok-4.20-0309-reasoning` reasons automatically and does not accept a configurable effort parameter. `grok-4.20-multi-agent-0309` uses `medium` for 4 agents and `high` for 16 agents.
 
 ### Grok 4.5 source notes
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ pi --model grok-4.5:low "Quick status check"   # fast mode
 
 This package adds **Grok 4.5** (default), **Grok 4.3**, **Grok Build**, and **Composer 2.5** as fully-integrated xAI OAuth models in pi, with proper OAuth login, automatic token refresh, and a suite of custom tools (`xai_generate_text`, `xai_web_search`, `xai_x_search`, etc.).
 
-> **Latest compatibility note:** `pi-xai-oauth` 1.2.4+ supports pi 0.79.8+'s OpenAI Responses API guard for Grok/xAI streaming. Existing npm installs should run `pi update npm:pi-xai-oauth`; local checkout installs should keep only one copy installed with `pi remove npm:pi-xai-oauth && pi install .`.
+> **Latest release:** `pi-xai-oauth` **1.3.0** adds **Grok 4.5** as the default model (500K context, low/medium/high reasoning; fast mode = `low`). Existing npm installs should run `pi update npm:pi-xai-oauth`; local checkout installs should keep only one copy with `pi remove npm:pi-xai-oauth && pi install .`.
+>
+> **Compatibility note:** 1.2.4+ supports pi 0.79.8+'s OpenAI Responses API guard for Grok/xAI streaming.
 
 ---
 
@@ -502,7 +504,7 @@ pi update npm:pi-xai-oauth
 
 This pulls the latest version from npm and updates your installed extension.
 
-pi 0.79.8+ enforces an OpenAI Responses API guard. `pi-xai-oauth` 1.2.4 handles that guard for Grok/xAI streaming. If you installed the published npm package, update with the command above. If you are testing a local checkout instead, reinstall the checkout:
+pi 0.79.8+ enforces an OpenAI Responses API guard. `pi-xai-oauth` 1.2.4+ handles that guard for Grok/xAI streaming; **1.3.0** adds Grok 4.5 as the default model. If you installed the published npm package, update with the command above. If you are testing a local checkout instead, reinstall the checkout:
 
 ```bash
 pi remove npm:pi-xai-oauth && pi install .

--- a/bin/setup.js
+++ b/bin/setup.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * pi-xai-oauth — One-command installer for xAI (Grok) OAuth + Grok 4.3
+ * pi-xai-oauth — One-command installer for xAI (Grok) OAuth + Grok 4.5
  * Enhanced with --scaffold support for 2026 agent best practices
  */
 
@@ -29,7 +29,7 @@ function color(text, c) {
 
 function printHeader() {
   console.log(`\n${color("🚀  pi-xai-oauth", "cyan")} — ${color("xAI Grok + OAuth for pi", "bold")}\n`);
-  console.log("   One-command setup for Grok 4.3, Grok Build, and Composer 2.5 with clean OAuth login.\n");
+  console.log("   One-command setup for Grok 4.5, Grok Build, and Composer 2.5 with clean OAuth login.\n");
 }
 
 function checkPi() {
@@ -97,10 +97,10 @@ function updateSettings() {
     console.log(color("   + Set defaultProvider: xai-auth", "green"));
   }
 
-  if (settings.defaultModel !== "grok-4.3") {
-    settings.defaultModel = "grok-4.3";
+  if (settings.defaultModel !== "grok-4.5") {
+    settings.defaultModel = "grok-4.5";
     changed = true;
-    console.log(color("   + Set defaultModel: grok-4.3", "green"));
+    console.log(color("   + Set defaultModel: grok-4.5", "green"));
   }
 
   if (settings.defaultThinkingLevel !== "high") {
@@ -130,13 +130,13 @@ function printNextSteps(nonInteractive = false) {
     console.log("Next steps:\n");
     console.log(`   ${color("1.", "bold")} Authenticate with xAI OAuth:`);
     console.log(`      ${color("pi /login xai-auth", "cyan")}\n`);
-    console.log(`   ${color("2.", "bold")} Start chatting with Grok 4.3 (already set as default)`);
+    console.log(`   ${color("2.", "bold")} Start chatting with Grok 4.5 (already set as default)`);
     console.log(`      ${color("pi", "cyan")}\n`);
   } else {
-    console.log("Grok 4.3, Grok Build, Composer 2.5 + xAI OAuth are now configured and ready.\n");
+    console.log("Grok 4.5, Grok 4.3, Grok Build, Composer 2.5 + xAI OAuth are now configured and ready.\n");
   }
 
-  console.log("You now have access to powerful reasoning, coding models, and 1M context!\n");
+  console.log("You now have access to powerful reasoning, coding models, and long context!\n");
   console.log("Bonus tools available:");
   console.log("   • xai_generate_text     — Generate text with full reasoning");
   console.log("   • xai_multi_agent       — Multi-agent research with web/X tools");
@@ -239,7 +239,7 @@ Update this file frequently.`,
 **Date:** ${date}
 
 ## Key Context
-- This project provides xAI OAuth + Grok 4.3 for pi agents.
+- This project provides xAI OAuth + Grok 4.5 for pi agents.
 - Use subagent tool for delegation.
 - Persistent state lives in .scaffold/.
 

--- a/extensions/xai/constants.ts
+++ b/extensions/xai/constants.ts
@@ -15,7 +15,7 @@ export const XAI_IMAGES_GENERATIONS_URL = "https://api.x.ai/v1/images/generation
 export const XAI_GROK_CLIENT_VERSION = "0.2.16";
 
 export const XAI_PROVIDER_ID = "xai-auth";
-export const DEFAULT_XAI_MODEL = "grok-4.3";
+export const DEFAULT_XAI_MODEL = "grok-4.5";
 export const DEFAULT_XAI_IMAGE_MODEL = "grok-imagine-image-quality";
 
 export const XAI_CURSOR_TOOL_NAMES = ["Read", "Write", "StrReplace", "Edit", "Delete", "LS", "Grep", "Glob", "Shell", "WebSearch"];

--- a/extensions/xai/models.ts
+++ b/extensions/xai/models.ts
@@ -11,6 +11,25 @@ import {
 
 export const MODELS = [
   {
+    id: "grok-4.5",
+    name: "Grok 4.5",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 0 },
+    contextWindow: 500_000,
+    // xAI has not published a Grok 4.5-specific max output limit yet;
+    // keep the existing Grok Responses ceiling until official metadata is available.
+    maxTokens: 131_072,
+    thinkingLevelMap: {
+      off: null,
+      minimal: "low",
+      low: "low",
+      medium: "medium",
+      high: "high",
+      xhigh: null,
+    },
+  },
+  {
     id: "grok-4.3",
     name: "Grok 4.3",
     reasoning: true,
@@ -134,6 +153,7 @@ export function grokSupportsReasoningEffort(modelId: string): boolean {
   return (
     normalized.startsWith("grok-3-mini") ||
     normalized.startsWith("grok-4.20-multi-agent") ||
-    normalized.startsWith("grok-4.3")
+    normalized.startsWith("grok-4.3") ||
+    normalized.startsWith("grok-4.5")
   );
 }

--- a/extensions/xai/payload.ts
+++ b/extensions/xai/payload.ts
@@ -152,10 +152,18 @@ export function rewriteXaiResponsesPayload(payload: unknown, model: Model<Api>, 
     if (body.include.length === 0) delete body.include;
   }
 
-  // xAI doesn't implement OpenAI's prompt_cache_retention knob. Keep the
-  // cache key (xAI documents it as a body field), but remove retention.
+  // xAI doesn't implement OpenAI's prompt_cache_retention knobs. Keep the
+  // cache key (Responses API body field), but remove retention.
+  // Docs: https://docs.x.ai/developers/advanced-api-usage/prompt-caching/maximizing-cache-hits
+  // prompt_cache_key routes a conversation to the same server so cache hits
+  // are reliable; without it multi-turn agent loops often pay full input price.
   delete body.prompt_cache_retention;
-  if (options?.sessionId && !body.prompt_cache_key) body.prompt_cache_key = options.sessionId;
+  const cacheKey =
+    (typeof body.prompt_cache_key === "string" && body.prompt_cache_key.trim()) ||
+    (typeof options?.sessionId === "string" && options.sessionId.trim()) ||
+    "";
+  if (cacheKey) body.prompt_cache_key = cacheKey;
+  else delete body.prompt_cache_key;
 
   return body;
 }

--- a/extensions/xai/responses.ts
+++ b/extensions/xai/responses.ts
@@ -148,13 +148,19 @@ export async function createXaiResponse(apiKey: string, body: Record<string, any
  * @returns A forwarding assistant stream compatible with pi's async iterator and `result()` contract.
  */
 export function streamSimpleXaiResponses(model: Model<Api>, context: Context, options?: SimpleStreamOptions) {
-  const grokCliSessionId = options?.sessionId || (isGrokCliProxyModel(model.id) ? randomUUID() : undefined);
+  // Prefer pi's stable session id for cache routing. For Grok CLI proxy only,
+  // fall back to a per-stream id so x-grok-conv-id is always present.
+  // Docs: Responses API uses body.prompt_cache_key; Chat Completions / CLI
+  // proxy also benefit from the x-grok-conv-id header.
+  // https://docs.x.ai/developers/advanced-api-usage/prompt-caching/maximizing-cache-hits
+  const sessionId = options?.sessionId;
+  const routingSessionId = sessionId || (isGrokCliProxyModel(model.id) ? randomUUID() : undefined);
   const streamModel = {
     ...model,
     baseUrl: xaiBaseUrlForModel(model.id),
     headers: {
       ...(model as any).headers,
-      ...xaiModelRequestHeaders(model.id, grokCliSessionId),
+      ...xaiModelRequestHeaders(model.id, routingSessionId),
     },
   };
   // pi 0.79.8+ API-guards the OpenAI Responses helper; keep the xAI
@@ -165,7 +171,7 @@ export function streamSimpleXaiResponses(model: Model<Api>, context: Context, op
     api: "openai-responses" as const,
   };
   const headers = { ...(options?.headers || {}) };
-  if (grokCliSessionId && !headers["x-grok-conv-id"]) headers["x-grok-conv-id"] = grokCliSessionId;
+  if (routingSessionId && !headers["x-grok-conv-id"]) headers["x-grok-conv-id"] = routingSessionId;
 
   const stream = createForwardingAssistantStream();
   void (async () => {
@@ -173,9 +179,14 @@ export function streamSimpleXaiResponses(model: Model<Api>, context: Context, op
       const { streamSimpleOpenAIResponses } = await import("@earendil-works/pi-ai");
       const inner = streamSimpleOpenAIResponses(openAIResponsesModel as Model<"openai-responses">, context, {
         ...options,
+        // Ensure rewriteXaiResponsesPayload can always stamp prompt_cache_key.
+        sessionId: sessionId || routingSessionId,
         headers,
         async onPayload(payload) {
-          const rewritten = rewriteXaiResponsesPayload(payload, streamModel, options);
+          const rewritten = rewriteXaiResponsesPayload(payload, streamModel, {
+            ...options,
+            sessionId: sessionId || routingSessionId,
+          });
           const userRewritten = await options?.onPayload?.(rewritten, streamModel);
           return userRewritten === undefined ? rewritten : userRewritten;
         },

--- a/extensions/xai/tools/cursor-args.ts
+++ b/extensions/xai/tools/cursor-args.ts
@@ -112,8 +112,15 @@ export function normalizeEditArgs(args: unknown) {
 /** Normalize arguments for the Cursor/Grok CLI Grep shim. */
 export function normalizeGrepArgs(args: unknown) {
   const params = objectFromCursorArgs(args);
+  const pattern = cursorSearchPattern(params);
+  if (!pattern) {
+    const received = Object.keys(params).sort().join(", ") || "(none)";
+    throw new Error(
+      `Grep requires a non-empty pattern (or query alias). Received keys: ${received}`,
+    );
+  }
   return {
-    pattern: cursorSearchPattern(params) || "",
+    pattern,
     path: firstString(params.path, params.directory, params.dir, params.folder, params.file_path, params.filePath),
     glob: cursorGlob(params),
     ignoreCase: firstBoolean(params.ignoreCase, params.ignore_case, params.case_insensitive, params.caseInsensitive),

--- a/extensions/xai/tools/cursor-shims.ts
+++ b/extensions/xai/tools/cursor-shims.ts
@@ -10,6 +10,7 @@ import {
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { readdir, readFile, rm, stat } from "fs/promises";
 import { join, relative, sep } from "path";
+import { Type } from "typebox";
 import { resolveXaiAuthToken } from "../auth";
 import { DEFAULT_XAI_MODEL, XAI_CURSOR_TOOL_NAMES, XAI_PROVIDER_ID } from "../constants";
 import { isGrokCliProxyModel } from "../models";
@@ -35,6 +36,34 @@ const DEFAULT_CURSOR_GREP_LIMIT = 1000;
 const MAX_CURSOR_REGEX_LENGTH = 500;
 const MAX_CURSOR_GREP_CONTEXT_LINES = 20;
 const SKIPPED_SEARCH_DIRS = new Set([".git", ".omp", "node_modules"]);
+
+/**
+ * TypeBox schema for the Grep shim.
+ * `pattern` is required (same as native pi grep) so models cannot omit the search text.
+ * `query` remains an optional Cursor/Grok CLI alias and is mapped in prepareArguments.
+ */
+const grepShimSchema = Type.Object({
+  pattern: Type.String({
+    description: "REQUIRED search text (regex or literal). This is the string to find in files — not a file glob.",
+  }),
+  query: Type.Optional(
+    Type.String({
+      description: "Alias for pattern (Cursor/Grok CLI style). Mapped to pattern before execution.",
+    }),
+  ),
+  path: Type.Optional(Type.String({ description: "Directory or file to search" })),
+  include: Type.Optional(
+    Type.String({ description: "Glob filter for which files to search, e.g. *.ts (NOT the search text)" }),
+  ),
+  glob: Type.Optional(
+    Type.String({ description: "Glob filter for which files to search, e.g. *.ts (NOT the search text)" }),
+  ),
+  glob_filter: Type.Optional(Type.String({ description: "Cursor-style alias for glob" })),
+  ignoreCase: Type.Optional(Type.Boolean({ description: "Case-insensitive search" })),
+  literal: Type.Optional(Type.Boolean({ description: "Treat pattern as a literal string instead of regex" })),
+  context: Type.Optional(Type.Number({ description: "Number of context lines before/after each match" })),
+  limit: Type.Optional(Type.Number({ description: "Maximum matches" })),
+});
 
 function toPosixPath(filePath: string): string {
   return filePath.split(sep).join("/");
@@ -214,7 +243,9 @@ async function runLocalGrep(cwd: string, params: ReturnType<typeof normalizeGrep
   if (!searchInfo) throw new Error(`Path not found: ${searchPath}`);
 
   const pattern = params.pattern || "";
-  if (!pattern) throw new Error("Grep requires a pattern");
+  if (!pattern) {
+    throw new Error("Grep requires a non-empty pattern (or query alias)");
+  }
 
   const ignoreCase = !!params.ignoreCase;
   const literalPattern = ignoreCase ? pattern.toLowerCase() : pattern;
@@ -426,23 +457,13 @@ export function registerCursorToolShims(pi: ExtensionAPI) {
     pi.registerTool({
       name: "Grep",
       label: "Grep",
-      description: "Cursor/Grok CLI compatibility shim for pi's grep tool. Accepts pattern/query plus include/glob filters.",
-      promptSnippet: "Cursor-style alias for grep; accepts pattern/query and include/glob filters",
-      parameters: {
-        type: "object",
-        properties: {
-          pattern: { type: "string", description: "Regex or literal search pattern" },
-          query: { type: "string", description: "Cursor-style alias for pattern" },
-          path: { type: "string", description: "Directory or file to search" },
-          include: { type: "string", description: "Glob filter, e.g. *.ts" },
-          glob: { type: "string", description: "Glob filter, e.g. *.ts" },
-          glob_filter: { type: "string", description: "Cursor-style alias for glob" },
-          ignoreCase: { type: "boolean", description: "Case-insensitive search" },
-          limit: { type: "number", description: "Maximum matches" },
-        },
-      },
+      description:
+        "Search file contents for a required pattern (search regex/string). query is an optional alias for pattern. include/glob only filter which files are searched — they are not the search text.",
+      promptSnippet: "Search file contents; requires pattern (query alias ok); optional include/glob file filters",
+      parameters: grepShimSchema,
       prepareArguments: normalizeGrepArgs,
       execute: async (_toolCallId: string, params: any, signal: any, _onUpdate: any, ctx: any) => {
+        // Re-normalize so direct execute() callers (and query-only args) still work.
         return runLocalGrep(ctx.cwd, normalizeGrepArgs(params), signal);
       },
     } as any);

--- a/extensions/xai/tools/custom-tools.ts
+++ b/extensions/xai/tools/custom-tools.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { resolveXaiAuthToken } from "../auth";
 import { DEFAULT_XAI_IMAGE_MODEL, DEFAULT_XAI_MODEL, XAI_IMAGES_GENERATIONS_URL } from "../constants";
 import { normalizeXaiImageInput } from "../images";
-import { grokSupportsReasoningEffort } from "../models";
+import { grokSupportsReasoningEffort, normalizedXaiModelId } from "../models";
 import { createXaiResponse, postXaiJson } from "../responses";
 import { extractResponsesText, messageFromError, statusFromError } from "../text";
 import { xaiTextInput, xaiToolError } from "./common";
@@ -50,7 +50,7 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
           input,
         };
 
-        const effort = params.reasoning_effort || "medium";
+        const effort = params.reasoning_effort || (normalizedXaiModelId(model) === "grok-4.5" ? "high" : "medium");
         if (grokSupportsReasoningEffort(model) && effort !== "none") {
           body.reasoning = { effort };
         }

--- a/extensions/xai/tools/custom-tools.ts
+++ b/extensions/xai/tools/custom-tools.ts
@@ -18,7 +18,12 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
         properties: {
           prompt: { type: "string", description: "The prompt or question" },
           model: { type: "string", description: "Model to use", default: DEFAULT_XAI_MODEL },
-          reasoning_effort: { type: "string", enum: ["none", "low", "medium", "high"], default: "medium" },
+          reasoning_effort: {
+            type: "string",
+            enum: ["none", "low", "medium", "high"],
+            description:
+              "Reasoning effort. Defaults to high for grok-4.5 and medium for other models when omitted.",
+          },
           response_format: { type: "string", description: "Set to 'json' for JSON output" },
           previous_response_id: { type: "string", description: "Continue conversation" },
           image_url: { type: "string", description: "Optional image URL for vision/multimodal input (supports image analysis)" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-xai-oauth",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-xai-oauth",
-      "version": "1.2.6",
+      "version": "1.3.0",
       "license": "MIT",
       "bin": {
         "pi-xai-oauth": "bin/setup.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-xai-oauth",
   "version": "1.2.6",
-  "description": "One-command installer for xAI OAuth provider + Grok, Grok Build, and Composer models in pi",
+  "description": "One-command installer for xAI OAuth provider + Grok 4.5, Grok Build, and Composer models in pi",
   "keywords": [
     "pi-package",
     "xai",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-xai-oauth",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "description": "One-command installer for xAI OAuth provider + Grok 4.5, Grok Build, and Composer models in pi",
   "keywords": [
     "pi-package",

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -152,6 +152,39 @@ async function verifyCursorToolShims(tools) {
     /Unsafe regex pattern/,
     "Grep shim should reject regexes with obvious catastrophic-backtracking structure",
   );
+  await assert.rejects(
+    () => runCursorTool(tools, "Grep", { path: "extensions", include: "*.ts", limit: 5 }),
+    /Grep requires a non-empty pattern \(or query alias\)/,
+    "Grep shim should fail clearly when pattern/query is omitted",
+  );
+  await assert.rejects(
+    () => runCursorTool(tools, "Grep", { pattern: "   ", path: "extensions" }),
+    /Grep requires a non-empty pattern \(or query alias\)/,
+    "Grep shim should reject whitespace-only patterns",
+  );
+
+  const grepByPattern = await runCursorTool(tools, "Grep", {
+    pattern: "registerProvider",
+    path: "extensions",
+    include: "*.ts",
+    limit: 3,
+  });
+  assert.match(grepByPattern.content[0].text, /registerProvider/, "Grep shim should accept pattern directly");
+
+  const grepPrepared = tools.get("Grep").prepareArguments({
+    query: "export const DEFAULT_XAI_MODEL",
+    include: "*.ts",
+    path: "extensions",
+  });
+  assert.equal(grepPrepared.pattern, "export const DEFAULT_XAI_MODEL", "Grep prepareArguments should map query to required pattern");
+  assert.equal(grepPrepared.glob, "*.ts", "Grep prepareArguments should map include to glob");
+  const grepParams = tools.get("Grep").parameters;
+  assert.ok(
+    Array.isArray(grepParams.required) && grepParams.required.includes("pattern"),
+    "Grep schema should require pattern so models do not omit the search text",
+  );
+  assert.ok(grepParams.properties?.pattern, "Grep schema should expose a pattern property");
+  assert.ok(grepParams.properties?.query, "Grep schema should keep query as a Cursor-style alias");
 
   const globResult = await runCursorTool(tools, "Glob", { glob: "xai-oauth.ts", limit: 5 });
   assert.match(globResult.content[0].text, /extensions\/xai-oauth\.ts/, "Glob shim should map glob to pi find");
@@ -419,6 +452,14 @@ async function main() {
     assert.ok(provider, "xai-auth provider should be registered");
     assert.equal(secondLoad.tools.size, tools.size, "extension reloads should register tools on the new pi API object");
     assert.equal(provider.api, "xai-responses");
+    const grok45 = provider.models.find((model) => model.id === "grok-4.5");
+    assert.ok(grok45, "grok-4.5 should be registered in the xAI model catalog");
+    assert.equal(grok45?.contextWindow, 500_000);
+    assert.equal(grok45?.reasoning, true);
+    assert.equal(grok45?.cost.input, 2);
+    assert.equal(grok45?.cost.cacheRead, 0.5);
+    assert.equal(grok45?.cost.output, 6);
+    assert.equal(grok45?.thinkingLevelMap?.off, null, "Grok 4.5 reasoning cannot be disabled");
     assert.equal(provider.models.find((model) => model.id === "grok-4.3")?.contextWindow, 1_000_000);
     assert.equal(provider.models.find((model) => model.id === "grok-build")?.contextWindow, 512_000);
     assert.equal(provider.models.find((model) => model.id === "grok-composer-2.5-fast")?.contextWindow, 200_000);
@@ -444,6 +485,13 @@ async function main() {
       },
     });
     assert.match(noAuthResult.content[0].text, /No xAI OAuth credentials/, "tools should not fall back to XAI_API_KEY");
+
+    const { body: grok45TextBody } = await runTool(tools, "xai_generate_text", {
+      prompt: "hi",
+      model: "grok-4.5",
+    });
+    assert.equal(grok45TextBody.model, "grok-4.5", "xai_generate_text should support explicit Grok 4.5 requests");
+    assert.equal(grok45TextBody.reasoning.effort, "high", "Grok 4.5 text generation should default to high reasoning");
 
     const { body: composerBody, request: composerRequest } = await runTool(
       tools,


### PR DESCRIPTION
## Summary
- Add **Grok 4.5** to the xAI model catalog and make it the **default** model (`constants`, `setup`, README showcase)
- Catalog details: 500K context, text+image input, reasoning `low`/`medium`/`high` (default high), $2/$0.50 cache/$6 pricing
- Harden Cursor **Grep** shim: TypeBox schema with required `pattern`, clearer missing-pattern errors, `query` alias mapping
- Improve Responses **prompt caching** routing via `prompt_cache_key` + CLI `x-grok-conv-id` per xAI docs

## Test plan
- [x] `node scripts/verify-extension.js`
- [x] `npx tsc --noEmit`
- [x] Live Grep after reload: pattern search, context lines, no-match, whitespace rejection
- [x] `npx pi-xai-oauth` / `pi install .` then `/model` shows `grok-4.5` as default
- [x] `pi --model grok-4.5 "hello"` streams successfully with OAuth
- [x] Confirm cache usage shows `cacheRead` on multi-turn with same session

## Docs / sources
- https://docs.x.ai/developers/models/grok-4.5
- https://docs.x.ai/developers/tools/function-calling
- https://docs.x.ai/developers/advanced-api-usage/prompt-caching/maximizing-cache-hits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Grok 4.5 as the default model, with updated model selection and usage guidance.
  * Improved model handling for reasoning settings and prompt caching during requests.
  * Enhanced Grep tool compatibility with stricter validation and broader argument support.
* **Bug Fixes**
  * Made session routing and conversation ID handling more consistent.
  * Ensured missing or empty Grep searches now fail with clear errors.
* **Documentation**
  * Updated README and project notes to reflect the new default model and current capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->