### PR TITLE
fix: cursor shims duplicate pi built-in tool names (400 "Tool names must be unique")

### DIFF
--- a/extensions/xai-oauth.ts
+++ b/extensions/xai-oauth.ts
@@ -21,8 +21,10 @@ export default function (pi: ExtensionAPI) {
   registerXaiTools(pi);
 
   if (typeof (pi as any).on === "function") {
-    (pi as any).on("session_start", (_event: any, ctx: any) => syncCursorToolShimsForModel(ctx, ctx?.model));
-    (pi as any).on("model_select", (event: any, ctx: any) => syncCursorToolShimsForModel(ctx, event?.model));
-    (pi as any).on("before_agent_start", (_event: any, ctx: any) => syncCursorToolShimsForModel(ctx, ctx?.model));
+    // The tool-registry accessors are on `pi`, not on the event `ctx`; the model
+    // is read from the event/ctx. See syncCursorToolShimsForModel for details.
+    (pi as any).on("session_start", (_event: any, ctx: any) => syncCursorToolShimsForModel(pi, ctx?.model));
+    (pi as any).on("model_select", (event: any, ctx: any) => syncCursorToolShimsForModel(pi, event?.model ?? ctx?.model));
+    (pi as any).on("before_agent_start", (_event: any, ctx: any) => syncCursorToolShimsForModel(pi, ctx?.model));
   }
 }

--- a/extensions/xai/tools/cursor-shims.ts
+++ b/extensions/xai/tools/cursor-shims.ts
@@ -313,17 +313,40 @@ function uniqueToolNames(toolNames: string[]): string[] {
   return [...new Set(toolNames)];
 }
 
