### PR TITLE
fix: sync Cursor shims via ExtensionAPI when event ctx lacks tool API

### DIFF
--- a/extensions/xai-oauth.ts
+++ b/extensions/xai-oauth.ts
@@ -21,8 +21,10 @@ export default function (pi: ExtensionAPI) {
   registerXaiTools(pi);
 
   if (typeof (pi as any).on === "function") {
-    (pi as any).on("session_start", (_event: any, ctx: any) => syncCursorToolShimsForModel(ctx, ctx?.model));
-    (pi as any).on("model_select", (event: any, ctx: any) => syncCursorToolShimsForModel(ctx, event?.model));
-    (pi as any).on("before_agent_start", (_event: any, ctx: any) => syncCursorToolShimsForModel(ctx, ctx?.model));
+    (pi as any).on("session_start", (_event: any, ctx: any) => syncCursorToolShimsForModel(pi, ctx?.model, ctx));
+    (pi as any).on("model_select", (event: any, ctx: any) =>
+      syncCursorToolShimsForModel(pi, event?.model ?? ctx?.model, ctx),
+    );
+    (pi as any).on("before_agent_start", (_event: any, ctx: any) => syncCursorToolShimsForModel(pi, ctx?.model, ctx));
   }
 }

--- a/extensions/xai/tools/cursor-shims.ts
+++ b/extensions/xai/tools/cursor-shims.ts
@@ -7,7 +7,6 @@ import {
   createReadToolDefinition,
   createWriteToolDefinition,
 } from "@earendil-works/pi-coding-agent";
-import type { Api, Model } from "@earendil-works/pi-ai";
 import { readdir, readFile, rm, stat } from "fs/promises";
 import { join, relative, sep } from "path";
 import { Type } from "typebox";
@@ -313,17 +312,52 @@ function uniqueToolNames(toolNames: string[]): string[] {
   return [...new Set(toolNames)];
 }
 
-/** Enable Cursor/Grok CLI shims only for Grok CLI proxy models. */
-export function syncCursorToolShimsForModel(ctx: any, model?: Model<Api>) {
-  if (typeof ctx?.getActiveTools !== "function" || typeof ctx?.setActiveTools !== "function") return;
+type ActiveToolsApi = {
+  getActiveTools?: () => string[];
+  setActiveTools?: (toolNames: string[]) => void;
+};
 
-  const activeTools = Array.isArray(ctx.getActiveTools()) ? (ctx.getActiveTools() as string[]) : [];
+type ShimModelRef = {
+  id: string;
+  provider: string;
+};
+
+function resolveActiveToolsApi(primary?: ActiveToolsApi, fallback?: ActiveToolsApi): ActiveToolsApi | undefined {
+  for (const candidate of [primary, fallback]) {
+    if (typeof candidate?.getActiveTools === "function" && typeof candidate?.setActiveTools === "function") {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+/** Enable Cursor/Grok CLI shims only for Grok CLI proxy models. */
+export function syncCursorToolShimsForModel(
+  primaryApi: ActiveToolsApi,
+  model?: ShimModelRef,
+  fallbackApi?: ActiveToolsApi,
+) {
+  const api = resolveActiveToolsApi(primaryApi, fallbackApi);
+  if (!api?.getActiveTools || !api?.setActiveTools) return;
+
+  let activeTools: string[];
+  try {
+    const listed = api.getActiveTools();
+    activeTools = Array.isArray(listed) ? listed : [];
+  } catch (error) {
+    throw new Error(`Cursor shim sync: failed to read active tools: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
   const withoutCursorShims = activeTools.filter((toolName) => !XAI_CURSOR_TOOL_NAMES.includes(toolName));
   const shouldEnableCursorShims = model?.provider === XAI_PROVIDER_ID && isGrokCliProxyModel(model.id);
   const nextTools = shouldEnableCursorShims ? uniqueToolNames([...withoutCursorShims, ...XAI_CURSOR_TOOL_NAMES]) : withoutCursorShims;
 
   if (nextTools.length !== activeTools.length || nextTools.some((toolName, index) => toolName !== activeTools[index])) {
-    ctx.setActiveTools(nextTools);
+    try {
+      api.setActiveTools(nextTools);
+    } catch (error) {
+      throw new Error(`Cursor shim sync: failed to apply active tools: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
 }
 


### PR DESCRIPTION
When using models from other providers (e.g., Anthropic via Claude OAuth), the xAI extension's Cursor/Grok CLI compatibility shims were never disabled. This caused Claude requests to include xAI-specific shims such as `Shell`, `Grep`, and `WebSearch`, resulting in a 400 error from Anthropic's API because those tool names are not recognized outside the xAI provider.

The shim sync logic (`syncCursorToolShimsForModel`) read/wrote the active tool list from the event `ctx` object. In real Pi sessions that `ctx` does not expose `getActiveTools`/`setActiveTools` — those live on `pi` (ExtensionAPI). So the function silently returned without updating tools, leaving shims permanently enabled.

## Impact
| Scenario | Before | After |
|----------|--------|-------|
| Claude / Anthropic OAuth after Grok CLI model | Shims stayed on → 400 error | Shims correctly disabled |
| Grok CLI proxy models (Composer, Build) | Shims enabled | Unchanged |
| Non-CLI xAI models (e.g. `grok-4.3`) | Shims disabled | Unchanged |

## Testing
- `npm test` passes (`verify-extension.js` + `verify-setup.js`)
- `verifyCursorToolActivation` asserts shims enabled for `grok-composer-2.5-fast`, disabled for `grok-4.3`
- `tsc --noEmit` has 2 pre-existing errors in `responses.ts` (unrelated); no new errors introduced in modified files