### PR TITLE
fix: prevent Cursor shims leaking into non-Grok requests

### DIFF
--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -171,4 +171,10 @@ Update this file frequently during execution.
 - [x] Removed the duplicate local package entry from `~/.pi/agent/settings.json` to unblock this machine while preserving the npm default `grok-4.5`.
 - [ ] Re-verify on latest main: `npm test`, `npm run typecheck`, `git diff --check`, `node bin/setup.js --help`, `npm pack --dry-run`.
 
-**Current branch:** fix/dedupe-local-package-install
+## Phase 17: Issue 40 Cursor shim leakage repair
+- [x] Routed Cursor shim synchronization through the pi `ExtensionAPI` active-tool registry.
+- [x] Added regression coverage for realistic event contexts, model switching, idempotency, and transient registry failures.
+- [x] Targeted shim checks and `git diff --check` pass; committed and pushed as PR #41, with PRs #37 and #38 superseded.
+- [x] Full `npm test` / `npm run typecheck` remain blocked by the pre-existing pi 0.80.3 `streamSimpleOpenAIResponses` API mismatch in `responses.ts`.
+
+**Current branch:** codex/fix-issue-40-cursor-shims

--- a/extensions/xai-oauth.ts
+++ b/extensions/xai-oauth.ts
@@ -21,8 +21,12 @@ export default function (pi: ExtensionAPI) {
   registerXaiTools(pi);
 
   if (typeof (pi as any).on === "function") {
-    (pi as any).on("session_start", (_event: any, ctx: any) => syncCursorToolShimsForModel(ctx, ctx?.model));
-    (pi as any).on("model_select", (event: any, ctx: any) => syncCursorToolShimsForModel(ctx, event?.model));
-    (pi as any).on("before_agent_start", (_event: any, ctx: any) => syncCursorToolShimsForModel(ctx, ctx?.model));
+    // Active-tool accessors belong to the ExtensionAPI (`pi`), while models
+    // are supplied by the event/context payload.
+    (pi as any).on("session_start", (_event: any, ctx: any) => syncCursorToolShimsForModel(pi, ctx?.model));
+    (pi as any).on("model_select", (event: any, ctx: any) =>
+      syncCursorToolShimsForModel(pi, event?.model ?? ctx?.model),
+    );
+    (pi as any).on("before_agent_start", (_event: any, ctx: any) => syncCursorToolShimsForModel(pi, ctx?.model));
   }
 }

--- a/extensions/xai/tools/cursor-shims.ts
+++ b/extensions/xai/tools/cursor-shims.ts
@@ -314,16 +314,28 @@ function uniqueToolNames(toolNames: string[]): string[] {
 }
 
 /** Enable Cursor/Grok CLI shims only for Grok CLI proxy models. */
