### PR TITLE
Add package-owned xAI paid-tool command

### DIFF
--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -1,7 +1,7 @@
 # Shared Agent Context
 
 **Project:** pi-xai-oauth
-**Branch:** feature/issues-49-50
+**Branch:** feature/issue-52-xai-tools
 **Date:** 2026-07-15
 
 ## Key Context
@@ -10,8 +10,8 @@
 - Persistent state lives in .scaffold/.
 
 ## Current Focus
-- GitHub #49: xAI paid search/research tools must be explicit opt-ins, guarded by the active `xai-auth` model, and routed through that model.
-- GitHub #50: consumed historical tool images must not be replayed; oversized current inline images need high-fidelity transport compaction and a hard aggregate budget.
-- Preserve OAuth-only behavior and never log credentials or inline image data.
+- GitHub #52: provide a package-owned `/xai-tools` command because core pi does not ship the optional `/tools` example.
+- Paid search tools remain session-scoped explicit opt-ins and fail closed outside active eligible `xai-auth` models.
+- Runtime messages and README instructions must point only to the command this package actually registers.
 
 See plan.md for active phases and progress.md for completed verification.

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,38 +1,29 @@
-# Implementation Plan: GitHub Issues #49 and #50
+# Implementation Plan: GitHub Issue #52
 
-**Branch:** feature/issues-49-50
+**Branch:** feature/issue-52-xai-tools
 
 **Date:** 2026-07-15
 
-**Goal:** Prevent unintended xAI paid-search calls and keep stateless Responses requests below the xAI OAuth gateway's unreliable inline-image payload range.
+**Goal:** Give users a package-owned, fail-closed way to opt in to paid xAI search tools without depending on pi's optional `/tools` example extension.
 
-## Phase 1: Issue review and baseline
-- [x] Read issues #49 and #50 and their comments through GitHub.
-- [x] Inspect the provider entrypoint, custom tool registration, payload normalization, Responses transport, setup script, tests, README, and pi extension contracts.
-- [x] Move the existing worktree from the obsolete merged branch to `feature/issues-49-50` at current `origin/main`.
-- [x] Run baseline `npm test` and `npm run typecheck`.
+## Phase 1: Reproduce and verify
+- [x] Read issue #52 and confirm there are no follow-up comments.
+- [x] Verify that core pi 0.80.7 does not register `/tools`; it ships only as an optional example extension.
+- [x] Inspect the active-tool registry, command UI API, existing model scope, docs, and verification harness.
+- [x] Run clean baseline tests and TypeScript validation.
 
-## Phase 2: Issue #49 paid-search guard
-- [x] Keep xAI search/research tools registered but inactive by default.
-- [x] Remove those tools immediately when the active model is not from `xai-auth`.
-- [x] Fail tool execution locally before auth/network resolution unless an active xAI model is present.
-- [x] Route web/X/deep-research requests through the active xAI model instead of `DEFAULT_XAI_MODEL`.
-- [x] Add regression coverage for default inactivity, model switching, local no-request rejection, active-model routing, and zero requests from lifecycle events.
+## Phase 2: Package-owned opt-in command
+- [x] Register `/xai-tools` from `pi-xai-oauth`.
+- [x] Provide an interactive paid-tool picker plus explicit `enable`, `disable`, and `status` arguments.
+- [x] Require an active xAI model for enablement and restrict `WebSearch` to Grok Build/Composer models.
+- [x] Preserve session-start reset, non-xAI model cleanup, and fail-closed registry behavior.
 
-## Phase 3: Issue #50 image lifecycle and transport mitigation
-- [x] Omit consumed historical tool-result image binaries after a later assistant response while retaining explicit text markers.
-- [x] Preserve unconsumed tool-result images until the first assistant response.
-- [x] Compact oversized inline PNG/JPEG images with high-fidelity JPEG encoding before transport and enforce an aggregate inline-image budget.
-- [x] Normalize delegated transport error prefixes from OpenAI to xAI.
-- [x] Add regression coverage for image lifecycle, compaction, dimensions, payload budget, and clear no-network overflow failure.
-
-## Phase 4: Verification and review
-- [x] Run focused tests, `npm test`, `npm run typecheck`, `git diff --check`, and `npm pack --dry-run`.
-- [x] Run an independent reviewer agent against the final diff.
-- [x] Address all valid findings and re-run validation.
+## Phase 3: Documentation and verification
+- [x] Replace every misleading core `/tools` reference with the package-owned command.
+- [x] Add regression coverage for command registration, eligibility, toggling, lifecycle persistence, and registry failures.
+- [x] Run `npm test`, `npm run typecheck`, `git diff --check`, and `npm pack --dry-run`.
+- [x] Smoke-test the command through pi's real extension loader.
 
 **Owner:** Main agent
-
-**Research:** Parallel issue #49 and issue #50 subagents
 
 **Next action:** Hand off the completed worktree for commit or PR publication.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -209,3 +209,16 @@ Update this file frequently during execution.
 - [x] Final validation passed: `npm test`, `npm run typecheck`, `git diff --check`, `npm pack --dry-run`, real pi extension loading, and real pi session/model lifecycle probes.
 
 **Current branch:** feature/issues-49-50
