### PR TITLE
Fix paid xAI search gating and screenshot replay

### DIFF
--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -1,15 +1,17 @@
 # Shared Agent Context
 
 **Project:** pi-xai-oauth
-**Branch:** feature/your-task
-**Date:** 2026-05-17
+**Branch:** feature/issues-49-50
+**Date:** 2026-07-15
 
 ## Key Context
-- This project provides xAI OAuth + Grok 4.3 for pi agents.
+- This project provides xAI OAuth + Grok 4.5 and related Grok models for pi agents.
 - Use subagent tool for delegation.
 - Persistent state lives in .scaffold/.
 
 ## Current Focus
-See plan.md for active phases.
+- GitHub #49: xAI paid search/research tools must be explicit opt-ins, guarded by the active `xai-auth` model, and routed through that model.
+- GitHub #50: consumed historical tool images must not be replayed; oversized current inline images need high-fidelity transport compaction and a hard aggregate budget.
+- Preserve OAuth-only behavior and never log credentials or inline image data.
 
-Update as work progresses.
+See plan.md for active phases and progress.md for completed verification.

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,56 +1,38 @@
-# Implementation Plan: Enhanced Agent Scaffolding for pi Projects
+# Implementation Plan: GitHub Issues #49 and #50
 
-**Branch:** feature/improved-agent-scaffolding  
-**Date:** 2026-05-17  
-**Goal:** Upgrade pi/agent and pi-package scaffolding with 2026 best practices (AGENTS.md, vertical slices, persistent external state, multi-agent orchestration, planning-first init).
+**Branch:** feature/issues-49-50
 
-## Phase 1: Foundation (Current)
-- [x] Create new branch `feature/improved-agent-scaffolding`
-- [x] Run parallel agents (scout + researcher) for context and best practices
-- [x] Generate AGENTS.md in project root
-- [x] Create `.scaffold/` directory with persistent state files
+**Date:** 2026-07-15
 
-## Phase 2: Persistent State Harness
-- [ ] Create `.scaffold/constraints.md` — Hard MUST/MUST NOT rules
-- [ ] Create `.scaffold/progress.md` — Execution tracking
-- [ ] Create `.scaffold/context.md` — Shared agent context
-- [ ] Update AGENTS.md to reference these files
+**Goal:** Prevent unintended xAI paid-search calls and keep stateless Responses requests below the xAI OAuth gateway's unreliable inline-image payload range.
 
-## Phase 3: Improved Setup / Init Script
-- [x] Enhance `bin/setup.js` to:
-  - Auto-generate full `.scaffold/` structure on first run
-  - Seed AGENTS.md if missing
-  - Set sensible pi defaults + agentic settings
-  - Add support for `--scaffold` flag for new projects
-- [x] Add npm script: `"scaffold": "node bin/setup.js --scaffold"`
+## Phase 1: Issue review and baseline
+- [x] Read issues #49 and #50 and their comments through GitHub.
+- [x] Inspect the provider entrypoint, custom tool registration, payload normalization, Responses transport, setup script, tests, README, and pi extension contracts.
+- [x] Move the existing worktree from the obsolete merged branch to `feature/issues-49-50` at current `origin/main`.
+- [x] Run baseline `npm test` and `npm run typecheck`.
 
-## Phase 4: Structure & Organization
-- [ ] Recommend (and optionally enforce) vertical feature slices in future packages
-- [ ] Add example `src/features/` structure to documentation
-- [ ] Update tsconfig / package.json if needed for better agent context
+## Phase 2: Issue #49 paid-search guard
+- [x] Keep xAI search/research tools registered but inactive by default.
+- [x] Remove those tools immediately when the active model is not from `xai-auth`.
+- [x] Fail tool execution locally before auth/network resolution unless an active xAI model is present.
+- [x] Route web/X/deep-research requests through the active xAI model instead of `DEFAULT_XAI_MODEL`.
+- [x] Add regression coverage for default inactivity, model switching, local no-request rejection, active-model routing, and zero requests from lifecycle events.
 
-## Phase 5: Multi-Agent Integration
-- [ ] Document preferred subagent usage patterns in AGENTS.md
-- [ ] Create a lightweight `scaffold-starter` template that includes:
-  - AGENTS.md
-  - .scaffold/ files
-  - Example parallel/chain subagent config
-- [ ] Add reviewer step in the workflow
+## Phase 3: Issue #50 image lifecycle and transport mitigation
+- [x] Omit consumed historical tool-result image binaries after a later assistant response while retaining explicit text markers.
+- [x] Preserve unconsumed tool-result images until the first assistant response.
+- [x] Compact oversized inline PNG/JPEG images with high-fidelity JPEG encoding before transport and enforce an aggregate inline-image budget.
+- [x] Normalize delegated transport error prefixes from OpenAI to xAI.
+- [x] Add regression coverage for image lifecycle, compaction, dimensions, payload budget, and clear no-network overflow failure.
 
-## Phase 6: Validation & Polish
-- [x] Run `reviewer` agent on all changes
-- [x] Test full setup flow on clean machine
-- [x] Update README.md with new scaffolding features
-- [x] Commit with clear message referencing this plan
+## Phase 4: Verification and review
+- [x] Run focused tests, `npm test`, `npm run typecheck`, `git diff --check`, and `npm pack --dry-run`.
+- [x] Run an independent reviewer agent against the final diff.
+- [x] Address all valid findings and re-run validation.
 
-## Success Metrics
-- New projects initialize with AGENTS.md + .scaffold/ in < 30 seconds
-- Agents using the scaffold show 40%+ reduction in exploratory turns
-- Clear separation between human docs (README) and agent docs (AGENTS.md)
+**Owner:** Main agent
 
-## Open Questions
-- Should we publish a reusable `pi-scaffold` npm package?
-- Add support for Tailwind / HyperFrames specific scaffolds?
+**Research:** Parallel issue #49 and issue #50 subagents
 
-**Owner:** Main agent (with parallel subagent support)  
-**Next Action:** Create remaining .scaffold/ files and enhance setup.js
+**Next action:** Hand off the completed worktree for commit or PR publication.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -195,3 +195,17 @@ Update this file frequently during execution.
 - [x] Routed Responses streaming through the supported `@earendil-works/pi-ai/compat` dispatcher.
 - [x] Verified unit/setup tests, TypeScript diagnostics, and an actual pi extension-loader stream probe.
 - [x] Bumped the npm package and lockfile to 1.3.3 and updated release guidance.
+
+## Phase 19: GitHub issues #49 and #50
+- [x] Read both issue reports and confirmed neither has follow-up comments or an existing fix PR.
+- [x] Replaced the stale merged worktree branch with `feature/issues-49-50` at current `origin/main` (`0f1ad5a`).
+- [x] Ran parallel read-only investigations for paid-search guarding and image replay/transport mitigation.
+- [x] Confirmed baseline `npm test` and `npm run typecheck` pass before source edits.
+- [x] Implemented issue #49 search/research tool opt-in, active-model execution guards, model-switch cleanup, and active-model routing.
+- [x] Implemented issue #50 consumed-image lifecycle, 3 MiB aggregate inline-image compaction, local overflow failure, and xAI error naming.
+- [x] Added regression coverage for lifecycle registry retries, zero-network guard failures, active routing, image replay boundaries, compaction, and direct/stream transport.
+- [x] Addressed reviewer findings covering the capital `WebSearch` bypass, fail-open registry errors, post-compaction payload-hook mutation, and MIME documentation.
+- [x] Independent closure review reported no remaining findings.
+- [x] Final validation passed: `npm test`, `npm run typecheck`, `git diff --check`, `npm pack --dry-run`, real pi extension loading, and real pi session/model lifecycle probes.
+
+**Current branch:** feature/issues-49-50

--- a/README.md
+++ b/README.md
@@ -286,9 +286,11 @@ The shims also normalize common Cursor argument names, such as `file_path`, `con
 
 ## Custom Tools
 
-This package registers OAuth-backed custom tools that use the xAI API directly. They appear alongside your other agent tools in the pi TUI and are available to any agent running with the `xai-auth` provider.
+This package registers OAuth-backed custom tools that use the xAI API directly. They appear alongside your other agent tools in the pi TUI.
 
-**How to use them:** Simply call the tool by name in your prompts or agent workflows (e.g. "use xai_web_search to find the latest Rust news"). The tools automatically use your authenticated xAI session.
+**How to use them:** Select an `xai-auth` model, then call the tool by name in your prompt or agent workflow. The tools use your authenticated xAI session.
+
+The paid server-side search tools — `xai_web_search`, `xai_x_search`, `xai_multi_agent`, `xai_deep_research`, and the Grok Build/Composer-compatible `WebSearch` shim — are deliberately **inactive by default**. Enable only the tool you want through pi's `/tools` picker, then request it explicitly in your prompt. Switching to a non-xAI model disables all five immediately; switching back does not silently re-enable them.
 
 > **Tip:** See the ⚠️ warning above about local vs published package conflicts.
 
@@ -304,7 +306,7 @@ Generate text with full reasoning and stateful conversations.
 ```
 
 ### `xai_multi_agent`