-export function syncCursorToolShimsForModel(ctx: any, model?: Model<Api>) {
-  if (typeof ctx?.getActiveTools !== "function" || typeof ctx?.setActiveTools !== "function") return;
+export function syncCursorToolShimsForModel(api: any, model?: Model<Api>) {
+  if (typeof api?.getActiveTools !== "function" || typeof api?.setActiveTools !== "function") return;
 
-  const activeTools = Array.isArray(ctx.getActiveTools()) ? (ctx.getActiveTools() as string[]) : [];
+  let activeTools: string[];
+  try {
+    const current = api.getActiveTools();
+    activeTools = Array.isArray(current) ? (current as string[]) : [];
+  } catch {
+    // The registry may not be bound during early session startup. The
+    // before_agent_start handler will retry once initialization is complete.
+    return;
+  }
   const withoutCursorShims = activeTools.filter((toolName) => !XAI_CURSOR_TOOL_NAMES.includes(toolName));
   const shouldEnableCursorShims = model?.provider === XAI_PROVIDER_ID && isGrokCliProxyModel(model.id);
   const nextTools = shouldEnableCursorShims ? uniqueToolNames([...withoutCursorShims, ...XAI_CURSOR_TOOL_NAMES]) : withoutCursorShims;
 
   if (nextTools.length !== activeTools.length || nextTools.some((toolName, index) => toolName !== activeTools[index])) {
-    ctx.setActiveTools(nextTools);
+    try {
+      api.setActiveTools(nextTools);
+    } catch {
+      // Ignore transient registry failures; a later synchronization will retry.
+    }
   }
 }
 

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -76,6 +76,8 @@ function loadExtension() {
   const tools = new Map();
   const handlers = new Map();
   let activeTools = ["read", "bash", "edit", "write"];
+  let throwOnGetActiveTools = false;
+  let throwOnSetActiveTools = false;
   extension({
     on(event, handler) {
       handlers.set(event, handler);
@@ -87,13 +89,25 @@ function loadExtension() {
       tools.set(tool.name, tool);
     },
     getActiveTools() {
+      if (throwOnGetActiveTools) throw new Error("tool registry not ready");
       return activeTools;
     },
     setActiveTools(toolNames) {
+      if (throwOnSetActiveTools) throw new Error("tool registry temporarily unavailable");
       activeTools = toolNames;
     },
   });
-  return { providers, tools, handlers, getActiveTools: () => activeTools, setActiveTools: (toolNames) => { activeTools = toolNames; } };
+  return {
+    providers,
+    tools,
+    handlers,
+    getActiveTools: () => activeTools,
+    setActiveTools: (toolNames) => { activeTools = toolNames; },
+    setToolRegistryFailures({ get = false, set = false } = {}) {
+      throwOnGetActiveTools = get;
+      throwOnSetActiveTools = set;
+    },
+  };
 }
 
 function authContext() {
@@ -219,16 +233,41 @@ async function verifyCursorToolShims(tools) {
 
 async function verifyCursorToolActivation(loadResult) {
   const { handlers, getActiveTools } = loadResult;
-  const ctx = {
-    getActiveTools,
-    setActiveTools: loadResult.setActiveTools,
-  };
+  // Real ExtensionContext objects do not expose the active-tool accessors.
+  // Keeping this context empty prevents the test from masking the regression.
+  const ctx = {};
+  const selectModel = (id, provider = "xai-auth") =>
+    handlers.get("model_select")?.({ model: { provider, id } }, ctx);
 
-  await handlers.get("model_select")?.({ model: { provider: "xai-auth", id: "grok-composer-2.5-fast" } }, ctx);
+  await selectModel("grok-composer-2.5-fast");
   assert.ok(getActiveTools().includes("Grep"), "Cursor shims should be enabled for Composer 2.5");
+  const composerTools = getActiveTools();
+  await selectModel("grok-composer-2.5-fast");
+  assert.deepStrictEqual(getActiveTools(), composerTools, "Repeated Composer sync should not duplicate shims");
 
-  await handlers.get("model_select")?.({ model: { provider: "xai-auth", id: "grok-4.3" } }, ctx);
+  await selectModel("grok-4.3");
   assert.ok(!getActiveTools().includes("Grep"), "Cursor shims should be disabled for non-Grok-CLI xAI models");
+  for (const shim of ["Read", "Write", "StrReplace", "Edit", "Delete", "LS", "Grep", "Glob", "Shell", "WebSearch"]) {
+    assert.ok(!getActiveTools().includes(shim), `${shim} shim must be removed for non-Grok models`);
+  }
+
+  await selectModel("grok-composer-2.5-fast");
+  await handlers.get("session_start")?.({}, { model: { provider: "anthropic", id: "claude-opus-4-8" } });
+  assert.ok(!getActiveTools().includes("Grep"), "session_start should prune shims for Anthropic models");
+
+  await selectModel("grok-composer-2.5-fast");
+  await handlers.get("before_agent_start")?.({}, { model: { provider: "anthropic", id: "claude-opus-4-8" } });
+  assert.ok(!getActiveTools().includes("Grep"), "before_agent_start should prune shims for Anthropic models");
+
+  loadResult.setToolRegistryFailures({ get: true });
+  await assert.doesNotReject(
+    () => handlers.get("session_start")?.({}, { model: { provider: "anthropic", id: "claude-opus-4-8" } }),
+    "session_start should tolerate an unavailable tool registry",
+  );
+  loadResult.setToolRegistryFailures({ get: false, set: true });
+  await selectModel("grok-composer-2.5-fast");
+  assert.ok(!getActiveTools().includes("Grep"), "a failed set should not partially update the tool list");
+  loadResult.setToolRegistryFailures();
 }
 
 function lastResultErrorMessage(result) {


### PR DESCRIPTION
## What changed

- Route Cursor/Grok CLI shim synchronization through pi's `ExtensionAPI` active-tool registry.
- Keep model resolution event-aware, preferring `event.model` with `ctx.model` fallback.
- Treat early or transient registry accessor failures as recoverable no-ops.
- Add regression coverage for realistic event contexts, model switching, idempotency, full shim removal, and registry failures.

## Why

The previous implementation looked for `getActiveTools` and `setActiveTools` on the event `ExtensionContext`, where they do not exist in real pi sessions. Synchronization therefore returned early, leaving xAI shims active for non-Grok providers and causing duplicate or unsupported tool-name errors.

## Validation

- Targeted runtime checks pass for Composer activation, Anthropic/non-Grok pruning, all Cursor shim names, idempotency, and transient registry failures.
- `git diff --check` passes.
- `npm test` and `npm run typecheck` are currently blocked by a pre-existing pi 0.80.3 API mismatch in `extensions/xai/responses.ts`: the installed package no longer exports `streamSimpleOpenAIResponses`. This is unrelated to the Cursor shim changes and reproduces against `main`.

Closes #40

PRs #37 and #38 contain prior reports/implementations of the same underlying bug. #39 is already closed as a duplicate of #40.
