### PR TITLE
docs: document setup auto-dedupe for local + npm installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,32 +35,39 @@ pi --model grok-4.5:low "Quick status check"   # fast mode
 
 This package adds **Grok 4.5** (default), **Grok 4.3**, **Grok Build**, and **Composer 2.5** as fully-integrated xAI OAuth models in pi, with proper OAuth login, automatic token refresh, and a suite of custom tools (`xai_generate_text`, `xai_web_search`, `xai_x_search`, etc.).
 
-> **Latest release:** `pi-xai-oauth` **1.3.0** adds **Grok 4.5** as the default model (500K context, low/medium/high reasoning; fast mode = `low`). Existing npm installs should run `pi update npm:pi-xai-oauth`; local checkout installs should keep only one copy with `pi remove npm:pi-xai-oauth && pi install .`.
+> **Latest release:** `pi-xai-oauth` **1.3.1** (Grok 4.5 default since **1.3.0**: 500K context, low/medium/high reasoning; fast mode = `low`). Existing npm installs should run `pi update npm:pi-xai-oauth`. Local checkout installs should keep only one copy with `pi remove npm:pi-xai-oauth && pi install .`.
 >
 > **Compatibility note:** 1.2.4+ supports pi 0.79.8+'s OpenAI Responses API guard for Grok/xAI streaming.
 
-> **✅ Setup auto-dedupes local + npm copies**
->
-> If `~/.pi/agent/settings.json` has both a local path (e.g. `../../projects/pi-xai-oauth`) and `npm:pi-xai-oauth`, pi loads the extension twice and fails with `Tool "xai_generate_text" conflicts with ...`.
->
-> Running setup fixes that:
-> ```bash
-> npx pi-xai-oauth --yes
-> # or from a checkout:
-> node bin/setup.js --yes
-> ```
-> Setup installs the npm package, removes matching local path entries for this package, and keeps a single `npm:pi-xai-oauth` entry. Confirm with:
-> ```bash
-> pi list
-> ```
->
-> `pi update npm:pi-xai-oauth` updates the published package but does **not** prune local path duplicates — re-run setup if you still see tool conflicts.
+### ✅ Setup auto-dedupes local + npm copies
+
+If `~/.pi/agent/settings.json` has both a local path (e.g. `../../projects/pi-xai-oauth`) **and** `npm:pi-xai-oauth`, pi loads the extension twice and fails with `Tool "xai_generate_text" conflicts with ...`.
+
+For normal **npm** users, re-run setup:
+
+```bash
+npx pi-xai-oauth --yes
+# or from a checkout:
+node bin/setup.js --yes
+```
+
+Setup will:
+1. Install `npm:pi-xai-oauth`
+2. Remove matching **local path** entries for this package from settings
+3. Keep a single `npm:pi-xai-oauth` entry
+
+Confirm with `pi list` (should show only one `pi-xai-oauth`).
+
+Notes:
+- `pi update npm:pi-xai-oauth` updates the published package but does **not** prune local path duplicates — re-run setup if tool conflicts remain.
+- Setup is **npm-oriented**. If you intentionally develop from a local checkout, do **not** run setup to “fix” conflicts; keep only the checkout with `pi remove npm:pi-xai-oauth && pi install .`.
 
 ---
 
 ## Table of Contents
 
 - [✨ New: Grok 4.5](#-new-grok-45)
+- [✅ Setup auto-dedupes local + npm copies](#-setup-auto-dedupes-local--npm-copies)
 - [Features](#features)
 - [How It Works](#how-it-works)
 - [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,23 @@ This package adds **Grok 4.5** (default), **Grok 4.3**, **Grok Build**, and **Co
 >
 > **Compatibility note:** 1.2.4+ supports pi 0.79.8+'s OpenAI Responses API guard for Grok/xAI streaming.
 
+> **✅ Setup auto-dedupes local + npm copies**
+>
+> If `~/.pi/agent/settings.json` has both a local path (e.g. `../../projects/pi-xai-oauth`) and `npm:pi-xai-oauth`, pi loads the extension twice and fails with `Tool "xai_generate_text" conflicts with ...`.
+>
+> Running setup fixes that:
+> ```bash
+> npx pi-xai-oauth --yes
+> # or from a checkout:
+> node bin/setup.js --yes
+> ```
+> Setup installs the npm package, removes matching local path entries for this package, and keeps a single `npm:pi-xai-oauth` entry. Confirm with:
+> ```bash
+> pi list
+> ```
+>
+> `pi update npm:pi-xai-oauth` updates the published package but does **not** prune local path duplicates — re-run setup if you still see tool conflicts.
+
 ---
 
 ## Table of Contents
@@ -105,9 +122,10 @@ npx pi-xai-oauth
 
 This runs the setup script which:
 1. Installs `npm:pi-xai-oauth` into pi
-2. Sets `xai-auth` as your default provider
-3. Sets `grok-4.5` as your default model
-4. Enables `high` thinking level by default
+2. Removes duplicate **local path** installs of this package from `~/.pi/agent/settings.json` (keeps the npm entry)
+3. Sets `xai-auth` as your default provider
+4. Sets `grok-4.5` as your default model
+5. Enables `high` thinking level by default
 
 ### Manual install
 
@@ -469,7 +487,14 @@ In the pi TUI, the current model is shown in the status bar. You can also check 
 
 You have more than one copy of this extension installed. This commonly happens when updating from npm to a local checkout, or when switching between two local worktrees. pi refuses to load duplicate tool names.
 
-First inspect installed packages:
+**Fastest fix for normal npm users** — re-run setup so it prunes local path duplicates and keeps `npm:pi-xai-oauth`:
+
+```bash
+npx pi-xai-oauth --yes
+pi list
+```
+
+Or clean up manually. First inspect installed packages:
 
 ```bash
 pi list
@@ -510,7 +535,13 @@ pi 0.79.8+ enforces an OpenAI Responses API guard. `pi-xai-oauth` 1.2.4+ handles
 pi remove npm:pi-xai-oauth && pi install .
 ```
 
-If you previously installed a local checkout with `pi install .`, `pi update npm:pi-xai-oauth` will not replace that local copy. Run `pi list` and make sure only one `pi-xai-oauth` entry is installed. Remove duplicate npm/local/worktree copies before restarting pi.
+If you previously installed a local checkout with `pi install .`, `pi update npm:pi-xai-oauth` will not replace that local copy. Run `pi list` and make sure only one `pi-xai-oauth` entry is installed. To switch back to npm and auto-remove local path duplicates, re-run setup:
+
+```bash
+npx pi-xai-oauth --yes
+```
+
+Or remove duplicate npm/local/worktree copies manually before restarting pi.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add a top-of-README callout explaining tool conflicts from local + `npm:pi-xai-oauth` and how setup auto-prunes them
- Document the prune step in the one-command install list
- Point troubleshooting/updating at `npx pi-xai-oauth --yes` as the fastest fix

## Test plan
- [x] Review README top section + Installation + Troubleshooting + Updating
- [ ] Confirm wording matches `bin/setup.js` prune behavior