### PR TITLE
fix: prune duplicate local pi-xai-oauth installs in setup

### DIFF
--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -161,3 +161,14 @@ Update this file frequently during execution.
 - [x] Verified with `npm test`, `npm run typecheck`.
 
 **Current branch:** feature/add-grok-4-5
+
+## Phase 16: npm/local package conflict repair
+- [x] Created branch `fix/dedupe-local-package-install`.
+- [x] Fast-forwarded branch onto latest `origin/main` (`00db405`, v1.3.0).
+- [x] Reproduced `pi` startup tool conflicts when user settings contained both `../../projects/pi-xai-oauth` and `npm:pi-xai-oauth`.
+- [x] Added setup-script package pruning helpers to remove duplicate local installs of this package when installing the npm package.
+- [x] Added setup regression coverage for npm spec parsing, local duplicate pruning, and settings rewrite behavior.
+- [x] Removed the duplicate local package entry from `~/.pi/agent/settings.json` to unblock this machine while preserving the npm default `grok-4.5`.
+- [ ] Re-verify on latest main: `npm test`, `npm run typecheck`, `git diff --check`, `node bin/setup.js --help`, `npm pack --dry-run`.
+
+**Current branch:** fix/dedupe-local-package-install

--- a/bin/setup.js
+++ b/bin/setup.js
@@ -10,7 +10,8 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 
-const NPM_SPEC = "npm:pi-xai-oauth";
+const PACKAGE_NAME = "pi-xai-oauth";
+const NPM_SPEC = `npm:${PACKAGE_NAME}`;
 const SETTINGS_PATH = path.join(os.homedir(), ".pi/agent/settings.json");
 
 // ANSI colors
@@ -54,18 +55,93 @@ function installPackage() {
   }
 }
 
