### PR TITLE
Release 1.3.3: fix pi 0.80 xAI Responses resolution

### DIFF
--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -189,3 +189,4 @@ Update this file frequently during execution.
 - [x] Reproduced pi's root alias rewriting `@earendil-works/pi-ai/api/openai-responses` to the invalid `compat.js/api/openai-responses` path.
 - [x] Routed Responses streaming through the supported `@earendil-works/pi-ai/compat` dispatcher.
 - [x] Verified unit/setup tests, TypeScript diagnostics, and an actual pi extension-loader stream probe.
+- [x] Bumped the npm package and lockfile to 1.3.3 and updated release guidance.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -184,3 +184,8 @@ Update this file frequently during execution.
 - [x] Full `npm test` / `npm run typecheck` remain blocked by the pre-existing pi 0.80.3 `streamSimpleOpenAIResponses` API mismatch in `responses.ts`.
 
 **Current branch:** codex/fix-issue-40-cursor-shims
+
+## Phase 18: pi 0.80 extension-loader subpath repair
+- [x] Reproduced pi's root alias rewriting `@earendil-works/pi-ai/api/openai-responses` to the invalid `compat.js/api/openai-responses` path.
+- [x] Routed Responses streaming through the supported `@earendil-works/pi-ai/compat` dispatcher.
+- [x] Verified unit/setup tests, TypeScript diagnostics, and an actual pi extension-loader stream probe.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pi --model grok-4.5:low "Quick status check"   # fast mode
 
 This package adds **Grok 4.5** (default), **Grok 4.3**, **Grok Build**, and **Composer 2.5** as fully-integrated xAI OAuth models in pi, with proper OAuth login, automatic token refresh, and a suite of custom tools (`xai_generate_text`, `xai_web_search`, `xai_x_search`, etc.).
 
-> **Latest release:** `pi-xai-oauth` **1.3.0** adds **Grok 4.5** as the default model (500K context, low/medium/high reasoning; fast mode = `low`). Existing npm installs should run `pi update npm:pi-xai-oauth`; local checkout installs should keep only one copy with `pi remove npm:pi-xai-oauth && pi install .`.
+> **Latest release:** `pi-xai-oauth` **1.3.3** fixes xAI Responses streaming under pi 0.80's extension loader and includes **Grok 4.5** as the default model (500K context, low/medium/high reasoning; fast mode = `low`). Existing npm installs should run `pi update npm:pi-xai-oauth`; local checkout installs should keep only one copy with `pi remove npm:pi-xai-oauth && pi install .`.
 >
 > **Compatibility note:** 1.2.4+ supports pi 0.79.8+'s OpenAI Responses API guard for Grok/xAI streaming.
 
@@ -504,7 +504,7 @@ pi update npm:pi-xai-oauth
 
 This pulls the latest version from npm and updates your installed extension.
 
-pi 0.79.8+ enforces an OpenAI Responses API guard. `pi-xai-oauth` 1.2.4+ handles that guard for Grok/xAI streaming; **1.3.0** adds Grok 4.5 as the default model. If you installed the published npm package, update with the command above. If you are testing a local checkout instead, reinstall the checkout:
+pi 0.79.8+ enforces an OpenAI Responses API guard. `pi-xai-oauth` 1.2.4+ handles that guard for Grok/xAI streaming; **1.3.3** also fixes Responses transport resolution under pi 0.80's extension loader and includes Grok 4.5 as the default model. If you installed the published npm package, update with the command above. If you are testing a local checkout instead, reinstall the checkout:
 
 ```bash
 pi remove npm:pi-xai-oauth && pi install .

--- a/extensions/xai/responses.ts
+++ b/extensions/xai/responses.ts
@@ -1,4 +1,5 @@
 import type { Api, Context, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
+import { streamSimple as streamSimplePi } from "@earendil-works/pi-ai/compat";
 import { randomUUID } from "crypto";
 import { isGrokCliProxyModel, xaiBaseUrlForModel, xaiModelForRequest, xaiModelRequestHeaders, xaiResponsesUrlForModel } from "./models";
 import { rewriteXaiResponsesPayload } from "./payload";
@@ -134,8 +135,8 @@ export async function createXaiResponse(apiKey: string, body: Record<string, any
 /**
  * Stream pi's simple Responses flow through xAI with payload normalization.
  *
- * The transport is delegated to pi's OpenAI Responses helper with a temporary
- * `openai-responses` API tag expected by pi's transport, while xAI
+ * The transport is delegated through pi's compatibility dispatcher with a
+ * temporary `openai-responses` API tag expected by pi's transport, while xAI
  * routing headers, request URLs, and payload rewriting continue to use the
  * original xAI model metadata. Returned events are forwarded through an
  * assistant stream exposing async iteration and `result()`. Delegate load or
@@ -175,8 +176,9 @@ export function streamSimpleXaiResponses(model: Model<Api>, context: Context, op
   const stream = createForwardingAssistantStream();
   void (async () => {
     try {
-      const { streamSimple } = await import("@earendil-works/pi-ai/api/openai-responses");
-      const inner = streamSimple(openAIResponsesModel as Model<"openai-responses">, context, {
+      // Pi aliases the package root to compat when loading extensions. Importing
+      // a root subpath here is therefore rewritten as `compat.js/api/...`.
+      const inner = streamSimplePi(openAIResponsesModel as Model<"openai-responses">, context, {
         ...options,
         // Ensure rewriteXaiResponsesPayload can always stamp prompt_cache_key.
         sessionId: sessionId || routingSessionId,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-xai-oauth",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-xai-oauth",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "MIT",
       "bin": {
         "pi-xai-oauth": "bin/setup.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-xai-oauth",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "One-command installer for xAI OAuth provider + Grok 4.5, Grok Build, and Composer models in pi",
   "keywords": [
     "pi-package",

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -284,7 +284,7 @@ async function captureStreamResultMessage(createStream) {
 }
 
 async function verifyOpenAIResponsesTransport() {
-  const { streamSimple } = await import("@earendil-works/pi-ai/api/openai-responses");
+  const { streamSimple } = await import("@earendil-works/pi-ai/compat");
   const context = { messages: [{ role: "user", content: "hello", timestamp: Date.now() }] };
   const baseModel = {
     id: "grok-4.3",


### PR DESCRIPTION
## Summary
- route xAI Responses streaming through the supported `@earendil-works/pi-ai/compat` dispatcher
- avoid pi extension-loader rewriting the API subpath to invalid `compat.js/api/openai-responses`
- bump the npm package and lockfile to `1.3.3`
- update transport regression coverage and release guidance

## Verification
- `npm test`
- `npm run typecheck`
- `npm pack --dry-run`
- LSP diagnostics
- actual pi extension-loader stream probe (aborted request reached the transport without module-resolution errors)