-/** Enable Cursor/Grok CLI shims only for Grok CLI proxy models. */
-export function syncCursorToolShimsForModel(ctx: any, model?: Model<Api>) {
-  if (typeof ctx?.getActiveTools !== "function" || typeof ctx?.setActiveTools !== "function") return;
+/**
+ * Enable Cursor/Grok CLI shims only for Grok CLI proxy models.
+ *
+ * The tool-registry accessors (`getActiveTools`/`setActiveTools`) live on the
+ * `pi` ExtensionAPI object, NOT on the per-event `ExtensionContext` that pi
+ * passes as the second handler argument. Passing the event `ctx` here made the
+ * guard below always fail, so the shims were never pruned and their names
+ * (`Read`/`Write`/`Edit`) collided with pi's built-in tools, producing
+ * `400 tools: Tool names must be unique` on every request for non-Grok models.
+ * Always pass the `pi` api object.
+ */
+export function syncCursorToolShimsForModel(api: any, model?: Model<Api>) {
+  if (typeof api?.getActiveTools !== "function" || typeof api?.setActiveTools !== "function") return;
 
-  const activeTools = Array.isArray(ctx.getActiveTools()) ? (ctx.getActiveTools() as string[]) : [];
+  let activeTools: string[];
+  try {
+    const current = api.getActiveTools();
+    activeTools = Array.isArray(current) ? (current as string[]) : [];
+  } catch {
+    // Tool registry not bound yet (e.g. called during early startup before the
+    // session finished initializing). It will be re-synced on before_agent_start.
+    return;
+  }
+
   const withoutCursorShims = activeTools.filter((toolName) => !XAI_CURSOR_TOOL_NAMES.includes(toolName));
   const shouldEnableCursorShims = model?.provider === XAI_PROVIDER_ID && isGrokCliProxyModel(model.id);
   const nextTools = shouldEnableCursorShims ? uniqueToolNames([...withoutCursorShims, ...XAI_CURSOR_TOOL_NAMES]) : withoutCursorShims;
 
   if (nextTools.length !== activeTools.length || nextTools.some((toolName, index) => toolName !== activeTools[index])) {
-    ctx.setActiveTools(nextTools);
+    try {
+      api.setActiveTools(nextTools);
+    } catch {
+      // Ignore if the registry is not ready; a later before_agent_start will retry.
+    }
   }
 }
 

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -219,16 +219,40 @@ async function verifyCursorToolShims(tools) {
 
 async function verifyCursorToolActivation(loadResult) {
   const { handlers, getActiveTools } = loadResult;
-  const ctx = {
-    getActiveTools,
-    setActiveTools: loadResult.setActiveTools,
-  };
+  // The real pi ExtensionContext does NOT expose getActiveTools/setActiveTools;
+  // those accessors live on the `pi` api object passed at load time. Mirror that
+  // here (empty ctx) so the handlers are forced to use the pi accessors. This is
+  // the regression guard for the "400 tools: Tool names must be unique" bug where
+  // reading the accessors off ctx made the sync silently bail and left the
+  // Read/Write/Edit shims colliding with pi's built-in tools.
+  const ctx = {};
+  const selectModel = (id, provider = "xai-auth") =>
+    handlers.get("model_select")?.({ model: { provider, id } }, ctx);
 
-  await handlers.get("model_select")?.({ model: { provider: "xai-auth", id: "grok-composer-2.5-fast" } }, ctx);
+  await selectModel("grok-composer-2.5-fast");
   assert.ok(getActiveTools().includes("Grep"), "Cursor shims should be enabled for Composer 2.5");
 
-  await handlers.get("model_select")?.({ model: { provider: "xai-auth", id: "grok-4.3" } }, ctx);
+  await selectModel("grok-4.3");
   assert.ok(!getActiveTools().includes("Grep"), "Cursor shims should be disabled for non-Grok-CLI xAI models");
+
+  // session_start reads the model from ctx.model (not the event). Verify it prunes
+  // the shims for a non-Grok model so their names can't duplicate the built-ins.
+  await selectModel("grok-composer-2.5-fast");
+  assert.ok(getActiveTools().includes("Grep"), "Cursor shims should re-enable for Composer 2.5");
+  await handlers.get("session_start")?.({}, { model: { provider: "anthropic", id: "claude-opus-4-8" } });
+  assert.ok(!getActiveTools().includes("Grep"), "session_start should prune Cursor shims for non-Grok models");
+  for (const shim of ["Read", "Write", "Edit"]) {
+    assert.ok(
+      !getActiveTools().includes(shim),
+      `${shim} shim must not stay active for non-Grok models (would duplicate pi's built-in tool name)`,
+    );
+  }
+
+  // before_agent_start also reads the model from ctx.model.
+  await selectModel("grok-composer-2.5-fast");
+  assert.ok(getActiveTools().includes("Grep"), "Cursor shims should re-enable before before_agent_start check");
+  await handlers.get("before_agent_start")?.({}, { model: { provider: "anthropic", id: "claude-opus-4-8" } });
+  assert.ok(!getActiveTools().includes("Grep"), "before_agent_start should prune Cursor shims for non-Grok models");
 }
 
 function lastResultErrorMessage(result) {


### PR DESCRIPTION
## Summary

With this extension enabled on a **non-Grok model** (e.g. `anthropic/claude-opus-4-8`), **every** request fails immediately:

```
400 {"type":"error","error":{"type":"invalid_request_error","message":"tools: Tool names must be unique."}}
```

Root cause: `syncCursorToolShimsForModel()` read the tool-registry accessors from the wrong object.

```ts
// before
pi.on("before_agent_start", (_e, ctx) => syncCursorToolShimsForModel(ctx, ctx?.model));

export function syncCursorToolShimsForModel(ctx, model) {
  if (typeof ctx?.getActiveTools !== "function" || typeof ctx?.setActiveTools !== "function") return; // always true
  ...
}
```

In pi, `getActiveTools`/`setActiveTools` are methods of the **`pi` `ExtensionAPI` object**, not of the per-event **`ExtensionContext`** passed as the handler's second argument. In `@earendil-works/pi-coding-agent` the runner's `createContext()` never attaches them, and the `ExtensionContext` interface doesn't declare them — they're bound onto `pi` via `bindCore()` (`getActiveTools → session.getActiveToolNames()`, etc.).

So `typeof ctx?.getActiveTools !== "function"` is **always** true and the function returns early on every call — in the TUI too, not just `--print`. The Cursor/Grok CLI shims are therefore **never pruned** for non-Grok models, and their names `Read` / `Write` / `Edit` collide with pi's built-in tools, so the provider rejects the whole request.

## Fix

- Pass `pi` (the `ExtensionAPI`) into `syncCursorToolShimsForModel` for `getActiveTools`/`setActiveTools`; read the `model` from the event/ctx as before.
- Wrap the accessor calls in `try/catch` so an early `session_start` (before `bindCore` wires the real registry) safely no-ops; `before_agent_start` re-syncs before the request is sent.

## Why the test didn't catch it

`verifyCursorToolActivation` injected a **fake `ctx`** carrying `getActiveTools`/`setActiveTools` — a shape the real runtime never produces — so the guard passed only in the test. Updated to use an empty `ctx` (matching the real `ExtensionContext`) and added `session_start` / `before_agent_start` pruning assertions, including explicit checks that `Read`/`Write`/`Edit` don't remain active for non-Grok models.

## Verification

Against pi `0.80.3`, loading the extension with `-e`:

| | tools sent | result |
|---|---|---|
| before | `[Read, Bash, Edit, Write, **Read, Write, StrReplace, Edit, ...**, xai_*]` → dup `Read/Edit/Write` | `400 Tool names must be unique` |
| after | `[Read, Bash, Edit, Write, xai_*]` — shims pruned, no dups | request succeeds |

- `pi --print -e <ext> "hi"` → **before:** 400; **after:** normal reply.
- Grok CLI proxy models (e.g. `grok-composer-2.5-fast`) still enable the shims (`Grep` present); non-Grok models prune them — verified via the updated `verifyCursorToolActivation`, which now **fails on the pre-fix code** and passes after.
- `npx tsc --noEmit` clean for the changed files.

> Note: `scripts/verify-extension.js` currently also fails earlier in `verifyRealGuardSemantics` on my machine due to a local `@earendil-works/pi-ai` install resolving a nested duplicate — this is unrelated to this change (reproduces on a clean `main` checkout) and I left it untouched.