-Deep multi-agent research using Grok's multi-agent model plus native web and X search tools.
+Opt-in deep multi-agent research using Grok's multi-agent model plus native web and X search tools. Enable it through `/tools` first.
 
 ```json
 {
@@ -315,7 +317,7 @@ Deep multi-agent research using Grok's multi-agent model plus native web and X s
 ```
 
 ### `xai_web_search`
-Search the web using xAI's native `web_search` tool.
+Opt-in search using xAI's native `web_search` tool and the active xAI model. Enable it through `/tools` first.
 
 ```json
 {
@@ -324,7 +326,7 @@ Search the web using xAI's native `web_search` tool.
 ```
 
 ### `xai_x_search`
-Search X (Twitter) using xAI's native `x_search` tool.
+Opt-in X (Twitter) search using xAI's native `x_search` tool and the active xAI model. Enable it through `/tools` first.
 
 ```json
 {
@@ -372,7 +374,7 @@ Get structured critique for code, designs, writing, or ideas.
 ```
 
 ### `xai_deep_research`
-Research a topic with Grok reasoning plus native web and X search tools.
+Opt-in research using the active xAI model plus native web and X search tools. Enable it through `/tools` first.
 
 ```json
 {
@@ -381,7 +383,7 @@ Research a topic with Grok reasoning plus native web and X search tools.
 }
 ```
 
-> **Note:** These tools use the xAI API under the hood — they count toward your SuperGrok rate limits.
+> **Note:** These tools use the xAI API under the hood. Search and research calls can consume paid credits or SuperGrok rate limits, which is why they require manual activation.
 
 ---
 
@@ -438,8 +440,14 @@ This means xAI rejected a multimodal Responses `input` shape. Use the latest pac
 If you call `xai_generate_text` directly, `image_url` may be either:
 
 - an `http(s)://...` URL
-- a `data:image/...;base64,...` URL
+- a `data:image/png;base64,...` or `data:image/jpeg;base64,...` URL
 - a local `.png`, `.jpg`, or `.jpeg` path, including shell-escaped paths like `/Users/me/My\\ Image.png`
+
+### `500 "Auth context expired"` after screenshots
+
+This xAI OAuth gateway error can be a misleading response to an oversized stateless Responses request, not an expired local token. The provider now omits consumed historical tool-result image binaries after a later assistant response and retains a text marker in their place. Current PNG/JPEG inputs are resized with high-fidelity encoding when necessary and kept within a 3 MiB aggregate base64 transport budget before any xAI request is sent.
+
+If an image cannot be decoded or compacted safely, the request fails locally with a clear image-budget error. Crop the screenshot or attach fewer current images; logging in again will not fix a payload-size failure.
 
 ### "Token expired / auth failed"
 

--- a/extensions/xai-oauth.ts
+++ b/extensions/xai-oauth.ts
@@ -4,8 +4,7 @@ import { XAI_API_BASE_URL, XAI_PROVIDER_ID } from "./xai/constants";
 import { MODELS } from "./xai/models";
 import { createXaiOAuth } from "./xai/oauth";
 import { streamSimpleXaiResponses } from "./xai/responses";