+
+## Phase 20: Issue 52 package-owned paid-tool command
+- [x] Confirmed core pi 0.80.7 does not include `/tools`; that command exists only in an optional example extension.
+- [x] Added package-owned `/xai-tools` interactive selection plus `status`, `enable`, and `disable` arguments.
+- [x] Kept paid tools off at session start, removed them outside xAI models, and restricted `WebSearch` to Grok Build/Composer.
+- [x] Replaced misleading README, tool-description, and runtime-error references to pi's `/tools` picker.
+- [x] Added regression coverage for command registration, model eligibility, explicit toggling, lifecycle persistence, and fail-closed registry errors.
+- [x] Verified real pi 0.80.7 RPC registration, default-disabled status, explicit enablement, and credit warning.
+- [x] Fixed independent review finding by tracking explicit authorization per paid tool and stripping stale unauthorized tools after registry recovery.
+- [x] Focused closure review reported no findings.
+- [x] Final validation passed: `npm test`, `npm run typecheck`, `git diff --check`, `npm pack --dry-run`, and real pi 0.80.7 RPC command probes.
+
+**Current branch:** feature/issue-52-xai-tools

--- a/README.md
+++ b/README.md
@@ -290,7 +290,23 @@ This package registers OAuth-backed custom tools that use the xAI API directly. 
 
 **How to use them:** Select an `xai-auth` model, then call the tool by name in your prompt or agent workflow. The tools use your authenticated xAI session.
 
-The paid server-side search tools — `xai_web_search`, `xai_x_search`, `xai_multi_agent`, `xai_deep_research`, and the Grok Build/Composer-compatible `WebSearch` shim — are deliberately **inactive by default**. Enable only the tool you want through pi's `/tools` picker, then request it explicitly in your prompt. Switching to a non-xAI model disables all five immediately; switching back does not silently re-enable them.
+The paid server-side search tools — `xai_web_search`, `xai_x_search`, `xai_multi_agent`, `xai_deep_research`, and the Grok Build/Composer-compatible `WebSearch` shim — are deliberately **inactive by default**. This package provides `/xai-tools` so you can explicitly enable only the tool you want, then request it by name in your prompt. Switching to a non-xAI model disables all five immediately; switching back does not silently re-enable them.
+
+In the pi TUI, select an `xai-auth` model and run:
+
+```text
+/xai-tools
+```
+
+The picker marks every entry as paid and applies changes only to the current xAI session. You can also manage one tool directly:
+
+```text
+/xai-tools status
+/xai-tools enable xai_web_search
+/xai-tools disable xai_web_search
+```
+
+`WebSearch` appears in the picker only for Grok Build and Composer models. `/xai-tools` is owned by this package; it does not depend on pi's optional example `/tools` extension.
 
 > **Tip:** See the ⚠️ warning above about local vs published package conflicts.
 
