### PR TITLE
fix: resolve OpenAI Responses stream via pi-ai/compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,18 @@ If localhost is blocked (VPN, Docker, remote SSH, WSL):
 3. **Paste it into the TUI's input field** that says "Paste redirect URL below."
 4. pi parses the authorization code from the URL and completes the login.
 
+### `Cannot find module .../pi-ai/dist/compat.js/api/openai-responses`
+
+This is a known compatibility issue on pi `0.80.x` when the extension dynamically imports `@earendil-works/pi-ai/api/openai-responses`.
+
+pi's extension loader aliases `@earendil-works/pi-ai` to `dist/compat.js`, so that subpath becomes:
+
+```text
+.../pi-ai/dist/compat.js/api/openai-responses
+```
+
+Upgrade to a package version that imports `@earendil-works/pi-ai/compat` instead, then restart pi or run `/reload`.
+
 ### "Cannot find provider xai-auth"
 
 Run `pi list` to verify the package is installed. If not:

--- a/extensions/xai/responses.ts
+++ b/extensions/xai/responses.ts
@@ -1,4 +1,5 @@
 import type { Api, Context, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
+import { streamSimple as streamOpenAIResponsesCompat } from "@earendil-works/pi-ai/compat";
 import { randomUUID } from "crypto";
 import { isGrokCliProxyModel, xaiBaseUrlForModel, xaiModelForRequest, xaiModelRequestHeaders, xaiResponsesUrlForModel } from "./models";
 import { rewriteXaiResponsesPayload } from "./payload";
@@ -134,13 +135,17 @@ export async function createXaiResponse(apiKey: string, body: Record<string, any
 /**
  * Stream pi's simple Responses flow through xAI with payload normalization.
  *
- * The transport is delegated to pi's OpenAI Responses helper with a temporary
+ * The transport is delegated through `@earendil-works/pi-ai/compat` with a temporary
  * `openai-responses` API tag expected by pi's transport, while xAI
  * routing headers, request URLs, and payload rewriting continue to use the
  * original xAI model metadata. Returned events are forwarded through an
- * assistant stream exposing async iteration and `result()`. Delegate load or
- * stream failures are converted into terminal error events with xAI provider
+ * assistant stream exposing async iteration and `result()`. Delegate stream
+ * failures are converted into terminal error events with xAI provider
  * metadata instead of escaping as unstructured promise failures.
+ *
+ * Note: do not dynamically import `@earendil-works/pi-ai/api/*` subpaths from
+ * extensions. pi's jiti loader aliases `@earendil-works/pi-ai` to
+ * `dist/compat.js`, which breaks subpath resolution at runtime.
  *
  * @param model xAI provider model selected by pi.
  * @param context Conversation messages and tool context to stream.
@@ -175,8 +180,9 @@ export function streamSimpleXaiResponses(model: Model<Api>, context: Context, op
   const stream = createForwardingAssistantStream();
   void (async () => {
     try {
-      const { streamSimple } = await import("@earendil-works/pi-ai/api/openai-responses");
-      const inner = streamSimple(openAIResponsesModel as Model<"openai-responses">, context, {
+      // Use the compat entrypoint so pi's extension loader can resolve the
+      // package (it aliases @earendil-works/pi-ai -> dist/compat.js).
+      const inner = streamOpenAIResponsesCompat(openAIResponsesModel as Model<"openai-responses">, context, {
         ...options,
         // Ensure rewriteXaiResponsesPayload can always stamp prompt_cache_key.
         sessionId: sessionId || routingSessionId,

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -284,7 +284,7 @@ async function captureStreamResultMessage(createStream) {
 }
 
 async function verifyOpenAIResponsesTransport() {
-  const { streamSimple } = await import("@earendil-works/pi-ai/api/openai-responses");
+  const { streamSimple } = await import("@earendil-works/pi-ai/compat");
   const context = { messages: [{ role: "user", content: "hello", timestamp: Date.now() }] };
   const baseModel = {
     id: "grok-4.3",


### PR DESCRIPTION
## Summary

Fixes #44.

On pi `0.80.x`, the extension loader aliases `@earendil-works/pi-ai` to `dist/compat.js`. The current dynamic import of `@earendil-works/pi-ai/api/openai-responses` therefore resolves to a non-existent `compat.js/api/...` path and breaks xAI streaming.

This PR routes the OpenAI Responses transport through the public `@earendil-works/pi-ai/compat` entrypoint while still tagging the delegate model as `api: "openai-responses"`.

## Changes

- `extensions/xai/responses.ts`: use `streamSimple` from `@earendil-works/pi-ai/compat`
- `scripts/verify-extension.js`: match the same import path
- `README.md`: document the failure mode and upgrade path

## Test plan

- [x] `npm test` (`verify-extension` + `verify-setup`)
- [x] `npm run typecheck`
- [x] Reproduced original failure with dynamic subpath import under pi 0.80.6
- [x] Confirmed patched import loads with `pi --list-models xai` and streams after `/reload`

## Notes

Related historical issue: #19 (API tag mismatch). This one is a separate module-resolution break introduced by the pi extension alias to `compat.js`.