### PR TITLE
Fix xAI response transport isolation

### DIFF
--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -168,6 +168,11 @@ Update this file frequently during execution.
 
 **Current branch:** feature/add-grok-4-5
 
+## Phase 18: Issue 47 compat dispatcher isolation
+- [x] Replaced global compat `streamSimple` dispatch with the builtin `openAIResponsesApi()` provider stream.
+- [x] Added regression coverage that registers a conflicting `openai-responses` compat provider and verifies xAI bypasses it.
+- [x] Final verification passed: `npm test`, `npm run typecheck`, and `git diff --check`.
+
 ## Phase 16: npm/local package conflict repair
 - [x] Created branch `fix/dedupe-local-package-install`.
 - [x] Fast-forwarded branch onto latest `origin/main` (`00db405`, v1.3.0).

--- a/extensions/xai/responses.ts
+++ b/extensions/xai/responses.ts
@@ -1,10 +1,12 @@
 import type { Api, Context, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
-import { streamSimple as streamSimplePi } from "@earendil-works/pi-ai/compat";
+import { openAIResponsesApi } from "@earendil-works/pi-ai/compat";
 import { randomUUID } from "crypto";
 import { isGrokCliProxyModel, xaiBaseUrlForModel, xaiModelForRequest, xaiModelRequestHeaders, xaiResponsesUrlForModel } from "./models";
 import { rewriteXaiResponsesPayload } from "./payload";
 
 type AssistantStreamEvent = Record<string, any>;
+
+const streamSimpleOpenAIResponses = openAIResponsesApi().streamSimple;
 
 function resultFromStreamEvent(event: AssistantStreamEvent): any {
   if (event.type === "done") return event.message;
@@ -135,13 +137,13 @@ export async function createXaiResponse(apiKey: string, body: Record<string, any
 /**
  * Stream pi's simple Responses flow through xAI with payload normalization.
  *
- * The transport is delegated through pi's compatibility dispatcher with a
- * temporary `openai-responses` API tag expected by pi's transport, while xAI
- * routing headers, request URLs, and payload rewriting continue to use the
- * original xAI model metadata. Returned events are forwarded through an
- * assistant stream exposing async iteration and `result()`. Delegate load or
- * stream failures are converted into terminal error events with xAI provider
- * metadata instead of escaping as unstructured promise failures.
+ * The transport is delegated to pi's builtin OpenAI Responses helper with a
+ * temporary `openai-responses` API tag, while xAI routing headers, request
+ * URLs, and payload rewriting continue to use the original xAI model metadata.
+ * Returned events are forwarded through an assistant stream exposing async
+ * iteration and `result()`. Delegate load or stream failures are converted
+ * into terminal error events with xAI provider metadata instead of escaping
+ * as unstructured promise failures.
  *
  * @param model xAI provider model selected by pi.
  * @param context Conversation messages and tool context to stream.
@@ -176,9 +178,7 @@ export function streamSimpleXaiResponses(model: Model<Api>, context: Context, op
   const stream = createForwardingAssistantStream();
   void (async () => {
     try {
-      // Pi aliases the package root to compat when loading extensions. Importing
-      // a root subpath here is therefore rewritten as `compat.js/api/...`.
-      const inner = streamSimplePi(openAIResponsesModel as Model<"openai-responses">, context, {
+      const inner = streamSimpleOpenAIResponses(openAIResponsesModel as Model<"openai-responses">, context, {
         ...options,
         // Ensure rewriteXaiResponsesPayload can always stamp prompt_cache_key.
         sessionId: sessionId || routingSessionId,

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -306,23 +306,43 @@ async function verifyOpenAIResponsesTransport() {
 }
 
 async function verifyXaiResponsesTransport(provider) {
+  const { registerApiProvider, resetApiProviders } = await import("@earendil-works/pi-ai/compat");
+  let compatDispatcherCalled = false;
+  registerApiProvider({
+    api: "openai-responses",
+    stream() {
+      compatDispatcherCalled = true;
+      throw new Error("conflicting compat stream should not be called");
+    },
+    streamSimple() {
+      compatDispatcherCalled = true;
+      throw new Error("conflicting compat streamSimple should not be called");
+    },
+  }, "verify-conflicting-extension");
+
   const before = requests.length;
-  const message = await captureStreamResultMessage(() =>
-    provider.streamSimple(
-      {
-        id: "grok-4.3",
-        provider: "xai-auth",
-        api: "xai-responses",
-        baseUrl: "https://api.x.ai/v1",
-        headers: {},
-        reasoning: true,
-        input: ["text", "image"],
-      },
-      { messages: [{ role: "user", content: "hello", timestamp: Date.now() }] },
-      { apiKey: "oauth-token", sessionId: "guard-session" },
-    ),
-  );
+  let message;
+  try {
+    message = await captureStreamResultMessage(() =>
+      provider.streamSimple(
+        {
+          id: "grok-4.3",
+          provider: "xai-auth",
+          api: "xai-responses",
+          baseUrl: "https://api.x.ai/v1",
+          headers: {},
+          reasoning: true,
+          input: ["text", "image"],
+        },
+        { messages: [{ role: "user", content: "hello", timestamp: Date.now() }] },
+        { apiKey: "oauth-token", sessionId: "guard-session" },
+      ),
+    );
+  } finally {
+    resetApiProviders();
+  }
   assert.ok(typeof message === "string", "xAI provider stream should expose a terminal result message");
+  assert.equal(compatDispatcherCalled, false, "xAI stream should bypass conflicting compat API registrations");
   assert.ok(
     requests.slice(before).some((entry) => entry.url && urlOriginIs(entry.url, "https://api.x.ai")),
     "xAI stream should reach the xAI endpoint through the OpenAI Responses transport",


### PR DESCRIPTION
## Summary

- route xAI streams through the builtin `openAIResponsesApi()` provider stream
- bypass the mutable global compat API registry
- add regression coverage with a conflicting `openai-responses` registration

## Root cause

The compat `streamSimple` dispatcher resolves transports through a global registry keyed by API name. Another extension can register `openai-responses` and replace the handler used by xAI, causing xAI requests to be routed through unrelated extension code.

Using the builtin provider stream directly preserves pi's extension-loader compatibility while isolating xAI from global registry overrides.

## Validation

- `npm test`
- `npm run typecheck`
- `git diff --check`
- pi Jiti alias extension-load simulation

Closes #47

Made with [Orca](https://github.com/stablyai/orca) 🐋