-function updateSettings() {
+function getPackageEntrySource(entry) {
+  if (typeof entry === "string") return entry;
+  if (entry && typeof entry === "object" && typeof entry.source === "string") return entry.source;
+  return undefined;
+}
+
+function getNpmPackageName(source) {
+  if (typeof source !== "string" || !source.startsWith("npm:")) return undefined;
+  const spec = source.slice("npm:".length);
+  if (spec.startsWith("@")) {
+    const slashIndex = spec.indexOf("/");
+    if (slashIndex === -1) return spec;
+    const versionIndex = spec.indexOf("@", slashIndex + 1);
+    return versionIndex === -1 ? spec : spec.slice(0, versionIndex);
+  }
+  const versionIndex = spec.indexOf("@");
+  return versionIndex === -1 ? spec : spec.slice(0, versionIndex);
+}
+
+function resolveLocalPackageJson(source, settingsPath = SETTINGS_PATH) {
+  if (typeof source !== "string") return undefined;
+  if (source.startsWith("npm:") || source.startsWith("git:") || /^[a-z]+:\/\//i.test(source)) return undefined;
+
+  const expanded = source.startsWith("~/") ? path.join(os.homedir(), source.slice(2)) : source;
+  const resolved = path.resolve(path.dirname(settingsPath), expanded);
+
+  try {
+    const stat = fs.statSync(resolved);
+    return stat.isDirectory() ? path.join(resolved, "package.json") : path.join(path.dirname(resolved), "package.json");
+  } catch {
+    return undefined;
+  }
+}
+
+function isLocalPackageNamed(source, packageName = PACKAGE_NAME, settingsPath = SETTINGS_PATH) {
+  const packageJsonPath = resolveLocalPackageJson(source, settingsPath);
+  if (!packageJsonPath) return false;
+
+  try {
+    const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+    return pkg.name === packageName;
+  } catch {
+    return false;
+  }
+}
+
+function pruneDuplicatePackageEntries(packages, settingsPath = SETTINGS_PATH, packageName = PACKAGE_NAME) {
+  let hasNpmPackage = false;
+  const removed = [];
+  const next = [];
+
+  for (const entry of packages) {
+    const source = getPackageEntrySource(entry);
+    if (getNpmPackageName(source) === packageName) {
+      hasNpmPackage = true;
+      next.push(entry);
+      continue;
+    }
+
+    if (isLocalPackageNamed(source, packageName, settingsPath)) {
+      removed.push(source);
+      continue;
+    }
+
+    next.push(entry);
+  }
+
+  if (!hasNpmPackage) {
+    next.push(NPM_SPEC);
+    hasNpmPackage = true;
+  }
+
+  return { packages: next, removed, addedNpmPackage: !packages.some((entry) => getNpmPackageName(getPackageEntrySource(entry)) === packageName) };
+}
+
+function updateSettings(settingsPath = SETTINGS_PATH) {
   console.log(color("\n⚙️  Configuring pi settings...", "cyan"));
 
   let settings = {};
 
-  if (fs.existsSync(SETTINGS_PATH)) {
+  if (fs.existsSync(settingsPath)) {
     try {
-      settings = JSON.parse(fs.readFileSync(SETTINGS_PATH, "utf8"));
+      settings = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
     } catch (e) {
-      const backupPath = `${SETTINGS_PATH}.bak-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+      const backupPath = `${settingsPath}.bak-${new Date().toISOString().replace(/[:.]/g, "-")}`;
       try {
-        fs.copyFileSync(SETTINGS_PATH, backupPath);
+        fs.copyFileSync(settingsPath, backupPath);
         console.log(color(`   Warning: Could not parse existing settings.json; backed it up to ${backupPath}`, "yellow"));
       } catch {
         console.log(color("   Warning: Could not parse existing settings.json and could not create a backup", "yellow"));
@@ -79,16 +155,19 @@ function updateSettings() {
     settings.packages = [];
   }
 
-  const hasPackage = settings.packages.some(p => {
-    if (typeof p === "string") return p === NPM_SPEC;
-    if (p && typeof p === "object") return p.source === NPM_SPEC;
-    return false;
-  });
-
-  if (!hasPackage) {
-    settings.packages.push(NPM_SPEC);
+  const packagePrune = pruneDuplicatePackageEntries(settings.packages, settingsPath);
+  if (packagePrune.removed.length > 0) {
+    settings.packages = packagePrune.packages;
     changed = true;
-    console.log(color("   + Added npm:pi-xai-oauth to packages", "green"));
+    for (const source of packagePrune.removed) {
+      console.log(color(`   - Removed duplicate local ${PACKAGE_NAME} package: ${source}`, "yellow"));
+    }
+  }
+
+  if (packagePrune.addedNpmPackage) {
+    settings.packages = packagePrune.packages;
+    changed = true;
+    console.log(color(`   + Added ${NPM_SPEC} to packages`, "green"));
   }
 
   if (settings.defaultProvider !== "xai-auth") {
@@ -111,9 +190,9 @@ function updateSettings() {
 
   if (changed) {
     try {
-      const dir = path.dirname(SETTINGS_PATH);
+      const dir = path.dirname(settingsPath);
       if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-      fs.writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2));
+      fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
       console.log(color("   ✅ Settings updated!", "green"));
     } catch (e) {
       console.log(color("   ⚠️  Could not write settings.json (you can configure manually)", "yellow"));
@@ -343,4 +422,15 @@ function main() {
   }
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  PACKAGE_NAME,
+  NPM_SPEC,
+  getNpmPackageName,
+  isLocalPackageNamed,
+  pruneDuplicatePackageEntries,
+  updateSettings,
+};

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "scaffold": "node bin/setup.js --scaffold",
     "setup": "node bin/setup.js",
-    "test": "node scripts/verify-extension.js",
+    "test": "node scripts/verify-extension.js && node scripts/verify-setup.js",
     "typecheck": "npx tsc --noEmit"
   },
   "pi": {

--- a/scripts/verify-setup.js
+++ b/scripts/verify-setup.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+const assert = require("assert");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..");
+const {
+  getNpmPackageName,
+  pruneDuplicatePackageEntries,
+  updateSettings,
+} = require(path.join(repoRoot, "bin", "setup.js"));
+
+function makeFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-xai-oauth-setup-"));
+  const settingsDir = path.join(root, ".pi", "agent");
+  const packageDir = path.join(root, "projects", "pi-xai-oauth");
+  const otherDir = path.join(root, "projects", "other-pkg");
+  fs.mkdirSync(settingsDir, { recursive: true });
+  fs.mkdirSync(packageDir, { recursive: true });
+  fs.mkdirSync(otherDir, { recursive: true });
+  fs.writeFileSync(path.join(packageDir, "package.json"), JSON.stringify({ name: "pi-xai-oauth" }));
+  fs.writeFileSync(path.join(otherDir, "package.json"), JSON.stringify({ name: "other-pkg" }));
+  return {
+    root,
+    settingsPath: path.join(settingsDir, "settings.json"),
+    localXai: "../../projects/pi-xai-oauth",
+    localOther: "../../projects/other-pkg",
+  };
+}
+
+(function verifyNpmSpecParsing() {
+  assert.equal(getNpmPackageName("npm:pi-xai-oauth"), "pi-xai-oauth");
+  assert.equal(getNpmPackageName("npm:pi-xai-oauth@1.3.0"), "pi-xai-oauth");
+  assert.equal(getNpmPackageName("npm:@scope/pkg@1.2.3"), "@scope/pkg");
+  assert.equal(getNpmPackageName("git:github.com/user/repo"), undefined);
+})();
+
+(function verifyLocalDuplicatePruning() {
+  const fixture = makeFixture();
+  const result = pruneDuplicatePackageEntries([
+    fixture.localXai,
+    "npm:pi-xai-oauth",
+    fixture.localOther,
+  ], fixture.settingsPath);
+
+  assert.deepEqual(result.removed, [fixture.localXai]);
+  assert.deepEqual(result.packages, ["npm:pi-xai-oauth", fixture.localOther]);
+  assert.equal(result.addedNpmPackage, false);
+  fs.rmSync(fixture.root, { recursive: true, force: true });
+})();
+
+(function verifyObjectLocalDuplicatePruningAndNpmAdd() {
+  const fixture = makeFixture();
+  const result = pruneDuplicatePackageEntries([
+    { source: fixture.localXai, extensions: ["./extensions"] },
+  ], fixture.settingsPath);
+
+  assert.deepEqual(result.removed, [fixture.localXai]);
+  assert.deepEqual(result.packages, ["npm:pi-xai-oauth"]);
+  assert.equal(result.addedNpmPackage, true);
+  fs.rmSync(fixture.root, { recursive: true, force: true });
+})();
+
+(function verifyUpdateSettingsWritesPrunedConfig() {
+  const fixture = makeFixture();
+  fs.writeFileSync(fixture.settingsPath, JSON.stringify({
+    packages: [fixture.localXai, "npm:pi-xai-oauth"],
+    defaultProvider: "xai-auth",
+    defaultModel: "grok-4.3",
+    defaultThinkingLevel: "high",
+  }));
+
+  updateSettings(fixture.settingsPath);
+  const settings = JSON.parse(fs.readFileSync(fixture.settingsPath, "utf8"));
+  assert.deepEqual(settings.packages, ["npm:pi-xai-oauth"]);
+  fs.rmSync(fixture.root, { recursive: true, force: true });
+})();
+
+console.log("verify-setup: ok");


### PR DESCRIPTION
## Summary
- Detect local package entries by `package.json` name and remove them when `npm:pi-xai-oauth` is installed
- Ensure setup always keeps a single npm package entry for this package
- Add `scripts/verify-setup.js` regression coverage for npm-spec parsing, local pruning, and settings rewrite

## Problem
Having both a local path (e.g. `../../projects/pi-xai-oauth`) and `npm:pi-xai-oauth` in `~/.pi/agent/settings.json` makes pi load the extension twice and report duplicate `xai_*` tool conflicts on startup.

## Test plan
- [x] `node scripts/verify-setup.js`
- [x] `node bin/setup.js --help`
- [ ] `npm test` / `npm run typecheck` (currently blocked on main by pre-existing `@earendil-works/pi-ai@0.80.3` API export drift: `streamSimpleOpenAIResponses` missing)
- [ ] Manual: settings with both local + npm entries; run `node bin/setup.js` and confirm local entry is pruned
- [ ] Manual: pi startup no longer reports tool conflicts after setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added setup verification coverage to check package parsing, duplicate package cleanup, and settings file updates.
  * Improved setup handling so duplicate local and npm package entries are automatically removed before reinstalling the package.

* **Bug Fixes**
  * Resolved a startup conflict caused by having both local and npm versions of the same package configured.
  * Made the setup process more reliable when updating package settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->