-import { registerXaiTools } from "./xai/tools";
-import { syncCursorToolShimsForModel } from "./xai/tools/cursor-shims";
+import { registerXaiTools, syncXaiToolsForModel } from "./xai/tools";
 
 export default function (pi: ExtensionAPI) {
   pi.registerProvider(XAI_PROVIDER_ID, {
@@ -23,10 +22,12 @@ export default function (pi: ExtensionAPI) {
   if (typeof (pi as any).on === "function") {
     // Active-tool accessors belong to the ExtensionAPI (`pi`), while models
     // are supplied by the event/context payload.
-    (pi as any).on("session_start", (_event: any, ctx: any) => syncCursorToolShimsForModel(pi, ctx?.model));
-    (pi as any).on("model_select", (event: any, ctx: any) =>
-      syncCursorToolShimsForModel(pi, event?.model ?? ctx?.model),
+    (pi as any).on("session_start", (_event: any, ctx: any) =>
+      syncXaiToolsForModel(pi, ctx?.model, { resetSearchTools: true }),
     );
-    (pi as any).on("before_agent_start", (_event: any, ctx: any) => syncCursorToolShimsForModel(pi, ctx?.model));
+    (pi as any).on("model_select", (event: any, ctx: any) =>
+      syncXaiToolsForModel(pi, event?.model ?? ctx?.model),
+    );
+    (pi as any).on("before_agent_start", (_event: any, ctx: any) => syncXaiToolsForModel(pi, ctx?.model));
   }
 }

--- a/extensions/xai/constants.ts
+++ b/extensions/xai/constants.ts
@@ -19,6 +19,7 @@ export const DEFAULT_XAI_MODEL = "grok-4.5";
 export const DEFAULT_XAI_IMAGE_MODEL = "grok-imagine-image-quality";
 
 export const XAI_CURSOR_TOOL_NAMES = ["Read", "Write", "StrReplace", "Edit", "Delete", "LS", "Grep", "Glob", "Shell", "WebSearch"];
+export const XAI_CURSOR_AUTO_TOOL_NAMES = ["Read", "Write", "StrReplace", "Edit", "Delete", "LS", "Grep", "Glob", "Shell"];
 
 export const XAI_GROK_CLI_AUTH_SCOPE_KEY = `${XAI_OAUTH_ISSUER}::${XAI_OAUTH_CLIENT_ID}`;
 export const XAI_GROK_CLI_LEGACY_AUTH_SCOPE_KEY = "https://accounts.x.ai/sign-in";

--- a/extensions/xai/images.ts
+++ b/extensions/xai/images.ts
@@ -1,6 +1,20 @@
 import { existsSync, readFileSync } from "fs";
 import { extname, isAbsolute, resolve } from "path";
 import { fileURLToPath } from "url";
+import { resizeImage } from "@earendil-works/pi-coding-agent";
+
+/** Aggregate base64 budget kept below the xAI OAuth gateway's observed failure range. */
+export const MAX_XAI_INLINE_IMAGE_BASE64_BYTES = 3 * 1024 * 1024;
+export const MAX_XAI_IMAGE_DIMENSION = 2000;
+export const XAI_JPEG_QUALITY = 95;
+
+interface InlineImageReference {
+  imagePart: Record<string, any>;
+  mimeType: string;
+  base64: string;
+  encodedSize: number;
+  targetSize: number;
+}
 
 function stripShellQuotes(value: string): string {
   const trimmed = value.trim();
@@ -65,4 +79,109 @@ export function normalizeXaiImageInput(value: unknown): string | undefined {
   const mimeType = imageMimeTypeForPath(localPath);
   const data = readFileSync(localPath).toString("base64");
   return `data:${mimeType};base64,${data}`;
+}
+
+function parseInlineImageDataUrl(value: string): { mimeType: string; base64: string } | undefined {
+  if (!/^data:image\//i.test(value)) return undefined;
+  const match = /^data:(image\/(?:png|jpe?g));base64,([A-Za-z0-9+/=\r\n]+)$/i.exec(value);
+  if (!match) {
+    throw new Error("xAI inline image payload contains an invalid or unsupported image data URL");
+  }
+  return {
+    mimeType: match[1].toLowerCase() === "image/jpg" ? "image/jpeg" : match[1].toLowerCase(),
+    base64: match[2].replace(/\s+/g, ""),
+  };
+}
+
+function clonePayloadAndCollectInlineImages(value: unknown, references: InlineImageReference[]): unknown {
+  if (Array.isArray(value)) return value.map((item) => clonePayloadAndCollectInlineImages(item, references));
+  if (!value || typeof value !== "object") return value;
+
+  const cloned: Record<string, any> = {};
+  for (const [key, child] of Object.entries(value as Record<string, any>)) {
+    cloned[key] = clonePayloadAndCollectInlineImages(child, references);
+  }
+
+  if (cloned.type === "input_image" && typeof cloned.image_url === "string") {
+    const parsed = parseInlineImageDataUrl(cloned.image_url);
+    if (parsed) {
+      references.push({
+        imagePart: cloned,
+        mimeType: parsed.mimeType,
+        base64: parsed.base64,
+        encodedSize: Buffer.byteLength(parsed.base64, "utf8"),
+        targetSize: 0,
+      });
+    }
+  }
+
+  return cloned;
+}
+
+function allocateInlineImageBudgets(references: InlineImageReference[], maxBase64Bytes: number) {
+  const sorted = [...references].sort((left, right) => left.encodedSize - right.encodedSize);
+  let remainingBytes = maxBase64Bytes;
+  let remainingImages = sorted.length;
+
+  for (let index = 0; index < sorted.length; index++) {
+    const reference = sorted[index];
+    const fairShare = Math.floor(remainingBytes / remainingImages);
+    if (reference.encodedSize <= fairShare) {
+      reference.targetSize = reference.encodedSize;
+      remainingBytes -= reference.encodedSize;
+      remainingImages--;
+      continue;
+    }
+
+    for (let remainingIndex = index; remainingIndex < sorted.length; remainingIndex++) {
+      sorted[remainingIndex].targetSize = Math.floor(remainingBytes / remainingImages);
+    }
+    return;
+  }
+}
+
+/**
+ * Compact inline PNG/JPEG inputs to a safe aggregate xAI transport budget.
+ *
+ * Small images keep their original allocation while oversized images share the
+ * remaining budget. Processing is sequential to cap peak decoded-image memory.
+ * A codec failure is surfaced locally so a known-risk oversized request is not sent.
+ */
+export async function compactXaiInlineImages(
+  payload: unknown,
+  maxBase64Bytes = MAX_XAI_INLINE_IMAGE_BASE64_BYTES,
+): Promise<unknown> {
+  if (!Number.isFinite(maxBase64Bytes) || maxBase64Bytes <= 0) {
+    throw new Error("xAI inline image transport budget must be a positive number");
+  }
+
+  const references: InlineImageReference[] = [];
+  const clonedPayload = clonePayloadAndCollectInlineImages(payload, references);
+  if (references.length === 0) return clonedPayload;
+
+  allocateInlineImageBudgets(references, Math.floor(maxBase64Bytes));
+  for (const reference of references) {
+    const bytes = Buffer.from(reference.base64, "base64");
+    if (bytes.length === 0 || reference.targetSize < 1) {
+      throw new Error("xAI inline image payload exceeds the safe transport budget and could not be compacted");
+    }
+
+    let resized;
+    try {
+      resized = await resizeImage(bytes, reference.mimeType, {
+        maxWidth: MAX_XAI_IMAGE_DIMENSION,
+        maxHeight: MAX_XAI_IMAGE_DIMENSION,
+        maxBytes: reference.targetSize + 1,
+        jpegQuality: XAI_JPEG_QUALITY,
+      });
+    } catch {
+      resized = null;
+    }
+    if (!resized || Buffer.byteLength(resized.data, "utf8") > reference.targetSize) {
+      throw new Error("xAI inline image payload exceeds the safe transport budget and could not be compacted");
+    }
+    reference.imagePart.image_url = `data:${resized.mimeType};base64,${resized.data}`;
+  }
+
+  return clonedPayload;
 }

--- a/extensions/xai/payload.ts
+++ b/extensions/xai/payload.ts
@@ -39,7 +39,9 @@ function isResponsesInputImagePart(value: unknown): value is Record<string, any>
   return !!value && typeof value === "object" && (value as Record<string, any>).type === "input_image";
 }
 
-function textForFunctionCallOutput(output: unknown): string {
+type ToolImageDisposition = "attached" | "omitted";
+
+function textForFunctionCallOutput(output: unknown, imageDisposition: ToolImageDisposition): string {
   if (typeof output === "string") return output;
   if (!Array.isArray(output)) return output === undefined || output === null ? "" : JSON.stringify(output);
 
@@ -53,8 +55,21 @@ function textForFunctionCallOutput(output: unknown): string {
     const text = textFromResponsesContent([part]).trim();
     if (text) chunks.push(text);
   }
-  if (imageCount > 0) chunks.push(`[${imageCount} image${imageCount === 1 ? "" : "s"} attached in the following user message]`);
-  return chunks.join("\n") || (imageCount > 0 ? `[${imageCount} image${imageCount === 1 ? "" : "s"} attached]` : "");
+  if (imageCount > 0) {
+    chunks.push(
+      imageDisposition === "attached"
+        ? `[${imageCount} image${imageCount === 1 ? "" : "s"} attached in the following user message]`
+        : `[${imageCount} historical tool image${imageCount === 1 ? "" : "s"} omitted after a later assistant response]`,
+    );
+  }
+  return chunks.join("\n");
+}
+
+function isAssistantResponseItem(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  const item = value as Record<string, any>;
+  if (item.role === "assistant") return true;
+  return item.type === "reasoning" || item.type === "function_call";
 }
 
 function normalizeXaiResponsesInput(input: unknown[], model: Model<Api>): unknown[] {
@@ -62,8 +77,16 @@ function normalizeXaiResponsesInput(input: unknown[], model: Model<Api>): unknow
   const rewritten: unknown[] = [];
   const modelInputs = Array.isArray((model as any).input) ? ((model as any).input as unknown[]) : [];
   const supportsImages = modelInputs.includes("image");
+  const hasLaterAssistantOutput = new Array<boolean>(normalizedInput.length).fill(false);
+  let assistantOutputSeen = false;
 
-  for (const item of normalizedInput) {
+  for (let index = normalizedInput.length - 1; index >= 0; index--) {
+    hasLaterAssistantOutput[index] = assistantOutputSeen;
+    if (isAssistantResponseItem(normalizedInput[index])) assistantOutputSeen = true;
+  }
+
+  for (let index = 0; index < normalizedInput.length; index++) {
+    const item = normalizedInput[index];
     if (!item || typeof item !== "object" || item.type !== "function_call_output" || !Array.isArray(item.output)) {
       rewritten.push(item);
       continue;
@@ -75,10 +98,11 @@ function normalizeXaiResponsesInput(input: unknown[], model: Model<Api>): unknow
     // output as text and replay images as a normal following user message.
     const outputParts = item.output;
     const imageParts = outputParts.filter(isResponsesInputImagePart);
-    const outputText = textForFunctionCallOutput(outputParts);
+    const imagesWereConsumed = imageParts.length > 0 && hasLaterAssistantOutput[index];
+    const outputText = textForFunctionCallOutput(outputParts, imagesWereConsumed ? "omitted" : "attached");
     rewritten.push({ ...item, output: outputText || "(tool returned no text output)" });
 
-    if (supportsImages && imageParts.length > 0) {
+    if (supportsImages && imageParts.length > 0 && !imagesWereConsumed) {
       const label = `The previous tool result${item.call_id ? ` (${item.call_id})` : ""} included ${imageParts.length} image${imageParts.length === 1 ? "" : "s"}. Use the attached image${imageParts.length === 1 ? "" : "s"} as the visual output from that tool.`;
       rewritten.push({
         role: "user",

--- a/extensions/xai/responses.ts
+++ b/extensions/xai/responses.ts
@@ -1,6 +1,7 @@
 import type { Api, Context, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
 import { openAIResponsesApi } from "@earendil-works/pi-ai/compat";
 import { randomUUID } from "crypto";
+import { compactXaiInlineImages } from "./images";
 import { isGrokCliProxyModel, xaiBaseUrlForModel, xaiModelForRequest, xaiModelRequestHeaders, xaiResponsesUrlForModel } from "./models";
 import { rewriteXaiResponsesPayload } from "./payload";
 
@@ -12,6 +13,20 @@ function resultFromStreamEvent(event: AssistantStreamEvent): any {
   if (event.type === "done") return event.message;
   if (event.type === "error") return event.error;
   return undefined;
+}
+
+function normalizeXaiErrorText(value: string): string {
+  return value.replace(/^OpenAI API error\b/i, "xAI API error");
+}
+
+function normalizeXaiStreamEvent(event: AssistantStreamEvent): AssistantStreamEvent {
+  if (event.type !== "error" || !event.error || typeof event.error !== "object") return event;
+  const error = event.error as Record<string, any>;
+  if (typeof error.errorMessage !== "string") return event;
+  return {
+    ...event,
+    error: { ...error, errorMessage: normalizeXaiErrorText(error.errorMessage) },
+  };
 }
 
 function createForwardingAssistantStream() {
@@ -83,7 +98,7 @@ function streamErrorMessage(model: Model<Api>, error: unknown) {
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
     },
     stopReason: "error",
-    errorMessage: error instanceof Error ? error.message : String(error),
+    errorMessage: normalizeXaiErrorText(error instanceof Error ? error.message : String(error)),
     timestamp: Date.now(),
   };
 }
@@ -120,7 +135,8 @@ export async function postXaiJson(
 /** Create a single xAI Responses API response with model-aware routing. */
 export async function createXaiResponse(apiKey: string, body: Record<string, any>, signal?: AbortSignal): Promise<any> {
   const model = xaiModelForRequest(typeof body.model === "string" ? body.model : undefined);
-  const payload = rewriteXaiResponsesPayload(body, model) as Record<string, any>;
+  const rewritten = rewriteXaiResponsesPayload(body, model);
+  const payload = (await compactXaiInlineImages(rewritten)) as Record<string, any>;
   const usesGrokCliProxy = isGrokCliProxyModel(model.id);
   const grokCliSessionId = usesGrokCliProxy
     ? (typeof body.previous_response_id === "string" && body.previous_response_id) || randomUUID()
@@ -189,11 +205,11 @@ export function streamSimpleXaiResponses(model: Model<Api>, context: Context, op
             sessionId: sessionId || routingSessionId,
           });
           const userRewritten = await options?.onPayload?.(rewritten, streamModel);
-          return userRewritten === undefined ? rewritten : userRewritten;
+          return compactXaiInlineImages(userRewritten === undefined ? rewritten : userRewritten);
         },
       });
       for await (const event of inner as AsyncIterable<AssistantStreamEvent>) {
-        stream.push(event);
+        stream.push(normalizeXaiStreamEvent(event));
       }
       stream.end();
     } catch (error) {

--- a/extensions/xai/tools/cursor-shims.ts
+++ b/extensions/xai/tools/cursor-shims.ts
@@ -12,11 +12,12 @@ import { readdir, readFile, rm, stat } from "fs/promises";
 import { join, relative, sep } from "path";
 import { Type } from "typebox";
 import { resolveXaiAuthToken } from "../auth";
-import { DEFAULT_XAI_MODEL, XAI_CURSOR_TOOL_NAMES, XAI_PROVIDER_ID } from "../constants";
+import { XAI_CURSOR_AUTO_TOOL_NAMES, XAI_PROVIDER_ID } from "../constants";
 import { isGrokCliProxyModel } from "../models";
 import { createXaiResponse } from "../responses";
 import { extractResponsesText, messageFromError, statusFromError } from "../text";
 import { xaiToolError } from "./common";
+import { isXaiSearchToolActive } from "./model-scope";
 import {
   firstString,
   normalizeDeleteArgs,
@@ -313,7 +314,7 @@ function uniqueToolNames(toolNames: string[]): string[] {
   return [...new Set(toolNames)];
 }
 
-/** Enable Cursor/Grok CLI shims only for Grok CLI proxy models. */
+/** Enable non-search Cursor/Grok CLI shims only for Grok CLI proxy models. */
 export function syncCursorToolShimsForModel(api: any, model?: Model<Api>) {
   if (typeof api?.getActiveTools !== "function" || typeof api?.setActiveTools !== "function") return;
 
@@ -326,9 +327,11 @@ export function syncCursorToolShimsForModel(api: any, model?: Model<Api>) {
     // before_agent_start handler will retry once initialization is complete.
     return;
   }
-  const withoutCursorShims = activeTools.filter((toolName) => !XAI_CURSOR_TOOL_NAMES.includes(toolName));
+  const withoutCursorShims = activeTools.filter((toolName) => !XAI_CURSOR_AUTO_TOOL_NAMES.includes(toolName));
   const shouldEnableCursorShims = model?.provider === XAI_PROVIDER_ID && isGrokCliProxyModel(model.id);
-  const nextTools = shouldEnableCursorShims ? uniqueToolNames([...withoutCursorShims, ...XAI_CURSOR_TOOL_NAMES]) : withoutCursorShims;
+  const nextTools = shouldEnableCursorShims
+    ? uniqueToolNames([...withoutCursorShims, ...XAI_CURSOR_AUTO_TOOL_NAMES])
+    : withoutCursorShims;
 
   if (nextTools.length !== activeTools.length || nextTools.some((toolName, index) => toolName !== activeTools[index])) {
     try {
@@ -522,8 +525,9 @@ export function registerCursorToolShims(pi: ExtensionAPI) {
     pi.registerTool({
       name: "WebSearch",
       label: "WebSearch",
-      description: "Cursor/Grok CLI compatibility shim for xAI web search. Searches the web with xAI's native web_search tool.",
+      description: "Opt-in paid Cursor/Grok CLI web search. Enable via /tools and call only when the user explicitly requests xAI web search.",
       promptSnippet: "Cursor-style web search backed by xAI native web_search",
+      promptGuidelines: ["Call WebSearch only when the user explicitly requests xAI web search."],
       parameters: {
         type: "object",
         properties: {
@@ -538,6 +542,12 @@ export function registerCursorToolShims(pi: ExtensionAPI) {
       execute: async (_toolCallId: string, params: any, _signal: any, _onUpdate: any, ctx: any) => {
         const query = firstString(params?.query, params?.search_term, params?.value);
         if (!query) return xaiToolError("Error: WebSearch requires a query.");
+        if (ctx?.model?.provider !== XAI_PROVIDER_ID || !isGrokCliProxyModel(ctx.model.id)) {
+          return xaiToolError("Error: WebSearch requires an active xAI Grok Build or Composer model. No xAI request was sent.");
+        }
+        if (!isXaiSearchToolActive(pi, "WebSearch")) {
+          return xaiToolError("Error: WebSearch is disabled. Enable it in pi's /tools picker and request it explicitly. No xAI request was sent.");
+        }
         const apiKey = await resolveXaiAuthToken(ctx);
         if (!apiKey) return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.");
 
@@ -545,7 +555,7 @@ export function registerCursorToolShims(pi: ExtensionAPI) {
           const data = await createXaiResponse(
             apiKey,
             {
-              model: DEFAULT_XAI_MODEL,
+              model: ctx.model.id,
               input: `Search the web for: ${query}\n\nSummarize the key results with sources where available.`,
               tools: [{ type: "web_search", enable_image_understanding: true }],
             },

--- a/extensions/xai/tools/custom-tools.ts
+++ b/extensions/xai/tools/custom-tools.ts
@@ -6,6 +6,22 @@ import { grokSupportsReasoningEffort, normalizedXaiModelId } from "../models";
 import { createXaiResponse, postXaiJson } from "../responses";
 import { extractResponsesText, messageFromError, statusFromError } from "../text";
 import { xaiTextInput, xaiToolError } from "./common";
+import { activeXaiModel, isXaiSearchToolActive, XAI_SEARCH_TOOL_NAMES } from "./model-scope";
+
+type XaiSearchToolName = (typeof XAI_SEARCH_TOOL_NAMES)[number];
+
+function activeModelForSearchTool(pi: ExtensionAPI, ctx: any, toolName: XaiSearchToolName) {
+  const model = activeXaiModel(ctx);
+  if (!model || !isXaiSearchToolActive(pi, toolName)) return undefined;
+  return model;
+}
+
+function searchToolDisabledError(toolName: XaiSearchToolName, details: Record<string, unknown> = {}) {
+  return xaiToolError(
+    `Error: ${toolName} is disabled. Select an xAI/Grok model, enable ${toolName} in pi's /tools picker, and request it explicitly. No xAI request was sent.`,
+    { error: true, ...details },
+  );
+}
 
 /** Register OAuth-backed custom xAI tools. */
 export function registerCustomXaiTools(pi: ExtensionAPI) {
@@ -94,7 +110,8 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
     pi.registerTool({
       name: "xai_multi_agent",
       label: "xAI Multi-Agent Research",
-      description: "Run deep multi-agent research using Grok.",
+      description: "Opt-in paid multi-agent web/X research using Grok. Enable via /tools and call only when the user explicitly requests xAI research.",
+      promptGuidelines: ["Call xai_multi_agent only when the user explicitly requests xAI multi-agent research."],
       parameters: {
         type: "object",
         properties: {
@@ -105,6 +122,9 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
         required: ["query"],
       },
       execute: async (_toolCallId: string, params: any, _signal: any, _onUpdate: any, ctx: any) => {
+        if (!activeModelForSearchTool(pi, ctx, "xai_multi_agent")) {
+          return searchToolDisabledError("xai_multi_agent", { query: params?.query });
+        }
         const apiKey = await resolveXaiAuthToken(ctx);
         if (!apiKey) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { agents_used: 0, response_id: "" });
@@ -147,13 +167,16 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
     pi.registerTool({
       name: "xai_web_search",
       label: "xAI Web Search",
-      description: "Search the web using Grok's native web knowledge and search capabilities.",
+      description: "Opt-in paid search using Grok's native web search. Enable via /tools and call only when the user explicitly requests xAI web search.",
+      promptGuidelines: ["Call xai_web_search only when the user explicitly requests xAI web search."],
       parameters: {
         type: "object",
         properties: { query: { type: "string", description: "Search query" } },
         required: ["query"],
       },
       execute: async (_toolCallId: string, params: { query?: string }, _signal: any, _onUpdate: any, ctx: any) => {
+        const activeModel = activeModelForSearchTool(pi, ctx, "xai_web_search");
+        if (!activeModel) return searchToolDisabledError("xai_web_search", { query: params?.query });
         const apiKey = await resolveXaiAuthToken(ctx);
         if (!apiKey) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { query: params?.query });
@@ -162,7 +185,7 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
         let data: any;
         try {
           data = await createXaiResponse(apiKey, {
-            model: DEFAULT_XAI_MODEL,
+            model: activeModel.id,
             input: xaiTextInput(prompt),
             reasoning: { effort: "medium" },
             tools: [{ type: "web_search", enable_image_understanding: true }],
@@ -179,7 +202,8 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
     pi.registerTool({
       name: "xai_x_search",
       label: "xAI X Search",
-      description: "Search X (Twitter) using Grok's native real-time X search and knowledge. Supports advanced filters like count, since, until.",
+      description: "Opt-in paid X search using Grok's native real-time search. Enable via /tools and call only when the user explicitly requests xAI X search.",
+      promptGuidelines: ["Call xai_x_search only when the user explicitly requests xAI X search."],
       parameters: {
         type: "object",
         properties: {
@@ -191,6 +215,8 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
         required: ["query"],
       },
       execute: async (_toolCallId: string, params: { query?: string; count?: number; since?: string; until?: string }, _signal: any, _onUpdate: any, ctx: any) => {
+        const activeModel = activeModelForSearchTool(pi, ctx, "xai_x_search");
+        if (!activeModel) return searchToolDisabledError("xai_x_search", { query: params?.query });
         const apiKey = await resolveXaiAuthToken(ctx);
         if (!apiKey) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { query: params?.query });
@@ -216,7 +242,7 @@ Be specific and cite examples where helpful.`;
         let data: any;
         try {
           data = await createXaiResponse(apiKey, {
-            model: DEFAULT_XAI_MODEL,
+            model: activeModel.id,
             input: xaiTextInput(prompt),
             reasoning: { effort: "medium" },
             tools: [xSearchTool],
@@ -387,7 +413,8 @@ Be specific and cite examples where helpful.`;
     pi.registerTool({
       name: "xai_deep_research",
       label: "xAI Deep Research",
-      description: "Conduct thorough multi-step research on a topic, synthesize information, cite sources, and provide comprehensive analysis with high reasoning effort.",
+      description: "Opt-in paid multi-step web/X research with Grok. Enable via /tools and call only when the user explicitly requests xAI research.",
+      promptGuidelines: ["Call xai_deep_research only when the user explicitly requests xAI deep research."],
       parameters: {
         type: "object",
         properties: {
@@ -397,6 +424,8 @@ Be specific and cite examples where helpful.`;
         required: ["topic"],
       },
       execute: async (_toolCallId: string, params: { topic?: string; depth?: string }, _signal: any, _onUpdate: any, ctx: any) => {
+        const activeModel = activeModelForSearchTool(pi, ctx, "xai_deep_research");
+        if (!activeModel) return searchToolDisabledError("xai_deep_research", { topic: params?.topic });
         const apiKey = await resolveXaiAuthToken(ctx);
         if (!apiKey) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { topic: params?.topic });
@@ -406,7 +435,7 @@ Be specific and cite examples where helpful.`;
         let data: any;
         try {
           data = await createXaiResponse(apiKey, {
-            model: DEFAULT_XAI_MODEL,
+            model: activeModel.id,
             input: xaiTextInput(prompt),
             reasoning: { effort: depth === "high" ? "high" : "medium" },
             tools: [{ type: "web_search" }, { type: "x_search" }],

--- a/extensions/xai/tools/index.ts
+++ b/extensions/xai/tools/index.ts
@@ -1,6 +1,8 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { registerCursorToolShims } from "./cursor-shims";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { registerCursorToolShims, syncCursorToolShimsForModel } from "./cursor-shims";
 import { registerCustomXaiTools } from "./custom-tools";
+import { syncXaiSearchToolsForModel } from "./model-scope";
 
 const xaiToolRegistrations = new WeakSet<object>();
 
@@ -11,4 +13,10 @@ export function registerXaiTools(pi: ExtensionAPI) {
 
   registerCursorToolShims(pi);
   registerCustomXaiTools(pi);
+}
+
+/** Synchronize all model-scoped xAI tool availability without making network requests. */
+export function syncXaiToolsForModel(pi: ExtensionAPI, model?: Model<Api>, options?: { resetSearchTools?: boolean }) {
+  syncCursorToolShimsForModel(pi, model);
+  syncXaiSearchToolsForModel(pi, model, { reset: options?.resetSearchTools });
 }

--- a/extensions/xai/tools/model-scope.ts
+++ b/extensions/xai/tools/model-scope.ts
@@ -1,0 +1,79 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { XAI_PROVIDER_ID } from "../constants";
+import { isGrokCliProxyModel } from "../models";
+
+/** Paid xAI tools that invoke xAI's server-side web or X search. */
+export const XAI_SEARCH_TOOL_NAMES = [
+  "xai_web_search",
+  "xai_x_search",
+  "xai_multi_agent",
+  "xai_deep_research",
+  "WebSearch",
+] as const;
+
+const initializedXaiSearchToolScopes = new WeakSet<object>();
+
+/** Return the active xAI model, or undefined when the session is using another provider. */
+export function activeXaiModel(ctx: Pick<ExtensionContext, "model"> | undefined): Model<Api> | undefined {
+  const model = ctx?.model;
+  if (model?.provider !== XAI_PROVIDER_ID || typeof model.id !== "string" || !model.id.trim()) return undefined;
+  return model as Model<Api>;
+}
+
+/** Return whether a paid search tool is deliberately active in pi's current tool set. */
+export function isXaiSearchToolActive(api: any, toolName: (typeof XAI_SEARCH_TOOL_NAMES)[number]): boolean {
+  if (typeof api?.getActiveTools !== "function") return false;
+  try {
+    if (!initializedXaiSearchToolScopes.has(api as object)) return false;
+    const activeTools = api.getActiveTools();
+    return Array.isArray(activeTools) && activeTools.includes(toolName);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Keep paid xAI search tools opt-in and remove them immediately outside xAI models.
+ *
+ * A session start resets them even for xAI models so installing or reloading the
+ * extension cannot silently expose a credit-gated tool. Users can deliberately
+ * enable an individual tool through pi's tool picker while an xAI model is active.
+ */
+export function syncXaiSearchToolsForModel(api: any, model?: Model<Api>, options?: { reset?: boolean }) {
+  if (typeof api?.getActiveTools !== "function" || typeof api?.setActiveTools !== "function") return;
+  const scope = api as object;
+  if (options?.reset || model?.provider !== XAI_PROVIDER_ID) initializedXaiSearchToolScopes.delete(scope);
+  const preservesIntentionalSelection = initializedXaiSearchToolScopes.has(scope) && model?.provider === XAI_PROVIDER_ID;
+  const toolNamesToRemove: readonly string[] = preservesIntentionalSelection
+    ? isGrokCliProxyModel(model.id)
+      ? []
+      : ["WebSearch"]
+    : XAI_SEARCH_TOOL_NAMES;
+  if (toolNamesToRemove.length === 0) return;
+
+  let activeTools: string[];
+  try {
+    const current = api.getActiveTools();
+    activeTools = Array.isArray(current) ? (current as string[]) : [];
+  } catch {
+    return;
+  }
+
+  const nextTools = activeTools.filter(
+    (toolName) => !toolNamesToRemove.includes(toolName),
+  );
+  if (nextTools.length === activeTools.length) {
+    initializedXaiSearchToolScopes.add(scope);
+    return;
+  }
+
+  try {
+    api.setActiveTools(nextTools);
+    initializedXaiSearchToolScopes.add(scope);
+  } catch {
+    initializedXaiSearchToolScopes.delete(scope);
+    // The registry can be transiently unavailable during startup. The
+    // before_agent_start synchronization retries before any model request.
+  }
+}

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -9,8 +9,24 @@ const repoRoot = path.resolve(__dirname, "..");
 const jiti = createJiti(__filename, { interopDefault: true });
 const extensionModule = jiti(path.join(repoRoot, "extensions", "xai-oauth.ts"));
 const extension = extensionModule.default || extensionModule;
+const { compactXaiInlineImages, MAX_XAI_INLINE_IMAGE_BASE64_BYTES } = jiti(
+  path.join(repoRoot, "extensions", "xai", "images.ts"),
+);
+const { rewriteXaiResponsesPayload } = jiti(path.join(repoRoot, "extensions", "xai", "payload.ts"));
+const { createXaiResponse } = jiti(path.join(repoRoot, "extensions", "xai", "responses.ts"));
 const originalFetch = global.fetch;
 const requests = [];
+let nextXaiResponse;
+
+const TEST_XAI_MODEL = {
+  id: "grok-4.5",
+  provider: "xai-auth",
+  api: "xai-responses",
+  baseUrl: "https://api.x.ai/v1",
+  headers: {},
+  reasoning: true,
+  input: ["text", "image"],
+};
 
 function jsonResponse(body, init = {}) {
   return new Response(JSON.stringify(body), {
@@ -46,6 +62,11 @@ function installFetchMock() {
 
     const body = init.body ? JSON.parse(String(init.body)) : undefined;
     requests.push({ url: href, headers: init.headers || {}, body, signal: init.signal });
+    if (nextXaiResponse && urlOriginIs(href, "https://api.x.ai")) {
+      const response = nextXaiResponse;
+      nextXaiResponse = undefined;
+      return jsonResponse(response.body, { status: response.status });
+    }
     if (href.endsWith("/images/generations")) {
       return jsonResponse({ data: [{ url: "https://example.test/image.png" }] });
     }
@@ -55,6 +76,10 @@ function installFetchMock() {
 
 function restoreFetchMock() {
   global.fetch = originalFetch;
+}
+
+function respondToNextXaiRequest(status, body) {
+  nextXaiResponse = { status, body };
 }
 
 function headerValue(headers, name) {
@@ -87,6 +112,7 @@ function loadExtension() {
     },
     registerTool(tool) {
       tools.set(tool.name, tool);
+      if (!activeTools.includes(tool.name)) activeTools.push(tool.name);
     },
     getActiveTools() {
       if (throwOnGetActiveTools) throw new Error("tool registry not ready");
@@ -110,8 +136,9 @@ function loadExtension() {
   };
 }
 
-function authContext() {
+function authContext(model = TEST_XAI_MODEL) {
   return {
+    model,
     modelRegistry: {
       find(provider, modelId) {
         return { provider, id: modelId, headers: {} };
@@ -123,10 +150,17 @@ function authContext() {
   };
 }
 
-async function runTool(tools, name, params = {}, expectedText = "OK", requestOrigin = "https://api.x.ai") {
+async function runTool(
+  tools,
+  name,
+  params = {},
+  expectedText = "OK",
+  requestOrigin = "https://api.x.ai",
+  model = TEST_XAI_MODEL,
+) {
   const controller = new AbortController();
   const before = requests.length;
-  const result = await tools.get(name).execute("call_test", params, controller.signal, () => {}, authContext());
+  const result = await tools.get(name).execute("call_test", params, controller.signal, () => {}, authContext(model));
   const request = requests.slice(before).find((entry) => entry.url && urlOriginIs(entry.url, requestOrigin));
   if (expectedText instanceof RegExp) {
     assert.match(result.content[0].text, expectedText, `${name} should surface mocked xAI text`);
@@ -144,10 +178,37 @@ async function runCursorTool(tools, name, params = {}, ctx = {}) {
   return tools.get(name).execute("call_cursor", params, controller.signal, () => {}, { cwd: repoRoot, ...ctx });
 }
 
-async function verifyCursorToolShims(tools) {
+async function verifyCursorToolShims(loadResult) {
+  const { tools, getActiveTools, setActiveTools } = loadResult;
   for (const name of ["Read", "Write", "StrReplace", "Edit", "Delete", "LS", "Grep", "Glob", "Shell", "WebSearch"]) {
     assert.ok(tools.has(name), `${name} Cursor/Grok CLI shim should be registered`);
   }
+
+  const composerModel = { ...TEST_XAI_MODEL, id: "grok-composer-2.5-fast" };
+  const beforeDisabledWebSearch = requests.length;
+  const disabledWebSearchResult = await runCursorTool(tools, "WebSearch", { query: "must opt in" }, authContext(composerModel));
+  assert.match(disabledWebSearchResult.content[0].text, /WebSearch is disabled/);
+  assert.equal(requests.length, beforeDisabledWebSearch, "inactive Cursor WebSearch must fail before network access");
+
+  setActiveTools([...getActiveTools(), "WebSearch"]);
+  const beforeWebSearch = requests.length;
+  const webSearchResult = await runCursorTool(tools, "WebSearch", { query: "xAI docs" }, authContext(composerModel));
+  assert.equal(webSearchResult.content[0].text, "OK");
+  const webSearchRequest = requests
+    .slice(beforeWebSearch)
+    .find((entry) => entry.url && urlOriginIs(entry.url, "https://cli-chat-proxy.grok.com"));
+  assert.ok(webSearchRequest, "Cursor WebSearch should route through the active Grok CLI model");
+  assert.equal(webSearchRequest.body.model, composerModel.id);
+
+  const beforeStaleWebSearch = requests.length;
+  const staleWebSearchResult = await runCursorTool(
+    tools,
+    "WebSearch",
+    { query: "must not run" },
+    authContext({ provider: "anthropic", id: "claude-opus-4-8" }),
+  );
+  assert.match(staleWebSearchResult.content[0].text, /requires an active xAI/);
+  assert.equal(requests.length, beforeStaleWebSearch, "stale Cursor WebSearch calls must fail before network access");
 
   const grepResult = await runCursorTool(tools, "Grep", { query: "export const DEFAULT_XAI_MODEL", include: "*.ts", path: "extensions", limit: 5 });
   assert.match(grepResult.content[0].text, /xai\/constants\.ts/, "Grep shim should map query/include to pi grep pattern/glob");
@@ -232,7 +293,7 @@ async function verifyCursorToolShims(tools) {
 }
 
 async function verifyCursorToolActivation(loadResult) {
-  const { handlers, getActiveTools } = loadResult;
+  const { handlers, getActiveTools, setActiveTools } = loadResult;
   // Real ExtensionContext objects do not expose the active-tool accessors.
   // Keeping this context empty prevents the test from masking the regression.
   const ctx = {};
@@ -241,9 +302,18 @@ async function verifyCursorToolActivation(loadResult) {
 
   await selectModel("grok-composer-2.5-fast");
   assert.ok(getActiveTools().includes("Grep"), "Cursor shims should be enabled for Composer 2.5");
+  assert.ok(!getActiveTools().includes("WebSearch"), "selecting a Grok CLI model must not activate paid WebSearch");
   const composerTools = getActiveTools();
   await selectModel("grok-composer-2.5-fast");
   assert.deepStrictEqual(getActiveTools(), composerTools, "Repeated Composer sync should not duplicate shims");
+  await handlers.get("before_agent_start")?.({}, { model: { provider: "xai-auth", id: "grok-composer-2.5-fast" } });
+  assert.ok(!getActiveTools().includes("WebSearch"), "before-agent synchronization must preserve a manual WebSearch disable");
+
+  setActiveTools([...getActiveTools(), "WebSearch"]);
+  await selectModel("grok-4.3");
+  assert.ok(!getActiveTools().includes("WebSearch"), "switching to a non-CLI xAI model must disable Cursor WebSearch");
+  await selectModel("grok-composer-2.5-fast");
+  assert.ok(!getActiveTools().includes("WebSearch"), "switching back to a Grok CLI model must not restore Cursor WebSearch");
 
   await selectModel("grok-4.3");
   assert.ok(!getActiveTools().includes("Grep"), "Cursor shims should be disabled for non-Grok-CLI xAI models");
@@ -268,6 +338,298 @@ async function verifyCursorToolActivation(loadResult) {
   await selectModel("grok-composer-2.5-fast");
   assert.ok(!getActiveTools().includes("Grep"), "a failed set should not partially update the tool list");
   loadResult.setToolRegistryFailures();
+}
+
+async function verifyXaiSearchToolActivation(loadResult) {
+  const { handlers, tools, getActiveTools, setActiveTools } = loadResult;
+  const customSearchTools = ["xai_web_search", "xai_x_search", "xai_multi_agent", "xai_deep_research"];
+  const searchTools = [...customSearchTools, "WebSearch"];
+  const anthropicModel = { provider: "anthropic", id: "claude-opus-4-8" };
+  const requestsBeforeLifecycle = requests.length;
+
+  assert.ok(searchTools.every((name) => getActiveTools().includes(name)), "pi activates newly registered extension tools by default");
+  await handlers.get("session_start")?.({}, { model: TEST_XAI_MODEL });
+  assert.ok(searchTools.every((name) => !getActiveTools().includes(name)), "session start must make paid xAI search tools opt-in");
+
+  await handlers.get("model_select")?.({ model: TEST_XAI_MODEL }, { model: TEST_XAI_MODEL });
+  assert.ok(
+    searchTools.every((name) => !getActiveTools().includes(name)),
+    "selecting an xAI model must not implicitly activate paid search tools",
+  );
+  assert.equal(requests.length, requestsBeforeLifecycle, "session/model lifecycle hooks must never send an xAI request");
+
+  setActiveTools([...getActiveTools(), ...searchTools]);
+  loadResult.setToolRegistryFailures({ get: true });
+  await assert.doesNotReject(
+    async () => handlers.get("session_start")?.({}, { model: TEST_XAI_MODEL }),
+    "search-tool reset should tolerate an unavailable registry",
+  );
+  loadResult.setToolRegistryFailures();
+  await handlers.get("before_agent_start")?.({}, { model: TEST_XAI_MODEL });
+  assert.ok(searchTools.every((name) => !getActiveTools().includes(name)), "before_agent_start should retry a failed registry read");
+
+  setActiveTools([...getActiveTools(), ...searchTools]);
+  loadResult.setToolRegistryFailures({ set: true });
+  await handlers.get("session_start")?.({}, { model: TEST_XAI_MODEL });
+  await handlers.get("before_agent_start")?.({}, { model: TEST_XAI_MODEL });
+  const requestsBeforePersistentSetFailure = requests.length;
+  const persistentFailureResult = await tools.get("xai_web_search").execute(
+    "call_persistent_registry_failure",
+    { query: "must fail closed" },
+    undefined,
+    () => {},
+    authContext(TEST_XAI_MODEL),
+  );
+  assert.match(persistentFailureResult.content[0].text, /is disabled/);
+  assert.equal(
+    requests.length,
+    requestsBeforePersistentSetFailure,
+    "persistent registry write failures must keep paid search tools fail-closed",
+  );
+  loadResult.setToolRegistryFailures();
+  await handlers.get("before_agent_start")?.({}, { model: TEST_XAI_MODEL });
+  assert.ok(searchTools.every((name) => !getActiveTools().includes(name)), "before_agent_start should retry a failed registry write");
+
+  setActiveTools([...getActiveTools(), ...searchTools]);
+  await handlers.get("before_agent_start")?.({}, { model: TEST_XAI_MODEL });
+  assert.ok(customSearchTools.every((name) => getActiveTools().includes(name)), "explicitly enabled xAI search tools should stay active for xAI models");
+  assert.ok(!getActiveTools().includes("WebSearch"), "Cursor WebSearch must remain disabled for non-CLI xAI models");
+
+  await handlers.get("model_select")?.({ model: anthropicModel }, { model: anthropicModel });
+  assert.ok(searchTools.every((name) => !getActiveTools().includes(name)), "switching away from xAI must disable paid search tools immediately");
+  await handlers.get("model_select")?.({ model: TEST_XAI_MODEL }, { model: TEST_XAI_MODEL });
+  assert.ok(searchTools.every((name) => !getActiveTools().includes(name)), "switching back to xAI must not silently restore paid search tools");
+
+  setActiveTools([...getActiveTools(), ...searchTools]);
+  const guardedCalls = {
+    xai_web_search: { query: "guard test" },
+    xai_x_search: { query: "guard test" },
+    xai_multi_agent: { query: "guard test" },
+    xai_deep_research: { topic: "guard test" },
+  };
+  const requestsBeforeGuards = requests.length;
+  for (const [name, params] of Object.entries(guardedCalls)) {
+    const result = await tools.get(name).execute("call_guard", params, undefined, () => {}, authContext(anthropicModel));
+    assert.match(result.content[0].text, /is disabled/, `${name} should reject a stale non-xAI invocation`);
+  }
+  assert.equal(requests.length, requestsBeforeGuards, "non-xAI search-tool guards must run before auth or network access");
+
+  setActiveTools(getActiveTools().filter((name) => name !== "WebSearch"));
+}
+
+function inlineImageUrls(value, urls = []) {
+  if (Array.isArray(value)) {
+    for (const item of value) inlineImageUrls(item, urls);
+    return urls;
+  }
+  if (!value || typeof value !== "object") return urls;
+  if (value.type === "input_image" && typeof value.image_url === "string" && value.image_url.startsWith("data:image/")) {
+    urls.push(value.image_url);
+  }
+  for (const child of Object.values(value)) inlineImageUrls(child, urls);
+  return urls;
+}
+
+function inlineImageBase64Bytes(value) {
+  return inlineImageUrls(value).reduce((total, url) => total + Buffer.byteLength(url.split(",", 2)[1] || "", "utf8"), 0);
+}
+
+function toolImageOutput(imageUrl, callId = "call_image") {
+  return {
+    type: "function_call_output",
+    call_id: callId,
+    output: [
+      { type: "input_text", text: "screenshot result" },
+      { type: "input_image", image_url: imageUrl, detail: "auto" },
+    ],
+  };
+}
+
+async function verifyXaiImageLifecycle() {
+  const tinyImageUrl = `data:image/png;base64,${Buffer.from("tiny-image-fixture").toString("base64")}`;
+  const assistantOutputs = [
+    { type: "reasoning", summary: [] },
+    { type: "function_call", call_id: "next_call", name: "read", arguments: "{}" },
+    { type: "message", role: "assistant", content: [{ type: "output_text", text: "done" }] },
+  ];
+
+  for (const assistantOutput of assistantOutputs) {
+    const rewritten = rewriteXaiResponsesPayload(
+      { model: TEST_XAI_MODEL.id, input: [toolImageOutput(tinyImageUrl), assistantOutput, { role: "user", content: "next" }] },
+      TEST_XAI_MODEL,
+    );
+    assert.equal(inlineImageUrls(rewritten).length, 0, `${assistantOutput.type} should consume earlier tool-result images`);
+    assert.match(JSON.stringify(rewritten), /historical tool image.*omitted/, "consumed tool images should leave an explicit marker");
+  }
+
+  const pending = rewriteXaiResponsesPayload(
+    { model: TEST_XAI_MODEL.id, input: [toolImageOutput(tinyImageUrl)] },
+    TEST_XAI_MODEL,
+  );
+  assert.equal(inlineImageUrls(pending).length, 1, "a tool image awaiting its first assistant response must be retained");
+
+  const nonAssistantTail = rewriteXaiResponsesPayload(
+    {
+      model: TEST_XAI_MODEL.id,
+      input: [
+        toolImageOutput(tinyImageUrl, "pending_a"),
+        { role: "user", content: [{ type: "input_text", text: "continue" }] },
+        { type: "function_call_output", call_id: "pending_b", output: "text only" },
+      ],
+    },
+    TEST_XAI_MODEL,
+  );
+  assert.equal(inlineImageUrls(nonAssistantTail).length, 1, "user and tool-output items must not consume a pending tool image");
+
+  const mixed = rewriteXaiResponsesPayload(
+    {
+      model: TEST_XAI_MODEL.id,
+      input: [
+        toolImageOutput(tinyImageUrl, "historical"),
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: "seen" }] },
+        toolImageOutput(tinyImageUrl, "current"),
+      ],
+    },
+    TEST_XAI_MODEL,
+  );
+  assert.equal(inlineImageUrls(mixed).length, 1, "mixed history should omit consumed images and retain the current pending image");
+
+  const ordinaryUserImage = rewriteXaiResponsesPayload(
+    {
+      model: TEST_XAI_MODEL.id,
+      input: [
+        { role: "user", content: [{ type: "input_image", image_url: tinyImageUrl, detail: "auto" }] },
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: "seen" }] },
+      ],
+    },
+    TEST_XAI_MODEL,
+  );
+  assert.equal(inlineImageUrls(ordinaryUserImage).length, 1, "ordinary user images must never be pruned by the tool-image lifecycle");
+}
+
+async function verifyXaiImageCompaction() {
+  const sourceBytes = await fs.readFile(path.join(repoRoot, "preview.jpeg"));
+  const sourceBase64 = sourceBytes.toString("base64");
+  const sourceUrl = `data:image/jpeg;base64,${sourceBase64}`;
+  const payload = {
+    input: [
+      {
+        role: "user",
+        content: [
+          { type: "input_image", image_url: sourceUrl, detail: "auto" },
+          { type: "input_image", image_url: sourceUrl, detail: "auto" },
+        ],
+      },
+    ],
+  };
+
+  const underBudget = await compactXaiInlineImages(payload, sourceBase64.length * 2 + 1);
+  assert.deepEqual(inlineImageUrls(underBudget), [sourceUrl, sourceUrl], "under-budget images within 2000px should remain byte-identical");
+
+  const compactBudget = Math.floor(sourceBase64.length * 1.5);
+  const compacted = await compactXaiInlineImages(payload, compactBudget);
+  const compactedUrls = inlineImageUrls(compacted);
+  assert.equal(compactedUrls.length, 2);
+  assert.ok(inlineImageBase64Bytes(compacted) <= compactBudget, "compacted inline images must obey the aggregate budget");
+  const { resizeImage } = await import("@earendil-works/pi-coding-agent");
+  for (const url of compactedUrls) {
+    assert.match(url, /^data:image\/(?:png|jpeg);base64,/);
+    const [metadata, data] = url.split(",", 2);
+    const inspected = await resizeImage(Buffer.from(data, "base64"), metadata.slice(5).split(";", 1)[0], {
+      maxWidth: 2000,
+      maxHeight: 2000,
+      maxBytes: Buffer.byteLength(data, "utf8") + 1,
+      jpegQuality: 95,
+    });
+    assert.ok(inspected && inspected.width <= 2000 && inspected.height <= 2000, "compacted image dimensions must stay within 2000px");
+  }
+
+  await assert.rejects(
+    () => compactXaiInlineImages({ input: [{ type: "input_image", image_url: "data:image/png;base64,bm90LWFuLWltYWdl" }] }, 2),
+    /exceeds the safe transport budget and could not be compacted/,
+    "undecodable oversized inline images should fail locally instead of reaching xAI",
+  );
+}
+
+async function verifyXaiImageTransport(provider) {
+  const sourceBytes = await fs.readFile(path.join(repoRoot, "preview.jpeg"));
+  const oversizedBytes = Buffer.concat(Array(10).fill(sourceBytes));
+  const oversizedBase64 = oversizedBytes.toString("base64");
+  const oversizedUrl = `data:image/jpeg;base64,${oversizedBase64}`;
+  const input = [
+    {
+      role: "user",
+      content: [
+        { type: "input_image", image_url: oversizedUrl, detail: "auto" },
+        { type: "input_image", image_url: oversizedUrl, detail: "auto" },
+        { type: "input_text", text: "Reply exactly OK." },
+      ],
+    },
+  ];
+
+  const beforeDirect = requests.length;
+  await createXaiResponse("oauth-token", { model: TEST_XAI_MODEL.id, input, max_output_tokens: 32 });
+  const directRequest = requests.slice(beforeDirect).find((entry) => entry.url?.endsWith("/responses"));
+  assert.ok(directRequest, "createXaiResponse should send the prepared payload");
+  assert.ok(inlineImageBase64Bytes(directRequest.body) <= MAX_XAI_INLINE_IMAGE_BASE64_BYTES);
+  assert.ok(inlineImageUrls(directRequest.body).every((url) => url !== oversizedUrl), "direct Responses calls should compact oversized images");
+
+  const beforeStream = requests.length;
+  const stream = provider.streamSimple(
+    TEST_XAI_MODEL,
+    {
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "image", data: oversizedBase64, mimeType: "image/jpeg" },
+            { type: "image", data: oversizedBase64, mimeType: "image/jpeg" },
+            { type: "text", text: "Reply exactly OK." },
+          ],
+          timestamp: Date.now(),
+        },
+      ],
+    },
+    { apiKey: "oauth-token", sessionId: "image-transport-session" },
+  );
+  await stream.result();
+  const streamRequest = requests.slice(beforeStream).find((entry) => entry.url?.endsWith("/responses"));
+  assert.ok(streamRequest, "provider streaming should send the prepared payload");
+  assert.ok(inlineImageBase64Bytes(streamRequest.body) <= MAX_XAI_INLINE_IMAGE_BASE64_BYTES);
+  assert.ok(inlineImageUrls(streamRequest.body).every((url) => url !== oversizedUrl), "streaming Responses calls should compact oversized images");
+
+  const beforeMutatingHook = requests.length;
+  const mutatingHookStream = provider.streamSimple(
+    TEST_XAI_MODEL,
+    { messages: [{ role: "user", content: "hello", timestamp: Date.now() }] },
+    {
+      apiKey: "oauth-token",
+      sessionId: "image-mutating-hook-session",
+      onPayload(payload) {
+        payload.input = input;
+      },
+    },
+  );
+  await mutatingHookStream.result();
+  const mutatingHookRequest = requests.slice(beforeMutatingHook).find((entry) => entry.url?.endsWith("/responses"));
+  assert.ok(mutatingHookRequest, "an in-place payload hook should still send a prepared request");
+  assert.ok(
+    inlineImageBase64Bytes(mutatingHookRequest.body) <= MAX_XAI_INLINE_IMAGE_BASE64_BYTES,
+    "in-place payload hook mutations must be compacted before transport",
+  );
+}
+
+async function verifyXaiStreamErrorPrefix(provider) {
+  respondToNextXaiRequest(500, { code: "internal", error: "Auth context expired." });
+  const message = await captureStreamResultMessage(() =>
+    provider.streamSimple(
+      TEST_XAI_MODEL,
+      { messages: [{ role: "user", content: "hello", timestamp: Date.now() }] },
+      { apiKey: "oauth-token", sessionId: "error-prefix-session" },
+    ),
+  );
+  assert.match(message, /^xAI API error\b/i, "delegated xAI transport errors should be labeled as xAI errors");
+  assert.doesNotMatch(message, /^OpenAI API error\b/i);
 }
 
 function lastResultErrorMessage(result) {
@@ -516,12 +878,19 @@ async function main() {
     assert.equal(provider.models.find((model) => model.id === "grok-4.20-0309-reasoning")?.contextWindow, 2_000_000);
     assert.ok(provider.models.some((model) => model.id === "grok-4.20-multi-agent-0309"));
 
+    await verifyXaiSearchToolActivation(firstLoad);
+    await verifyXaiImageLifecycle();
+    await verifyXaiImageCompaction();
+
     await verifyOpenAIResponsesTransport();
     await verifyXaiResponsesTransport(provider);
 
+    await verifyXaiImageTransport(provider);
+    await verifyXaiStreamErrorPrefix(provider);
+
     await verifyCliModelStreamRouting(provider);
     await verifyCursorToolActivation(firstLoad);
-    await verifyCursorToolShims(tools);
+    await verifyCursorToolShims(firstLoad);
 
     await verifyOAuthCallbackState(provider);
     await verifyOAuthManualRawCode(provider);
@@ -566,11 +935,38 @@ async function main() {
     assert.equal(headerValue(buildRequest.headers, "x-grok-model-override"), "grok-build");
     assert.ok(headerValue(buildRequest.headers, "x-grok-conv-id"), "Grok Build tool calls should include a Grok conversation id");
 
+    firstLoad.setActiveTools([
+      ...firstLoad.getActiveTools(),
+      "xai_web_search",
+      "xai_x_search",
+      "xai_multi_agent",
+      "xai_deep_research",
+    ]);
     const { body: webBody } = await runTool(tools, "xai_web_search", { query: "xAI docs" });
     assert.deepEqual(webBody.tools, [{ type: "web_search", enable_image_understanding: true }]);
+    assert.equal(webBody.model, TEST_XAI_MODEL.id, "xai_web_search should use the active xAI model");
+
+    respondToNextXaiRequest(403, {
+      code: "personal-team-blocked:spending-limit",
+      error: "You have run out of credits or need a Grok subscription.",
+    });
+    const beforeProviderError = requests.length;
+    const selectedGrok43 = { ...TEST_XAI_MODEL, id: "grok-4.3" };
+    const providerErrorResult = await tools.get("xai_web_search").execute(
+      "call_provider_error",
+      { query: "one attempt" },
+      undefined,
+      () => {},
+      authContext(selectedGrok43),
+    );
+    assert.match(providerErrorResult.content[0].text, /xAI API Error 403/);
+    const providerErrorRequests = requests.slice(beforeProviderError).filter((entry) => urlOriginIs(entry.url, "https://api.x.ai"));
+    assert.equal(providerErrorRequests.length, 1, "a provider failure should result in one xAI request, not an implicit retry loop");
+    assert.equal(providerErrorRequests[0].body.model, selectedGrok43.id, "provider errors should still use the active selected model");
 
     const { body: xBody } = await runTool(tools, "xai_x_search", { query: "grok", since: "2026-05-01", until: "2026-05-22" });
     assert.equal(xBody.tools[0].type, "x_search");
+    assert.equal(xBody.model, TEST_XAI_MODEL.id, "xai_x_search should use the active xAI model");
     assert.equal(xBody.tools[0].from_date, "2026-05-01");
     assert.equal(xBody.tools[0].to_date, "2026-05-22");
 


### PR DESCRIPTION
## Summary

- make xAI server-side search and research tools explicit opt-ins, including the Grok CLI `WebSearch` shim
- fail closed before auth or network access when tool scope/model state is invalid
- route eligible search calls through the active selected xAI model
- stop replaying consumed historical tool-result images
- compact current inline PNG/JPEG images to a safe aggregate transport budget
- normalize delegated transport errors as xAI errors

## Root causes

Issue #49: Pi activates extension tools by default, while the xAI search tools were globally registered and some silently used `DEFAULT_XAI_MODEL`. Model changes could therefore expose a paid search path without deliberate tool activation.

Issue #50: stateless Responses turns replayed historical base64 tool images. Multiple large screenshots crossed an unreliable xAI OAuth gateway payload range, which surfaced as the misleading `500 "Auth context expired"` error.

## Impact

Paid search/research tools now require an active eligible xAI model and explicit `/tools` activation. Switching away disables them and switching back does not restore them. Registry failures fail closed.

Historical tool images are omitted only after a later assistant response has consumed them. Current images remain available and are compacted before both direct and streaming transport, including payload-hook mutations.

Closes #49
Closes #50

## Validation

- `npm test`
- `npm run typecheck`
- `git diff --check`
- `npm pack --dry-run`
- real Pi extension loader smoke test
- real Pi session/model lifecycle probes
- independent review and clean follow-up review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch paid-tool gating, request payload shaping, and all Responses traffic; mistakes could block legitimate search or break multimodal sessions, but fail-closed guards and broad regression tests reduce exposure.
> 
> **Overview**
> **Paid xAI search/research** (`xai_web_search`, `xai_x_search`, `xai_multi_agent`, `xai_deep_research`, and Grok CLI `WebSearch`) are now **opt-in via `/tools`**, stripped on session start and when leaving `xai-auth`, and **blocked locally** (no auth/network) unless an active xAI model and explicit activation apply. Eligible calls use **`ctx.model.id`** instead of `DEFAULT_XAI_MODEL`. Cursor auto-shims no longer auto-enable `WebSearch`; lifecycle hooks call **`syncXaiToolsForModel`**.
> 
> **Multimodal transport:** consumed historical tool-result images are **dropped** after a later assistant turn (text markers only); pending images stay until then. **`compactXaiInlineImages`** enforces a **3 MiB** aggregate inline base64 budget with resize/JPEG compaction on direct and streaming paths, including post-`onPayload` mutations. Stream errors are labeled **xAI** instead of OpenAI.
> 
> Docs and **`verify-extension.js`** cover opt-in behavior, lifecycle, routing, image lifecycle, compaction, and transport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 433c46504f29843003535b90f65169d6faaaab74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->