@@ -306,7 +322,7 @@ Generate text with full reasoning and stateful conversations.
 ```
 
 ### `xai_multi_agent`
-Opt-in deep multi-agent research using Grok's multi-agent model plus native web and X search tools. Enable it through `/tools` first.
+Opt-in deep multi-agent research using Grok's multi-agent model plus native web and X search tools. Enable it through `/xai-tools` first.
 
 ```json
 {
@@ -317,7 +333,7 @@ Opt-in deep multi-agent research using Grok's multi-agent model plus native web 
 ```
 
 ### `xai_web_search`
-Opt-in search using xAI's native `web_search` tool and the active xAI model. Enable it through `/tools` first.
+Opt-in search using xAI's native `web_search` tool and the active xAI model. Enable it through `/xai-tools` first.
 
 ```json
 {
@@ -326,7 +342,7 @@ Opt-in search using xAI's native `web_search` tool and the active xAI model. Ena
 ```
 
 ### `xai_x_search`
-Opt-in X (Twitter) search using xAI's native `x_search` tool and the active xAI model. Enable it through `/tools` first.
+Opt-in X (Twitter) search using xAI's native `x_search` tool and the active xAI model. Enable it through `/xai-tools` first.
 
 ```json
 {
@@ -374,7 +390,7 @@ Get structured critique for code, designs, writing, or ideas.
 ```
 
 ### `xai_deep_research`
-Opt-in research using the active xAI model plus native web and X search tools. Enable it through `/tools` first.
+Opt-in research using the active xAI model plus native web and X search tools. Enable it through `/xai-tools` first.
 
 ```json
 {
@@ -400,6 +416,7 @@ Opt-in research using the active xAI model plus native web and X search tools. E
 | List packages | `pi list` |
 | Set default model | `/model grok-4.5` (in TUI) |
 | Set thinking level | `/think high` (in TUI) |
+| Manage paid xAI tools | `/xai-tools` (in TUI) |
 
 ---
 

--- a/extensions/xai/tools/commands.ts
+++ b/extensions/xai/tools/commands.ts
@@ -1,0 +1,146 @@
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { isGrokCliProxyModel } from "../models";
+import {
+  activeXaiModel,
+  isXaiSearchToolActive,
+  setXaiSearchToolActive,
+  XAI_SEARCH_TOOL_NAMES,
+  type XaiSearchToolName,
+} from "./model-scope";
+
+interface PaidToolOption {
+  name: XaiSearchToolName;
+  summary: string;
+}
+
+const PAID_TOOL_OPTIONS: readonly PaidToolOption[] = [
+  { name: "xai_web_search", summary: "native xAI web search" },
+  { name: "xai_x_search", summary: "native xAI X search" },
+  { name: "xai_multi_agent", summary: "multi-agent web/X research" },
+  { name: "xai_deep_research", summary: "deep web/X research" },
+  { name: "WebSearch", summary: "Grok Build/Composer native web search" },
+];
+
+const XAI_TOOLS_USAGE =
+  "Usage: /xai-tools [status | enable <tool> | disable <tool>]";
+
+function commandToolName(value: string | undefined): XaiSearchToolName | undefined {
+  if (!value) return undefined;
+  const normalized = value.toLowerCase();
+  return XAI_SEARCH_TOOL_NAMES.find((name) => name.toLowerCase() === normalized);
+}
+
+function eligibleToolOptions(model: Model<Api>): readonly PaidToolOption[] {
+  return PAID_TOOL_OPTIONS.filter(
+    ({ name }) => name !== "WebSearch" || isGrokCliProxyModel(model.id),
+  );
+}
+
+function activeToolStatus(pi: ExtensionAPI, model: Model<Api> | undefined): string {
+  return PAID_TOOL_OPTIONS.map(({ name }) => {
+    const unavailable = name === "WebSearch" && (!model || !isGrokCliProxyModel(model.id));
+    if (unavailable) return `${name}=unavailable`;
+    return `${name}=${isXaiSearchToolActive(pi, name) ? "enabled" : "disabled"}`;
+  }).join(", ");
+}
+
+function notifyUpdate(
+  ctx: ExtensionCommandContext,
+  toolName: XaiSearchToolName,
+  active: boolean,
+  error?: string,
+) {
+  if (error) {
+    ctx.ui.notify(error, "error");
+    return;
+  }
+  ctx.ui.notify(
+    active
+      ? `Enabled ${toolName} for this xAI session. Calls may use xAI credits.`
+      : `Disabled ${toolName}.`,
+    active ? "warning" : "info",
+  );
+}
+
+async function showXaiToolPicker(
+  pi: ExtensionAPI,
+  ctx: ExtensionCommandContext,
+  model: Model<Api>,
+) {
+  if (!ctx.hasUI) {
+    ctx.ui.notify(`${XAI_TOOLS_USAGE} Interactive selection requires TUI or RPC mode.`, "error");
+    return;
+  }
+
+  while (true) {
+    const labels = new Map<string, XaiSearchToolName>();
+    for (const option of eligibleToolOptions(model)) {
+      const active = isXaiSearchToolActive(pi, option.name);
+      labels.set(
+        `${active ? "[x]" : "[ ]"} ${option.name} — ${option.summary}`,
+        option.name,
+      );
+    }
+    const done = "Done";
+    const selected = await ctx.ui.select(
+      "xAI paid tools — explicit opt-in; enabled calls may use xAI credits",
+      [...labels.keys(), done],
+    );
+    if (!selected || selected === done) return;
+
+    const toolName = labels.get(selected);
+    if (!toolName) continue;
+    const nextActive = !isXaiSearchToolActive(pi, toolName);
+    const result = setXaiSearchToolActive(pi, model, toolName, nextActive);
+    notifyUpdate(ctx, toolName, result.active, result.error);
+    if (!result.ok) return;
+  }
+}
+
+/** Register the package-owned command for explicitly managing paid xAI tools. */
+export function registerXaiToolsCommand(pi: ExtensionAPI) {
+  pi.registerCommand("xai-tools", {
+    description: "Enable or disable paid xAI search tools for this session",
+    handler: async (args, ctx) => {
+      const [action, rawToolName, ...extra] = args.trim().split(/\s+/).filter(Boolean);
+      const model = activeXaiModel(ctx);
+
+      if (!action) {
+        if (!model) {
+          ctx.ui.notify("Select an xAI/Grok model before opening /xai-tools.", "error");
+          return;
+        }
+        await showXaiToolPicker(pi, ctx, model);
+        return;
+      }
+
+      if (action.toLowerCase() === "status" && !rawToolName) {
+        ctx.ui.notify(
+          `xAI paid tools${model ? ` for ${model.id}` : " (no active xAI model)"}: ${activeToolStatus(pi, model)}`,
+          "info",
+        );
+        return;
+      }
+
+      const normalizedAction = action.toLowerCase();
+      const toolName = commandToolName(rawToolName);
+      if (
+        (normalizedAction !== "enable" && normalizedAction !== "disable")
+        || !toolName
+        || extra.length > 0
+      ) {
+        ctx.ui.notify(XAI_TOOLS_USAGE, "error");
+        return;
+      }
+
+      const result = setXaiSearchToolActive(
+        pi,
+        model,
+        toolName,
+        normalizedAction === "enable",
+      );
+      notifyUpdate(ctx, toolName, result.active, result.error);
+    },
+  });
+}

--- a/extensions/xai/tools/cursor-shims.ts
+++ b/extensions/xai/tools/cursor-shims.ts
@@ -525,7 +525,7 @@ export function registerCursorToolShims(pi: ExtensionAPI) {
     pi.registerTool({
       name: "WebSearch",
       label: "WebSearch",
-      description: "Opt-in paid Cursor/Grok CLI web search. Enable via /tools and call only when the user explicitly requests xAI web search.",
+      description: "Opt-in paid Cursor/Grok CLI web search. Enable via /xai-tools and call only when the user explicitly requests xAI web search.",
       promptSnippet: "Cursor-style web search backed by xAI native web_search",
       promptGuidelines: ["Call WebSearch only when the user explicitly requests xAI web search."],
       parameters: {
@@ -546,7 +546,7 @@ export function registerCursorToolShims(pi: ExtensionAPI) {
           return xaiToolError("Error: WebSearch requires an active xAI Grok Build or Composer model. No xAI request was sent.");
         }
         if (!isXaiSearchToolActive(pi, "WebSearch")) {
-          return xaiToolError("Error: WebSearch is disabled. Enable it in pi's /tools picker and request it explicitly. No xAI request was sent.");
+          return xaiToolError("Error: WebSearch is disabled. Run /xai-tools to enable it and request it explicitly. No xAI request was sent.");
         }
         const apiKey = await resolveXaiAuthToken(ctx);
         if (!apiKey) return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.");

--- a/extensions/xai/tools/custom-tools.ts
+++ b/extensions/xai/tools/custom-tools.ts
@@ -18,7 +18,7 @@ function activeModelForSearchTool(pi: ExtensionAPI, ctx: any, toolName: XaiSearc
 
 function searchToolDisabledError(toolName: XaiSearchToolName, details: Record<string, unknown> = {}) {
   return xaiToolError(
-    `Error: ${toolName} is disabled. Select an xAI/Grok model, enable ${toolName} in pi's /tools picker, and request it explicitly. No xAI request was sent.`,
+    `Error: ${toolName} is disabled. Select an xAI/Grok model, run /xai-tools to enable ${toolName}, and request it explicitly. No xAI request was sent.`,
     { error: true, ...details },
   );
 }
@@ -110,7 +110,7 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
     pi.registerTool({
       name: "xai_multi_agent",
       label: "xAI Multi-Agent Research",
-      description: "Opt-in paid multi-agent web/X research using Grok. Enable via /tools and call only when the user explicitly requests xAI research.",
+      description: "Opt-in paid multi-agent web/X research using Grok. Enable via /xai-tools and call only when the user explicitly requests xAI research.",
       promptGuidelines: ["Call xai_multi_agent only when the user explicitly requests xAI multi-agent research."],
       parameters: {
         type: "object",
@@ -167,7 +167,7 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
     pi.registerTool({
       name: "xai_web_search",
       label: "xAI Web Search",
-      description: "Opt-in paid search using Grok's native web search. Enable via /tools and call only when the user explicitly requests xAI web search.",
+      description: "Opt-in paid search using Grok's native web search. Enable via /xai-tools and call only when the user explicitly requests xAI web search.",
       promptGuidelines: ["Call xai_web_search only when the user explicitly requests xAI web search."],
       parameters: {
         type: "object",
@@ -202,7 +202,7 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
     pi.registerTool({
       name: "xai_x_search",
       label: "xAI X Search",
-      description: "Opt-in paid X search using Grok's native real-time search. Enable via /tools and call only when the user explicitly requests xAI X search.",
+      description: "Opt-in paid X search using Grok's native real-time search. Enable via /xai-tools and call only when the user explicitly requests xAI X search.",
       promptGuidelines: ["Call xai_x_search only when the user explicitly requests xAI X search."],
       parameters: {
         type: "object",
@@ -413,7 +413,7 @@ Be specific and cite examples where helpful.`;
     pi.registerTool({
       name: "xai_deep_research",
       label: "xAI Deep Research",
-      description: "Opt-in paid multi-step web/X research with Grok. Enable via /tools and call only when the user explicitly requests xAI research.",
+      description: "Opt-in paid multi-step web/X research with Grok. Enable via /xai-tools and call only when the user explicitly requests xAI research.",
       promptGuidelines: ["Call xai_deep_research only when the user explicitly requests xAI deep research."],
       parameters: {
         type: "object",

--- a/extensions/xai/tools/index.ts
+++ b/extensions/xai/tools/index.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { Api, Model } from "@earendil-works/pi-ai";
+import { registerXaiToolsCommand } from "./commands";
 import { registerCursorToolShims, syncCursorToolShimsForModel } from "./cursor-shims";
 import { registerCustomXaiTools } from "./custom-tools";
 import { syncXaiSearchToolsForModel } from "./model-scope";
@@ -13,6 +14,7 @@ export function registerXaiTools(pi: ExtensionAPI) {
 
   registerCursorToolShims(pi);
   registerCustomXaiTools(pi);
+  registerXaiToolsCommand(pi);
 }
 
 /** Synchronize all model-scoped xAI tool availability without making network requests. */

--- a/extensions/xai/tools/model-scope.ts
+++ b/extensions/xai/tools/model-scope.ts
@@ -12,7 +12,26 @@ export const XAI_SEARCH_TOOL_NAMES = [
   "WebSearch",
 ] as const;
 
-const initializedXaiSearchToolScopes = new WeakSet<object>();
+export type XaiSearchToolName = (typeof XAI_SEARCH_TOOL_NAMES)[number];
+
+export interface XaiSearchToolUpdateResult {
+  ok: boolean;
+  active: boolean;
+  error?: string;
+}
+
+const explicitlyEnabledXaiSearchTools = new WeakMap<object, Set<XaiSearchToolName>>();
+const xaiSearchToolNameSet = new Set<string>(XAI_SEARCH_TOOL_NAMES);
+
+function activeToolsWithExplicitSearchSelection(
+  activeTools: readonly string[],
+  enabledSearchTools: ReadonlySet<XaiSearchToolName>,
+): string[] {
+  return [
+    ...activeTools.filter((name) => !xaiSearchToolNameSet.has(name)),
+    ...XAI_SEARCH_TOOL_NAMES.filter((name) => enabledSearchTools.has(name)),
+  ];
+}
 
 /** Return the active xAI model, or undefined when the session is using another provider. */
 export function activeXaiModel(ctx: Pick<ExtensionContext, "model"> | undefined): Model<Api> | undefined {
@@ -22,14 +41,81 @@ export function activeXaiModel(ctx: Pick<ExtensionContext, "model"> | undefined)
 }
 
 /** Return whether a paid search tool is deliberately active in pi's current tool set. */
-export function isXaiSearchToolActive(api: any, toolName: (typeof XAI_SEARCH_TOOL_NAMES)[number]): boolean {
+export function isXaiSearchToolActive(api: any, toolName: XaiSearchToolName): boolean {
   if (typeof api?.getActiveTools !== "function") return false;
   try {
-    if (!initializedXaiSearchToolScopes.has(api as object)) return false;
+    if (!explicitlyEnabledXaiSearchTools.get(api as object)?.has(toolName)) return false;
     const activeTools = api.getActiveTools();
     return Array.isArray(activeTools) && activeTools.includes(toolName);
   } catch {
     return false;
+  }
+}
+
+/** Deliberately enable or disable one paid xAI search tool for the current model scope. */
+export function setXaiSearchToolActive(
+  api: any,
+  model: Model<Api> | undefined,
+  toolName: XaiSearchToolName,
+  active: boolean,
+): XaiSearchToolUpdateResult {
+  const xaiModel = activeXaiModel(model ? { model } : undefined);
+  if (active && !xaiModel) {
+    return {
+      ok: false,
+      active: false,
+      error: "Select an xAI/Grok model before enabling a paid xAI search tool.",
+    };
+  }
+  if (active && toolName === "WebSearch" && !isGrokCliProxyModel(xaiModel!.id)) {
+    return {
+      ok: false,
+      active: false,
+      error: "WebSearch is available only with xAI Grok Build or Composer models.",
+    };
+  }
+  if (typeof api?.getActiveTools !== "function" || typeof api?.setActiveTools !== "function") {
+    return {
+      ok: false,
+      active: false,
+      error: "pi's active-tool registry is unavailable; no tools were changed.",
+    };
+  }
+
+  const scope = api as object;
+  const previousSelection = new Set(explicitlyEnabledXaiSearchTools.get(scope) ?? []);
+  const nextSelection = xaiModel ? new Set(previousSelection) : new Set<XaiSearchToolName>();
+  if (xaiModel && !isGrokCliProxyModel(xaiModel.id)) nextSelection.delete("WebSearch");
+  if (active) nextSelection.add(toolName);
+  else nextSelection.delete(toolName);
+
+  let activeTools: string[];
+  try {
+    const current = api.getActiveTools();
+    if (!Array.isArray(current)) throw new Error("invalid active-tool registry response");
+    activeTools = current as string[];
+  } catch {
+    return {
+      ok: false,
+      active: previousSelection.has(toolName),
+      error: "pi's active-tool registry could not be read; no tools were changed.",
+    };
+  }
+
+  const nextTools = activeToolsWithExplicitSearchSelection(activeTools, nextSelection);
+  try {
+    const unchanged = nextTools.length === activeTools.length
+      && nextTools.every((name, index) => name === activeTools[index]);
+    if (!unchanged) api.setActiveTools(nextTools);
+    if (xaiModel) explicitlyEnabledXaiSearchTools.set(scope, nextSelection);
+    else explicitlyEnabledXaiSearchTools.delete(scope);
+    return { ok: true, active };
+  } catch {
+    return {
+      ok: false,
+      active: previousSelection.has(toolName),
+      error: "pi's active-tool registry could not be updated; no tools were changed.",
+    };
   }
 }
 
@@ -38,19 +124,22 @@ export function isXaiSearchToolActive(api: any, toolName: (typeof XAI_SEARCH_TOO
  *
  * A session start resets them even for xAI models so installing or reloading the
  * extension cannot silently expose a credit-gated tool. Users can deliberately
- * enable an individual tool through pi's tool picker while an xAI model is active.
+ * enable an individual tool through this package's `/xai-tools` command while
+ * an xAI model is active.
  */
 export function syncXaiSearchToolsForModel(api: any, model?: Model<Api>, options?: { reset?: boolean }) {
   if (typeof api?.getActiveTools !== "function" || typeof api?.setActiveTools !== "function") return;
   const scope = api as object;
-  if (options?.reset || model?.provider !== XAI_PROVIDER_ID) initializedXaiSearchToolScopes.delete(scope);
-  const preservesIntentionalSelection = initializedXaiSearchToolScopes.has(scope) && model?.provider === XAI_PROVIDER_ID;
-  const toolNamesToRemove: readonly string[] = preservesIntentionalSelection
-    ? isGrokCliProxyModel(model.id)
-      ? []
-      : ["WebSearch"]
-    : XAI_SEARCH_TOOL_NAMES;
-  if (toolNamesToRemove.length === 0) return;
+  const xaiModel = activeXaiModel(model ? { model } : undefined);
+  let enabledSearchTools: Set<XaiSearchToolName>;
+  if (options?.reset || !xaiModel) {
+    explicitlyEnabledXaiSearchTools.delete(scope);
+    enabledSearchTools = new Set();
+  } else {
+    enabledSearchTools = new Set(explicitlyEnabledXaiSearchTools.get(scope) ?? []);
+    if (!isGrokCliProxyModel(xaiModel.id)) enabledSearchTools.delete("WebSearch");
+    explicitlyEnabledXaiSearchTools.set(scope, enabledSearchTools);
+  }
 
   let activeTools: string[];
   try {
@@ -60,19 +149,14 @@ export function syncXaiSearchToolsForModel(api: any, model?: Model<Api>, options
     return;
   }
 
-  const nextTools = activeTools.filter(
-    (toolName) => !toolNamesToRemove.includes(toolName),
-  );
-  if (nextTools.length === activeTools.length) {
-    initializedXaiSearchToolScopes.add(scope);
-    return;
-  }
+  const nextTools = activeToolsWithExplicitSearchSelection(activeTools, enabledSearchTools);
+  const unchanged = nextTools.length === activeTools.length
+    && nextTools.every((name, index) => name === activeTools[index]);
+  if (unchanged) return;
 
   try {
     api.setActiveTools(nextTools);
-    initializedXaiSearchToolScopes.add(scope);
   } catch {
-    initializedXaiSearchToolScopes.delete(scope);
     // The registry can be transiently unavailable during startup. The
     // before_agent_start synchronization retries before any model request.
   }

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -100,6 +100,7 @@ function loadExtension() {
   const providers = new Map();
   const tools = new Map();
   const handlers = new Map();
+  const commands = new Map();
   let activeTools = ["read", "bash", "edit", "write"];
   let throwOnGetActiveTools = false;
   let throwOnSetActiveTools = false;
@@ -114,6 +115,9 @@ function loadExtension() {
       tools.set(tool.name, tool);
       if (!activeTools.includes(tool.name)) activeTools.push(tool.name);
     },
+    registerCommand(name, command) {
+      commands.set(name, command);
+    },
     getActiveTools() {
       if (throwOnGetActiveTools) throw new Error("tool registry not ready");
       return activeTools;
@@ -127,6 +131,7 @@ function loadExtension() {
     providers,
     tools,
     handlers,
+    commands,
     getActiveTools: () => activeTools,
     setActiveTools: (toolNames) => { activeTools = toolNames; },
     setToolRegistryFailures({ get = false, set = false } = {}) {
@@ -145,6 +150,22 @@ function authContext(model = TEST_XAI_MODEL) {
       },
       async getApiKeyAndHeaders() {
         return { ok: true, apiKey: "oauth-token" };
+      },
+    },
+  };
+}
+
+function extensionCommandContext(model, notifications = [], select) {
+  return {
+    model,
+    mode: "tui",
+    hasUI: true,
+    ui: {
+      notify(message, type) {
+        notifications.push({ message, type });
+      },
+      async select(title, options) {
+        return select?.(title, options);
       },
     },
   };
@@ -179,7 +200,7 @@ async function runCursorTool(tools, name, params = {}, ctx = {}) {
 }
 
 async function verifyCursorToolShims(loadResult) {
-  const { tools, getActiveTools, setActiveTools } = loadResult;
+  const { commands, tools } = loadResult;
   for (const name of ["Read", "Write", "StrReplace", "Edit", "Delete", "LS", "Grep", "Glob", "Shell", "WebSearch"]) {
     assert.ok(tools.has(name), `${name} Cursor/Grok CLI shim should be registered`);
   }
@@ -190,7 +211,7 @@ async function verifyCursorToolShims(loadResult) {
   assert.match(disabledWebSearchResult.content[0].text, /WebSearch is disabled/);
   assert.equal(requests.length, beforeDisabledWebSearch, "inactive Cursor WebSearch must fail before network access");
 
-  setActiveTools([...getActiveTools(), "WebSearch"]);
+  await commands.get("xai-tools").handler("enable WebSearch", extensionCommandContext(composerModel));
   const beforeWebSearch = requests.length;
   const webSearchResult = await runCursorTool(tools, "WebSearch", { query: "xAI docs" }, authContext(composerModel));
   assert.equal(webSearchResult.content[0].text, "OK");
@@ -392,8 +413,10 @@ async function verifyXaiSearchToolActivation(loadResult) {
 
   setActiveTools([...getActiveTools(), ...searchTools]);
   await handlers.get("before_agent_start")?.({}, { model: TEST_XAI_MODEL });
-  assert.ok(customSearchTools.every((name) => getActiveTools().includes(name)), "explicitly enabled xAI search tools should stay active for xAI models");
-  assert.ok(!getActiveTools().includes("WebSearch"), "Cursor WebSearch must remain disabled for non-CLI xAI models");
+  assert.ok(
+    searchTools.every((name) => !getActiveTools().includes(name)),
+    "direct registry additions must not bypass package-owned paid-tool opt-in",
+  );
 
   await handlers.get("model_select")?.({ model: anthropicModel }, { model: anthropicModel });
   assert.ok(searchTools.every((name) => !getActiveTools().includes(name)), "switching away from xAI must disable paid search tools immediately");
@@ -415,6 +438,88 @@ async function verifyXaiSearchToolActivation(loadResult) {
   assert.equal(requests.length, requestsBeforeGuards, "non-xAI search-tool guards must run before auth or network access");
 
   setActiveTools(getActiveTools().filter((name) => name !== "WebSearch"));
+}
+
+async function verifyXaiToolsCommand(loadResult) {
+  const { commands, handlers, getActiveTools, setToolRegistryFailures } = loadResult;
+  const command = commands.get("xai-tools");
+  assert.ok(command, "the package should register /xai-tools");
+
+  const notifications = [];
+  const runCommand = (args, model, select) => command.handler(args, extensionCommandContext(model, notifications, select));
+  const searchTools = ["xai_web_search", "xai_x_search", "xai_multi_agent", "xai_deep_research", "WebSearch"];
+
+  await handlers.get("session_start")?.({}, { model: TEST_XAI_MODEL });
+  assert.ok(searchTools.every((name) => !getActiveTools().includes(name)));
+
+  await runCommand("enable xai_web_search", TEST_XAI_MODEL);
+  assert.ok(getActiveTools().includes("xai_web_search"), "/xai-tools should explicitly enable an eligible tool");
+  assert.match(notifications.at(-1).message, /may use xAI credits/);
+  await handlers.get("before_agent_start")?.({}, { model: TEST_XAI_MODEL });
+  assert.ok(getActiveTools().includes("xai_web_search"), "before-agent sync should preserve command-based opt-in");
+
+  await runCommand("disable xai_web_search", TEST_XAI_MODEL);
+  assert.ok(!getActiveTools().includes("xai_web_search"), "/xai-tools should disable an enabled tool");
+
+  await runCommand("enable WebSearch", TEST_XAI_MODEL);
+  assert.ok(!getActiveTools().includes("WebSearch"), "standard xAI models must not enable the Grok CLI WebSearch shim");
+  assert.match(notifications.at(-1).message, /only with xAI Grok Build or Composer/);
+
+  const composerModel = { ...TEST_XAI_MODEL, id: "grok-composer-2.5-fast" };
+  await handlers.get("model_select")?.({ model: composerModel }, { model: composerModel });
+  await runCommand("enable WebSearch", composerModel);
+  assert.ok(getActiveTools().includes("WebSearch"), "Grok CLI models should allow deliberate WebSearch enablement");
+  await handlers.get("before_agent_start")?.({}, { model: composerModel });
+  assert.ok(getActiveTools().includes("WebSearch"), "Grok CLI sync should preserve command-based WebSearch opt-in");
+
+  const anthropicModel = { provider: "anthropic", id: "claude-opus-4-8" };
+  await handlers.get("model_select")?.({ model: anthropicModel }, { model: anthropicModel });
+  await runCommand("enable xai_x_search", anthropicModel);
+  assert.ok(!getActiveTools().includes("xai_x_search"), "non-xAI models must not enable paid xAI tools");
+  assert.match(notifications.at(-1).message, /Select an xAI\/Grok model/);
+
+  await handlers.get("model_select")?.({ model: TEST_XAI_MODEL }, { model: TEST_XAI_MODEL });
+  let pickerPass = 0;
+  await runCommand("", TEST_XAI_MODEL, (_title, options) => {
+    pickerPass += 1;
+    return pickerPass === 1
+      ? options.find((option) => option.includes("xai_web_search"))
+      : "Done";
+  });
+  assert.ok(getActiveTools().includes("xai_web_search"), "interactive /xai-tools should toggle the selected paid tool");
+
+  await runCommand("status", TEST_XAI_MODEL);
+  assert.match(notifications.at(-1).message, /xai_web_search=enabled/);
+
+  await runCommand("disable xai_web_search", TEST_XAI_MODEL);
+  setToolRegistryFailures({ get: true });
+  await runCommand("enable xai_web_search", TEST_XAI_MODEL);
+  setToolRegistryFailures();
+  assert.ok(!getActiveTools().includes("xai_web_search"), "registry read failures must keep command enablement fail-closed");
+  assert.match(notifications.at(-1).message, /could not be read/);
+  setToolRegistryFailures({ set: true });
+  await runCommand("enable xai_web_search", TEST_XAI_MODEL);
+  assert.ok(!getActiveTools().includes("xai_web_search"), "registry write failures must not partially enable a paid tool");
+  assert.match(notifications.at(-1).message, /could not be updated/);
+  setToolRegistryFailures();
+
+  loadResult.setActiveTools([...getActiveTools(), ...searchTools]);
+  setToolRegistryFailures({ set: true });
+  await handlers.get("session_start")?.({}, { model: TEST_XAI_MODEL });
+  setToolRegistryFailures();
+  assert.ok(searchTools.every((name) => getActiveTools().includes(name)), "the fixture should retain stale default-active tools after a failed reset");
+  await runCommand("enable xai_web_search", TEST_XAI_MODEL);
+  assert.ok(getActiveTools().includes("xai_web_search"), "the deliberately selected tool should be enabled after registry recovery");
+  assert.ok(
+    searchTools.filter((name) => name !== "xai_web_search").every((name) => !getActiveTools().includes(name)),
+    "enabling one tool after reset recovery must strip every stale unauthorized paid tool",
+  );
+  await handlers.get("before_agent_start")?.({}, { model: TEST_XAI_MODEL });
+  assert.deepStrictEqual(
+    searchTools.filter((name) => getActiveTools().includes(name)),
+    ["xai_web_search"],
+    "lifecycle sync must preserve only individually authorized paid tools",
+  );
 }
 
 function inlineImageUrls(value, urls = []) {
@@ -862,6 +967,8 @@ async function main() {
     const provider = providers.get("xai-auth");
     assert.ok(provider, "xai-auth provider should be registered");
     assert.equal(secondLoad.tools.size, tools.size, "extension reloads should register tools on the new pi API object");
+    assert.ok(firstLoad.commands.has("xai-tools"), "the xAI paid-tool command should be registered");
+    assert.equal(secondLoad.commands.size, firstLoad.commands.size, "extension reloads should register commands on the new pi API object");
     assert.equal(provider.api, "xai-responses");
     const grok45 = provider.models.find((model) => model.id === "grok-4.5");
     assert.ok(grok45, "grok-4.5 should be registered in the xAI model catalog");
@@ -879,6 +986,7 @@ async function main() {
     assert.ok(provider.models.some((model) => model.id === "grok-4.20-multi-agent-0309"));
 
     await verifyXaiSearchToolActivation(firstLoad);
+    await verifyXaiToolsCommand(firstLoad);
     await verifyXaiImageLifecycle();
     await verifyXaiImageCompaction();
 
@@ -935,13 +1043,12 @@ async function main() {
     assert.equal(headerValue(buildRequest.headers, "x-grok-model-override"), "grok-build");
     assert.ok(headerValue(buildRequest.headers, "x-grok-conv-id"), "Grok Build tool calls should include a Grok conversation id");
 
-    firstLoad.setActiveTools([
-      ...firstLoad.getActiveTools(),
-      "xai_web_search",
-      "xai_x_search",
-      "xai_multi_agent",
-      "xai_deep_research",
-    ]);
+    for (const toolName of ["xai_web_search", "xai_x_search", "xai_multi_agent", "xai_deep_research"]) {
+      await firstLoad.commands.get("xai-tools").handler(
+        `enable ${toolName}`,
+        extensionCommandContext(TEST_XAI_MODEL),
+      );
+    }
     const { body: webBody } = await runTool(tools, "xai_web_search", { query: "xAI docs" });
     assert.deepEqual(webBody.tools, [{ type: "web_search", enable_image_understanding: true }]);
     assert.equal(webBody.model, TEST_XAI_MODEL.id, "xai_web_search should use the active xAI model");


### PR DESCRIPTION
## Summary

- add a package-owned `/xai-tools` command with an interactive picker
- support explicit `status`, `enable`, and `disable` command arguments
- require an active eligible xAI model before enabling paid tools
- restrict the `WebSearch` shim to Grok Build and Composer models
- track authorization per paid tool and strip stale unauthorized tools
- update README guidance, tool descriptions, and runtime errors to point to the real command

## Root cause

The paid xAI search tools were deliberately disabled at session start, but the documented re-enable path used `/tools`. Core pi does not provide that command; it exists only as an optional example extension. A stock installation therefore had no working package-owned path to opt in.

## Impact

Users can now opt in to exactly one paid xAI search or research tool without installing another extension. The command displays a credit warning, keeps tools disabled by default, removes them when leaving xAI, and does not silently restore them when returning.

Per-tool authorization also keeps the system fail-closed if the active-tool registry is temporarily unavailable: recovery strips every stale paid tool except the one the user explicitly selected.

Closes #52

## Validation

- `npm test`
- `npm run typecheck`
- `git diff --check`
- `npm pack --dry-run`
- real pi 0.80.7 RPC registration, status, and enablement probes
- independent review, finding repair, and clean closure review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how paid, credit-consuming search tools are activated and guarded; behavior is fail-closed with broad regression tests, but mistakes could still block legitimate opt-in or leave stale tools active until sync runs.
> 
> **Overview**
> Fixes a broken opt-in path: paid xAI search tools were documented as enabled via pi’s `/tools`, but stock pi does not register that command (it lives only in an optional example extension).
> 
> This PR adds **`/xai-tools`** from `pi-xai-oauth`—an interactive paid-tool picker plus **`status`**, **`enable <tool>`**, and **`disable <tool>`**. Enablement requires an active `xai-auth` model; **`WebSearch`** is limited to Grok Build/Composer. Successful enables surface a credit warning.
> 
> **`model-scope.ts`** now tracks **per-tool explicit authorization** instead of treating “present in the active-tool registry” as opted in. **`isXaiSearchToolActive`** only returns true for tools the user enabled through the command; lifecycle sync **strips stale paid tools** from the registry (including after failed resets) unless individually authorized. Direct `setActiveTools` additions no longer bypass opt-in.
> 
> README, tool descriptions, and runtime errors are updated to reference **`/xai-tools`**. **`verify-extension.js`** gains command registration, eligibility, registry failure, and recovery coverage; search tool smoke tests enable tools via the command instead of raw registry mutation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e2a71e09c754a75b29721552e393c5352cc9338. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->