### PR TITLE
Guard all network-backed xAI tools

### DIFF
--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -1,17 +1,19 @@
 # Shared Agent Context
 
 **Project:** pi-xai-oauth
-**Branch:** feature/issue-52-xai-tools
+**Branch:** feature/issue-54-paid-xai-tools
 **Date:** 2026-07-15
 
 ## Key Context
-- This project provides xAI OAuth + Grok 4.5 and related Grok models for pi agents.
-- Use subagent tool for delegation.
-- Persistent state lives in .scaffold/.
+- GitHub #54 reported that `xai_generate_image` was paid, active by default, absent from `/xai-tools`, and unguarded.
+- The audit found the same boundary defect in `xai_generate_text`, `xai_code_execution`, `xai_analyze_image`, and `xai_critique`.
+- Every helper that sends an additional xAI request is now a session-scoped explicit opt-in.
+- Local filesystem and shell compatibility shims remain automatic for eligible Grok CLI models because they do not make an extra xAI request.
+- `WebSearch` remains opt-in and is eligible only for Grok Build/Composer models.
+- Disabled tools must fail before OAuth credential resolution or network access.
 
 ## Current Focus
-- GitHub #52: provide a package-owned `/xai-tools` command because core pi does not ship the optional `/tools` example.
-- Paid search tools remain session-scoped explicit opt-ins and fail closed outside active eligible `xai-auth` models.
-- Runtime messages and README instructions must point only to the command this package actually registers.
+- Implementation and verification are complete; the branch is ready for commit or PR publication.
+- Preserve the unrelated untracked pi session HTML export.
 
-See plan.md for active phases and progress.md for completed verification.
+See plan.md for the active phases and progress.md for completed work.

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,29 +1,31 @@
-# Implementation Plan: GitHub Issue #52
+# Implementation Plan: GitHub Issue #54
 
-**Branch:** feature/issue-52-xai-tools
+**Branch:** feature/issue-54-paid-xai-tools
 
 **Date:** 2026-07-15
 
-**Goal:** Give users a package-owned, fail-closed way to opt in to paid xAI search tools without depending on pi's optional `/tools` example extension.
+**Goal:** Make image generation and every other network-backed xAI helper a model-scoped explicit opt-in, with one package-owned activation policy and fail-closed execution guards.
 
-## Phase 1: Reproduce and verify
-- [x] Read issue #52 and confirm there are no follow-up comments.
-- [x] Verify that core pi 0.80.7 does not register `/tools`; it ships only as an optional example extension.
-- [x] Inspect the active-tool registry, command UI API, existing model scope, docs, and verification harness.
+## Phase 1: Audit and policy
+- [x] Read issue #54 and audit every registered custom xAI and Cursor/Grok CLI tool.
 - [x] Run clean baseline tests and TypeScript validation.
+- [x] Independently confirm the policy boundary: extra xAI requests require opt-in; local shims remain automatic.
 
-## Phase 2: Package-owned opt-in command
-- [x] Register `/xai-tools` from `pi-xai-oauth`.
-- [x] Provide an interactive paid-tool picker plus explicit `enable`, `disable`, and `status` arguments.
-- [x] Require an active xAI model for enablement and restrict `WebSearch` to Grok Build/Composer models.
-- [x] Preserve session-start reset, non-xAI model cleanup, and fail-closed registry behavior.
+## Phase 2: Activation boundary
+- [x] Expand the package-owned catalog to all ten network-backed xAI tools.
+- [x] Require an active eligible xAI model plus per-tool package authorization.
+- [x] Guard every custom executor before OAuth credential lookup or network access.
+- [x] Reset authorization on session start and when leaving xAI; never silently restore it.
+- [x] Keep `WebSearch` restricted to Grok Build/Composer models.
 
-## Phase 3: Documentation and verification
-- [x] Replace every misleading core `/tools` reference with the package-owned command.
-- [x] Add regression coverage for command registration, eligibility, toggling, lifecycle persistence, and registry failures.
-- [x] Run `npm test`, `npm run typecheck`, `git diff --check`, and `npm pack --dry-run`.
-- [x] Smoke-test the command through pi's real extension loader.
+## Phase 3: UX, documentation, and verification
+- [x] Add category and cost-risk context to `/xai-tools`.
+- [x] Add explicit-user-intent guidance, especially for `xai_generate_image`.
+- [x] Document the activation policy for every tool and distinguish automatic local shims.
+- [x] Add catalog-completeness, no-auth/no-network, lifecycle, command, and image-generation regressions.
+- [x] Run final tests, package checks, and a real pi loader/RPC smoke.
+- [x] Complete independent diff review with no findings.
 
 **Owner:** Main agent
 
-**Next action:** Hand off the completed worktree for commit or PR publication.
+**Next action:** Hand off the completed branch for commit or PR publication.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,7 +1,7 @@
 # Execution Progress
 
 **Project:** pi-xai-oauth Repair + Tool Verification  
-**Branch:** feature/issue-19-api-guard
+**Branch:** feature/issue-54-paid-xai-tools
 **Started:** 2026-05-27
 
 ## Completed
@@ -221,4 +221,17 @@ Update this file frequently during execution.
 - [x] Focused closure review reported no findings.
 - [x] Final validation passed: `npm test`, `npm run typecheck`, `git diff --check`, `npm pack --dry-run`, and real pi 0.80.7 RPC command probes.
 
-**Current branch:** feature/issue-52-xai-tools
+**Branch:** feature/issue-52-xai-tools
+
+## Phase 21: Issue 54 all-network-tool opt-in policy
+- [x] Audited every custom xAI tool and separated outbound API helpers from local Cursor/Grok CLI shims.
+- [x] Generalized the package-owned activation catalog and lifecycle guard from search-only tools to all ten network-backed helpers.
+- [x] Added pre-auth execution guards and explicit-user-intent guidance to text generation, code execution, image generation, critique, and image analysis.
+- [x] Expanded `/xai-tools` with category and cost-risk context, including `xai_generate_image`.
+- [x] Documented that normal xAI chat and local shims remain available without enabling outbound helpers.
+- [x] Added regression coverage for catalog completeness, default inactivity, credential/network fail-closed behavior, image opt-in, model switching, session reset, registry recovery, and command UX.
+- [x] Passed `npm test`, `npm run typecheck`, `git diff --check`, and `npm pack --dry-run`.
+- [x] Verified through pi's real extension loader/RPC mode that `/xai-tools` registers and reports every network-backed tool disabled for a standard xAI model.
+- [x] Independent closure review reported no findings.
+
+**Current branch:** feature/issue-54-paid-xai-tools

--- a/README.md
+++ b/README.md
@@ -280,17 +280,32 @@ Composer 2.5 and Grok Build are trained against Cursor/Grok CLI-style tool names
 | `Shell` | `bash` |
 | `WebSearch` | xAI native web search |
 
-The shims also normalize common Cursor argument names, such as `file_path`, `contents`, `old_string` / `new_string`, `query`, `include`, `glob_filter`, and `cmd`. They are disabled again when you switch back to non-Grok-CLI models such as `grok-4.5` or `grok-4.3`.
+The local filesystem and shell shims also normalize common Cursor argument names, such as `file_path`, `contents`, `old_string` / `new_string`, `query`, `include`, `glob_filter`, and `cmd`. They are enabled automatically for eligible Grok CLI models and disabled again when you switch back to models such as `grok-4.5` or `grok-4.3`. `WebSearch` is the exception: it sends an additional xAI request, so it remains inactive until you enable it through `/xai-tools`.
 
 ---
 
 ## Custom Tools
 
-This package registers OAuth-backed custom tools that use the xAI API directly. They appear alongside your other agent tools in the pi TUI.
+This package registers OAuth-backed custom tools that make additional xAI API requests. They appear alongside your other agent tools in the pi TUI, but all of them are **inactive by default**.
 
-**How to use them:** Select an `xai-auth` model, then call the tool by name in your prompt or agent workflow. The tools use your authenticated xAI session.
+This opt-in boundary applies only to the extra tools below. Normal conversation with the selected `xai-auth` model works without enabling any of them.
 
-The paid server-side search tools — `xai_web_search`, `xai_x_search`, `xai_multi_agent`, `xai_deep_research`, and the Grok Build/Composer-compatible `WebSearch` shim — are deliberately **inactive by default**. This package provides `/xai-tools` so you can explicitly enable only the tool you want, then request it by name in your prompt. Switching to a non-xAI model disables all five immediately; switching back does not silently re-enable them.
+| Tool | Category | Additional usage / cost risk |
+|------|----------|------------------------------|
+| `xai_generate_text` | Generation | Separate model-token usage |
+| `xai_web_search` | Search | Model tokens plus native tool usage |
+| `xai_x_search` | Search | Model tokens plus native tool usage |
+| `xai_multi_agent` | Research | High/variable: 4 or 16 agents plus web/X tools |
+| `xai_deep_research` | Research | High/variable model and web/X tool usage |
+| `xai_code_execution` | Execution | Model tokens plus code-interpreter usage |
+| `xai_generate_image` | Image generation | Charged per generated image; supports 1-4 images |
+| `xai_analyze_image` | Vision | Separate model-token and image-input usage |
+| `xai_critique` | Reasoning | Separate high-reasoning model-token usage |
+| `WebSearch` | Search | Grok Build/Composer model tokens plus native tool usage |
+
+**How to use them:** Select an `xai-auth` model, enable only the tool you want through `/xai-tools`, then explicitly request that tool in your prompt or agent workflow. Enabling a tool makes it available; it is not permission for the model to call it without user intent.
+
+Every new session resets all network-backed tools to inactive. Switching to a non-xAI model disables them immediately, and switching back does not restore them. The Grok CLI local filesystem and shell shims are automatic because they do not create a separate xAI API request.
 
 In the pi TUI, select an `xai-auth` model and run:
 
@@ -298,12 +313,13 @@ In the pi TUI, select an `xai-auth` model and run:
 /xai-tools
 ```
 
-The picker marks every entry as paid and applies changes only to the current xAI session. You can also manage one tool directly:
+The picker shows each tool's category and cost-risk context, warns that calls may use xAI credits, and applies changes only to the current xAI session. You can also manage one tool directly:
 
 ```text
 /xai-tools status
 /xai-tools enable xai_web_search
 /xai-tools disable xai_web_search
+/xai-tools enable xai_generate_image
 ```
 
 `WebSearch` appears in the picker only for Grok Build and Composer models. `/xai-tools` is owned by this package; it does not depend on pi's optional example `/tools` extension.
@@ -311,7 +327,7 @@ The picker marks every entry as paid and applies changes only to the current xAI
 > **Tip:** See the ⚠️ warning above about local vs published package conflicts.
 
 ### `xai_generate_text`
-Generate text with full reasoning and stateful conversations.
+Opt-in text generation with full reasoning and stateful conversations. Enable it through `/xai-tools` first.
 
 ```json
 {
@@ -351,7 +367,7 @@ Opt-in X (Twitter) search using xAI's native `x_search` tool and the active xAI 
 ```
 
 ### `xai_code_execution`
-Run Python-oriented analysis using xAI's native `code_interpreter` tool.
+Opt-in Python-oriented analysis using xAI's native `code_interpreter` tool. Enable it through `/xai-tools` first.
 
 ```json
 {
@@ -360,7 +376,7 @@ Run Python-oriented analysis using xAI's native `code_interpreter` tool.
 ```
 
 ### `xai_generate_image`
-Generate images with xAI's current image generation model.
+Opt-in paid image generation with xAI's current image generation model. Enable it through `/xai-tools` first, and request it explicitly in your prompt.
 
 ```json
 {
@@ -370,7 +386,7 @@ Generate images with xAI's current image generation model.
 ```
 
 ### `xai_analyze_image`
-Analyze an image URL, data URL, or local `.png` / `.jpg` path with Grok vision.
+Opt-in analysis of an image URL, data URL, or local `.png` / `.jpg` path with Grok vision. Enable it through `/xai-tools` first.
 
 ```json
 {
@@ -380,7 +396,7 @@ Analyze an image URL, data URL, or local `.png` / `.jpg` path with Grok vision.
 ```
 
 ### `xai_critique`
-Get structured critique for code, designs, writing, or ideas.
+Opt-in structured critique for code, designs, writing, or ideas. Enable it through `/xai-tools` first.
 
 ```json
 {
@@ -399,7 +415,7 @@ Opt-in research using the active xAI model plus native web and X search tools. E
 }
 ```
 
-> **Note:** These tools use the xAI API under the hood. Search and research calls can consume paid credits or SuperGrok rate limits, which is why they require manual activation.
+> **Note:** Every tool in this section makes a separate xAI request and can consume credits or rate limits. Image generation is charged per generated image. See [xAI pricing](https://docs.x.ai/developers/pricing) for current rates.
 
 ---
 
@@ -416,7 +432,7 @@ Opt-in research using the active xAI model plus native web and X search tools. E
 | List packages | `pi list` |
 | Set default model | `/model grok-4.5` (in TUI) |
 | Set thinking level | `/think high` (in TUI) |
-| Manage paid xAI tools | `/xai-tools` (in TUI) |
+| Manage outbound xAI tools | `/xai-tools` (in TUI) |
 
 ---
 

--- a/extensions/xai-oauth.ts
+++ b/extensions/xai-oauth.ts
@@ -23,7 +23,7 @@ export default function (pi: ExtensionAPI) {
     // Active-tool accessors belong to the ExtensionAPI (`pi`), while models
     // are supplied by the event/context payload.
     (pi as any).on("session_start", (_event: any, ctx: any) =>
-      syncXaiToolsForModel(pi, ctx?.model, { resetSearchTools: true }),
+      syncXaiToolsForModel(pi, ctx?.model, { resetNetworkTools: true }),
     );
     (pi as any).on("model_select", (event: any, ctx: any) =>
       syncXaiToolsForModel(pi, event?.model ?? ctx?.model),

--- a/extensions/xai/tools/commands.ts
+++ b/extensions/xai/tools/commands.ts
@@ -3,51 +3,58 @@ import type { Api, Model } from "@earendil-works/pi-ai";
 import { isGrokCliProxyModel } from "../models";
 import {
   activeXaiModel,
-  isXaiSearchToolActive,
-  setXaiSearchToolActive,
-  XAI_SEARCH_TOOL_NAMES,
-  type XaiSearchToolName,
+  isXaiNetworkToolActive,
+  setXaiNetworkToolActive,
+  XAI_NETWORK_TOOL_NAMES,
+  type XaiNetworkToolName,
 } from "./model-scope";
 
-interface PaidToolOption {
-  name: XaiSearchToolName;
+interface NetworkToolOption {
+  name: XaiNetworkToolName;
+  category: string;
+  costRisk: string;
   summary: string;
 }
 
-const PAID_TOOL_OPTIONS: readonly PaidToolOption[] = [
-  { name: "xai_web_search", summary: "native xAI web search" },
-  { name: "xai_x_search", summary: "native xAI X search" },
-  { name: "xai_multi_agent", summary: "multi-agent web/X research" },
-  { name: "xai_deep_research", summary: "deep web/X research" },
-  { name: "WebSearch", summary: "Grok Build/Composer native web search" },
+const NETWORK_TOOL_OPTIONS: readonly NetworkToolOption[] = [
+  { name: "xai_generate_text", category: "generation", costRisk: "token usage", summary: "separate Grok response" },
+  { name: "xai_web_search", category: "search", costRisk: "token + tool", summary: "native xAI web search" },
+  { name: "xai_x_search", category: "search", costRisk: "token + tool", summary: "native xAI X search" },
+  { name: "xai_multi_agent", category: "research", costRisk: "high/variable", summary: "4- or 16-agent web/X research" },
+  { name: "xai_deep_research", category: "research", costRisk: "high/variable", summary: "multi-step web/X research" },
+  { name: "xai_code_execution", category: "execution", costRisk: "token + tool", summary: "xAI code interpreter" },
+  { name: "xai_generate_image", category: "image", costRisk: "per image", summary: "generate 1-4 images" },
+  { name: "xai_analyze_image", category: "vision", costRisk: "token usage", summary: "analyze an image with Grok" },
+  { name: "xai_critique", category: "reasoning", costRisk: "token usage", summary: "separate high-reasoning critique" },
+  { name: "WebSearch", category: "search", costRisk: "token + tool", summary: "Grok Build/Composer native web search" },
 ];
 
 const XAI_TOOLS_USAGE =
   "Usage: /xai-tools [status | enable <tool> | disable <tool>]";
 
-function commandToolName(value: string | undefined): XaiSearchToolName | undefined {
+function commandToolName(value: string | undefined): XaiNetworkToolName | undefined {
   if (!value) return undefined;
   const normalized = value.toLowerCase();
-  return XAI_SEARCH_TOOL_NAMES.find((name) => name.toLowerCase() === normalized);
+  return XAI_NETWORK_TOOL_NAMES.find((name) => name.toLowerCase() === normalized);
 }
 
-function eligibleToolOptions(model: Model<Api>): readonly PaidToolOption[] {
-  return PAID_TOOL_OPTIONS.filter(
+function eligibleToolOptions(model: Model<Api>): readonly NetworkToolOption[] {
+  return NETWORK_TOOL_OPTIONS.filter(
     ({ name }) => name !== "WebSearch" || isGrokCliProxyModel(model.id),
   );
 }
 
 function activeToolStatus(pi: ExtensionAPI, model: Model<Api> | undefined): string {
-  return PAID_TOOL_OPTIONS.map(({ name }) => {
+  return NETWORK_TOOL_OPTIONS.map(({ name }) => {
     const unavailable = name === "WebSearch" && (!model || !isGrokCliProxyModel(model.id));
     if (unavailable) return `${name}=unavailable`;
-    return `${name}=${isXaiSearchToolActive(pi, name) ? "enabled" : "disabled"}`;
+    return `${name}=${isXaiNetworkToolActive(pi, name) ? "enabled" : "disabled"}`;
   }).join(", ");
 }
 
 function notifyUpdate(
   ctx: ExtensionCommandContext,
-  toolName: XaiSearchToolName,
+  toolName: XaiNetworkToolName,
   active: boolean,
   error?: string,
 ) {
@@ -74,34 +81,34 @@ async function showXaiToolPicker(
   }
 
   while (true) {
-    const labels = new Map<string, XaiSearchToolName>();
+    const labels = new Map<string, XaiNetworkToolName>();
     for (const option of eligibleToolOptions(model)) {
-      const active = isXaiSearchToolActive(pi, option.name);
+      const active = isXaiNetworkToolActive(pi, option.name);
       labels.set(
-        `${active ? "[x]" : "[ ]"} ${option.name} — ${option.summary}`,
+        `${active ? "[x]" : "[ ]"} ${option.name} — ${option.category}; ${option.costRisk}; ${option.summary}`,
         option.name,
       );
     }
     const done = "Done";
     const selected = await ctx.ui.select(
-      "xAI paid tools — explicit opt-in; enabled calls may use xAI credits",
+      "xAI API tools — explicit opt-in; enabled calls may use xAI credits",
       [...labels.keys(), done],
     );
     if (!selected || selected === done) return;
 
     const toolName = labels.get(selected);
     if (!toolName) continue;
-    const nextActive = !isXaiSearchToolActive(pi, toolName);
-    const result = setXaiSearchToolActive(pi, model, toolName, nextActive);
+    const nextActive = !isXaiNetworkToolActive(pi, toolName);
+    const result = setXaiNetworkToolActive(pi, model, toolName, nextActive);
     notifyUpdate(ctx, toolName, result.active, result.error);
     if (!result.ok) return;
   }
 }
 
-/** Register the package-owned command for explicitly managing paid xAI tools. */
+/** Register the package-owned command for explicitly managing network-backed xAI tools. */
 export function registerXaiToolsCommand(pi: ExtensionAPI) {
   pi.registerCommand("xai-tools", {
-    description: "Enable or disable paid xAI search tools for this session",
+    description: "Enable or disable network-backed xAI tools for this session",
     handler: async (args, ctx) => {
       const [action, rawToolName, ...extra] = args.trim().split(/\s+/).filter(Boolean);
       const model = activeXaiModel(ctx);
@@ -117,7 +124,7 @@ export function registerXaiToolsCommand(pi: ExtensionAPI) {
 
       if (action.toLowerCase() === "status" && !rawToolName) {
         ctx.ui.notify(
-          `xAI paid tools${model ? ` for ${model.id}` : " (no active xAI model)"}: ${activeToolStatus(pi, model)}`,
+          `xAI API tools${model ? ` for ${model.id}` : " (no active xAI model)"}: ${activeToolStatus(pi, model)}`,
           "info",
         );
         return;
@@ -134,7 +141,7 @@ export function registerXaiToolsCommand(pi: ExtensionAPI) {
         return;
       }
 
-      const result = setXaiSearchToolActive(
+      const result = setXaiNetworkToolActive(
         pi,
         model,
         toolName,

--- a/extensions/xai/tools/cursor-shims.ts
+++ b/extensions/xai/tools/cursor-shims.ts
@@ -17,7 +17,7 @@ import { isGrokCliProxyModel } from "../models";
 import { createXaiResponse } from "../responses";
 import { extractResponsesText, messageFromError, statusFromError } from "../text";
 import { xaiToolError } from "./common";
-import { isXaiSearchToolActive } from "./model-scope";
+import { isXaiNetworkToolActive } from "./model-scope";
 import {
   firstString,
   normalizeDeleteArgs,
@@ -545,7 +545,7 @@ export function registerCursorToolShims(pi: ExtensionAPI) {
         if (ctx?.model?.provider !== XAI_PROVIDER_ID || !isGrokCliProxyModel(ctx.model.id)) {
           return xaiToolError("Error: WebSearch requires an active xAI Grok Build or Composer model. No xAI request was sent.");
         }
-        if (!isXaiSearchToolActive(pi, "WebSearch")) {
+        if (!isXaiNetworkToolActive(pi, "WebSearch")) {
           return xaiToolError("Error: WebSearch is disabled. Run /xai-tools to enable it and request it explicitly. No xAI request was sent.");
         }
         const apiKey = await resolveXaiAuthToken(ctx);

--- a/extensions/xai/tools/custom-tools.ts
+++ b/extensions/xai/tools/custom-tools.ts
@@ -6,17 +6,15 @@ import { grokSupportsReasoningEffort, normalizedXaiModelId } from "../models";
 import { createXaiResponse, postXaiJson } from "../responses";
 import { extractResponsesText, messageFromError, statusFromError } from "../text";
 import { xaiTextInput, xaiToolError } from "./common";
-import { activeXaiModel, isXaiSearchToolActive, XAI_SEARCH_TOOL_NAMES } from "./model-scope";
+import { activeXaiModel, isXaiNetworkToolActive, type XaiNetworkToolName } from "./model-scope";
 
-type XaiSearchToolName = (typeof XAI_SEARCH_TOOL_NAMES)[number];
-
-function activeModelForSearchTool(pi: ExtensionAPI, ctx: any, toolName: XaiSearchToolName) {
+function activeModelForXaiTool(pi: ExtensionAPI, ctx: any, toolName: XaiNetworkToolName) {
   const model = activeXaiModel(ctx);
-  if (!model || !isXaiSearchToolActive(pi, toolName)) return undefined;
+  if (!model || !isXaiNetworkToolActive(pi, toolName)) return undefined;
   return model;
 }
 
-function searchToolDisabledError(toolName: XaiSearchToolName, details: Record<string, unknown> = {}) {
+function xaiToolDisabledError(toolName: XaiNetworkToolName, details: Record<string, unknown> = {}) {
   return xaiToolError(
     `Error: ${toolName} is disabled. Select an xAI/Grok model, run /xai-tools to enable ${toolName}, and request it explicitly. No xAI request was sent.`,
     { error: true, ...details },
@@ -28,7 +26,8 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
     pi.registerTool({
       name: "xai_generate_text",
       label: "xAI Generate Text",
-      description: "Generate text using Grok with full reasoning, structured output, and stateful conversations.",
+      description: "Opt-in text generation through a separate xAI API request. Enable via /xai-tools and call only when the user explicitly requests it.",
+      promptGuidelines: ["Call xai_generate_text only when the user explicitly requests a separate xAI text-generation request."],
       parameters: {
         type: "object",
         properties: {
@@ -47,6 +46,9 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
         required: ["prompt"],
       },
       execute: async (_toolCallId: string, params: any, _signal: any, _onUpdate: any, ctx: any) => {
+        if (!activeModelForXaiTool(pi, ctx, "xai_generate_text")) {
+          return xaiToolDisabledError("xai_generate_text", { prompt: params?.prompt });
+        }
         const apiKey = await resolveXaiAuthToken(ctx);
         if (!apiKey) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { reasoning: "", response_id: "" });
@@ -122,8 +124,8 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
         required: ["query"],
       },
       execute: async (_toolCallId: string, params: any, _signal: any, _onUpdate: any, ctx: any) => {
-        if (!activeModelForSearchTool(pi, ctx, "xai_multi_agent")) {
-          return searchToolDisabledError("xai_multi_agent", { query: params?.query });
+        if (!activeModelForXaiTool(pi, ctx, "xai_multi_agent")) {
+          return xaiToolDisabledError("xai_multi_agent", { query: params?.query });
         }
         const apiKey = await resolveXaiAuthToken(ctx);
         if (!apiKey) {
@@ -175,8 +177,8 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
         required: ["query"],
       },
       execute: async (_toolCallId: string, params: { query?: string }, _signal: any, _onUpdate: any, ctx: any) => {
-        const activeModel = activeModelForSearchTool(pi, ctx, "xai_web_search");
-        if (!activeModel) return searchToolDisabledError("xai_web_search", { query: params?.query });
+        const activeModel = activeModelForXaiTool(pi, ctx, "xai_web_search");
+        if (!activeModel) return xaiToolDisabledError("xai_web_search", { query: params?.query });
         const apiKey = await resolveXaiAuthToken(ctx);
         if (!apiKey) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { query: params?.query });
@@ -215,8 +217,8 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
         required: ["query"],
       },
       execute: async (_toolCallId: string, params: { query?: string; count?: number; since?: string; until?: string }, _signal: any, _onUpdate: any, ctx: any) => {
-        const activeModel = activeModelForSearchTool(pi, ctx, "xai_x_search");
-        if (!activeModel) return searchToolDisabledError("xai_x_search", { query: params?.query });
+        const activeModel = activeModelForXaiTool(pi, ctx, "xai_x_search");
+        if (!activeModel) return xaiToolDisabledError("xai_x_search", { query: params?.query });
         const apiKey = await resolveXaiAuthToken(ctx);
         if (!apiKey) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { query: params?.query });
@@ -259,13 +261,17 @@ Be specific and cite examples where helpful.`;
     pi.registerTool({
       name: "xai_code_execution",
       label: "xAI Code Execution",
-      description: "Execute or analyze Python code using xAI's native code interpreter tool.",
+      description: "Opt-in execution through xAI's native code interpreter. Enable via /xai-tools and call only when the user explicitly requests it.",
+      promptGuidelines: ["Call xai_code_execution only when the user explicitly requests xAI code execution."],
       parameters: {
         type: "object",
         properties: { code: { type: "string", description: "Python code to execute or analyze" } },
         required: ["code"],
       },
       execute: async (_toolCallId: string, params: { code?: string }, _signal: any, _onUpdate: any, ctx: any) => {
+        if (!activeModelForXaiTool(pi, ctx, "xai_code_execution")) {
+          return xaiToolDisabledError("xai_code_execution", { code: params?.code });
+        }
         const apiKey = await resolveXaiAuthToken(ctx);
         if (!apiKey) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { code: params?.code });
@@ -292,7 +298,8 @@ Be specific and cite examples where helpful.`;
     pi.registerTool({
       name: "xai_generate_image",
       label: "xAI Image Generation",
-      description: "Generate images using xAI's current image generation model.",
+      description: "Opt-in paid image generation through xAI. Enable via /xai-tools and call only when the user explicitly requests an image.",
+      promptGuidelines: ["Call xai_generate_image only when the user explicitly asks to generate an image with xAI."],
       parameters: {
         type: "object",
         properties: {
@@ -303,6 +310,9 @@ Be specific and cite examples where helpful.`;
         required: ["prompt"],
       },
       execute: async (_toolCallId: string, params: { prompt?: string; model?: string; size?: string; n?: number }, _signal: any, _onUpdate: any, ctx: any) => {
+        if (!activeModelForXaiTool(pi, ctx, "xai_generate_image")) {
+          return xaiToolDisabledError("xai_generate_image", { prompt: params?.prompt });
+        }
         if (params?.size !== undefined) {
           return xaiToolError("Error: The xAI image API does not support the 'size' parameter. Omit it from the request.", {
             error: true,
@@ -348,7 +358,8 @@ Be specific and cite examples where helpful.`;
     pi.registerTool({
       name: "xai_critique",
       label: "xAI Critique",
-      description: "Provide detailed, reasoned critique of code, designs, writing, ideas, or arguments with structured feedback.",
+      description: "Opt-in critique through a separate high-reasoning xAI API request. Enable via /xai-tools and call only when explicitly requested.",
+      promptGuidelines: ["Call xai_critique only when the user explicitly requests a separate xAI critique."],
       parameters: {
         type: "object",
         properties: {
@@ -359,6 +370,9 @@ Be specific and cite examples where helpful.`;
         required: ["content"],
       },
       execute: async (_toolCallId: string, params: { content?: string; aspect?: string; tone?: string }, _signal: any, _onUpdate: any, ctx: any) => {
+        if (!activeModelForXaiTool(pi, ctx, "xai_critique")) {
+          return xaiToolDisabledError("xai_critique", { content: params?.content });
+        }
         const apiKey = await resolveXaiAuthToken(ctx);
         if (!apiKey) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { content: params?.content });
@@ -381,7 +395,8 @@ Be specific and cite examples where helpful.`;
     pi.registerTool({
       name: "xai_analyze_image",
       label: "xAI Image Analysis",
-      description: "Analyze images, describe visual content, answer questions about images, or extract information using Grok's vision capabilities.",
+      description: "Opt-in image analysis through a separate xAI API request. Enable via /xai-tools and call only when explicitly requested.",
+      promptGuidelines: ["Call xai_analyze_image only when the user explicitly requests xAI image analysis."],
       parameters: {
         type: "object",
         properties: {
@@ -391,6 +406,9 @@ Be specific and cite examples where helpful.`;
         required: ["image"],
       },
       execute: async (_toolCallId: string, params: { image?: string; question?: string }, _signal: any, _onUpdate: any, ctx: any) => {
+        if (!activeModelForXaiTool(pi, ctx, "xai_analyze_image")) {
+          return xaiToolDisabledError("xai_analyze_image", { image: params?.image });
+        }
         const apiKey = await resolveXaiAuthToken(ctx);
         if (!apiKey) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { image: params?.image });
@@ -424,8 +442,8 @@ Be specific and cite examples where helpful.`;
         required: ["topic"],
       },
       execute: async (_toolCallId: string, params: { topic?: string; depth?: string }, _signal: any, _onUpdate: any, ctx: any) => {
-        const activeModel = activeModelForSearchTool(pi, ctx, "xai_deep_research");
-        if (!activeModel) return searchToolDisabledError("xai_deep_research", { topic: params?.topic });
+        const activeModel = activeModelForXaiTool(pi, ctx, "xai_deep_research");
+        if (!activeModel) return xaiToolDisabledError("xai_deep_research", { topic: params?.topic });
         const apiKey = await resolveXaiAuthToken(ctx);
         if (!apiKey) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { topic: params?.topic });

--- a/extensions/xai/tools/index.ts
+++ b/extensions/xai/tools/index.ts
@@ -3,7 +3,7 @@ import type { Api, Model } from "@earendil-works/pi-ai";
 import { registerXaiToolsCommand } from "./commands";
 import { registerCursorToolShims, syncCursorToolShimsForModel } from "./cursor-shims";
 import { registerCustomXaiTools } from "./custom-tools";
-import { syncXaiSearchToolsForModel } from "./model-scope";
+import { syncXaiNetworkToolsForModel } from "./model-scope";
 
 const xaiToolRegistrations = new WeakSet<object>();
 
@@ -18,7 +18,7 @@ export function registerXaiTools(pi: ExtensionAPI) {
 }
 
 /** Synchronize all model-scoped xAI tool availability without making network requests. */
-export function syncXaiToolsForModel(pi: ExtensionAPI, model?: Model<Api>, options?: { resetSearchTools?: boolean }) {
+export function syncXaiToolsForModel(pi: ExtensionAPI, model?: Model<Api>, options?: { resetNetworkTools?: boolean }) {
   syncCursorToolShimsForModel(pi, model);
-  syncXaiSearchToolsForModel(pi, model, { reset: options?.resetSearchTools });
+  syncXaiNetworkToolsForModel(pi, model, { reset: options?.resetNetworkTools });
 }

--- a/extensions/xai/tools/model-scope.ts
+++ b/extensions/xai/tools/model-scope.ts
@@ -3,33 +3,38 @@ import type { Api, Model } from "@earendil-works/pi-ai";
 import { XAI_PROVIDER_ID } from "../constants";
 import { isGrokCliProxyModel } from "../models";
 
-/** Paid xAI tools that invoke xAI's server-side web or X search. */
-export const XAI_SEARCH_TOOL_NAMES = [
+/** Network-backed xAI tools that make an additional authenticated API request. */
+export const XAI_NETWORK_TOOL_NAMES = [
+  "xai_generate_text",
   "xai_web_search",
   "xai_x_search",
   "xai_multi_agent",
   "xai_deep_research",
+  "xai_code_execution",
+  "xai_generate_image",
+  "xai_analyze_image",
+  "xai_critique",
   "WebSearch",
 ] as const;
 
-export type XaiSearchToolName = (typeof XAI_SEARCH_TOOL_NAMES)[number];
+export type XaiNetworkToolName = (typeof XAI_NETWORK_TOOL_NAMES)[number];
 
-export interface XaiSearchToolUpdateResult {
+export interface XaiNetworkToolUpdateResult {
   ok: boolean;
   active: boolean;
   error?: string;
 }
 
-const explicitlyEnabledXaiSearchTools = new WeakMap<object, Set<XaiSearchToolName>>();
-const xaiSearchToolNameSet = new Set<string>(XAI_SEARCH_TOOL_NAMES);
+const explicitlyEnabledXaiNetworkTools = new WeakMap<object, Set<XaiNetworkToolName>>();
+const xaiNetworkToolNameSet = new Set<string>(XAI_NETWORK_TOOL_NAMES);
 
-function activeToolsWithExplicitSearchSelection(
+function activeToolsWithExplicitNetworkSelection(
   activeTools: readonly string[],
-  enabledSearchTools: ReadonlySet<XaiSearchToolName>,
+  enabledNetworkTools: ReadonlySet<XaiNetworkToolName>,
 ): string[] {
   return [
-    ...activeTools.filter((name) => !xaiSearchToolNameSet.has(name)),
-    ...XAI_SEARCH_TOOL_NAMES.filter((name) => enabledSearchTools.has(name)),
+    ...activeTools.filter((name) => !xaiNetworkToolNameSet.has(name)),
+    ...XAI_NETWORK_TOOL_NAMES.filter((name) => enabledNetworkTools.has(name)),
   ];
 }
 
@@ -40,11 +45,11 @@ export function activeXaiModel(ctx: Pick<ExtensionContext, "model"> | undefined)
   return model as Model<Api>;
 }
 
-/** Return whether a paid search tool is deliberately active in pi's current tool set. */
-export function isXaiSearchToolActive(api: any, toolName: XaiSearchToolName): boolean {
+/** Return whether a network-backed xAI tool is deliberately active in pi's current tool set. */
+export function isXaiNetworkToolActive(api: any, toolName: XaiNetworkToolName): boolean {
   if (typeof api?.getActiveTools !== "function") return false;
   try {
-    if (!explicitlyEnabledXaiSearchTools.get(api as object)?.has(toolName)) return false;
+    if (!explicitlyEnabledXaiNetworkTools.get(api as object)?.has(toolName)) return false;
     const activeTools = api.getActiveTools();
     return Array.isArray(activeTools) && activeTools.includes(toolName);
   } catch {
@@ -52,19 +57,19 @@ export function isXaiSearchToolActive(api: any, toolName: XaiSearchToolName): bo
   }
 }
 
-/** Deliberately enable or disable one paid xAI search tool for the current model scope. */
-export function setXaiSearchToolActive(
+/** Deliberately enable or disable one network-backed xAI tool for the current model scope. */
+export function setXaiNetworkToolActive(
   api: any,
   model: Model<Api> | undefined,
-  toolName: XaiSearchToolName,
+  toolName: XaiNetworkToolName,
   active: boolean,
-): XaiSearchToolUpdateResult {
+): XaiNetworkToolUpdateResult {
   const xaiModel = activeXaiModel(model ? { model } : undefined);
   if (active && !xaiModel) {
     return {
       ok: false,
       active: false,
-      error: "Select an xAI/Grok model before enabling a paid xAI search tool.",
+      error: "Select an xAI/Grok model before enabling a network-backed xAI tool.",
     };
   }
   if (active && toolName === "WebSearch" && !isGrokCliProxyModel(xaiModel!.id)) {
@@ -83,8 +88,8 @@ export function setXaiSearchToolActive(
   }
 
   const scope = api as object;
-  const previousSelection = new Set(explicitlyEnabledXaiSearchTools.get(scope) ?? []);
-  const nextSelection = xaiModel ? new Set(previousSelection) : new Set<XaiSearchToolName>();
+  const previousSelection = new Set(explicitlyEnabledXaiNetworkTools.get(scope) ?? []);
+  const nextSelection = xaiModel ? new Set(previousSelection) : new Set<XaiNetworkToolName>();
   if (xaiModel && !isGrokCliProxyModel(xaiModel.id)) nextSelection.delete("WebSearch");
   if (active) nextSelection.add(toolName);
   else nextSelection.delete(toolName);
@@ -102,13 +107,13 @@ export function setXaiSearchToolActive(
     };
   }
 
-  const nextTools = activeToolsWithExplicitSearchSelection(activeTools, nextSelection);
+  const nextTools = activeToolsWithExplicitNetworkSelection(activeTools, nextSelection);
   try {
     const unchanged = nextTools.length === activeTools.length
       && nextTools.every((name, index) => name === activeTools[index]);
     if (!unchanged) api.setActiveTools(nextTools);
-    if (xaiModel) explicitlyEnabledXaiSearchTools.set(scope, nextSelection);
-    else explicitlyEnabledXaiSearchTools.delete(scope);
+    if (xaiModel) explicitlyEnabledXaiNetworkTools.set(scope, nextSelection);
+    else explicitlyEnabledXaiNetworkTools.delete(scope);
     return { ok: true, active };
   } catch {
     return {
@@ -120,25 +125,25 @@ export function setXaiSearchToolActive(
 }
 
 /**
- * Keep paid xAI search tools opt-in and remove them immediately outside xAI models.
+ * Keep network-backed xAI tools opt-in and remove them immediately outside xAI models.
  *
  * A session start resets them even for xAI models so installing or reloading the
  * extension cannot silently expose a credit-gated tool. Users can deliberately
  * enable an individual tool through this package's `/xai-tools` command while
  * an xAI model is active.
  */
-export function syncXaiSearchToolsForModel(api: any, model?: Model<Api>, options?: { reset?: boolean }) {
+export function syncXaiNetworkToolsForModel(api: any, model?: Model<Api>, options?: { reset?: boolean }) {
   if (typeof api?.getActiveTools !== "function" || typeof api?.setActiveTools !== "function") return;
   const scope = api as object;
   const xaiModel = activeXaiModel(model ? { model } : undefined);
-  let enabledSearchTools: Set<XaiSearchToolName>;
+  let enabledNetworkTools: Set<XaiNetworkToolName>;
   if (options?.reset || !xaiModel) {
-    explicitlyEnabledXaiSearchTools.delete(scope);
-    enabledSearchTools = new Set();
+    explicitlyEnabledXaiNetworkTools.delete(scope);
+    enabledNetworkTools = new Set();
   } else {
-    enabledSearchTools = new Set(explicitlyEnabledXaiSearchTools.get(scope) ?? []);
-    if (!isGrokCliProxyModel(xaiModel.id)) enabledSearchTools.delete("WebSearch");
-    explicitlyEnabledXaiSearchTools.set(scope, enabledSearchTools);
+    enabledNetworkTools = new Set(explicitlyEnabledXaiNetworkTools.get(scope) ?? []);
+    if (!isGrokCliProxyModel(xaiModel.id)) enabledNetworkTools.delete("WebSearch");
+    explicitlyEnabledXaiNetworkTools.set(scope, enabledNetworkTools);
   }
 
   let activeTools: string[];
@@ -149,7 +154,7 @@ export function syncXaiSearchToolsForModel(api: any, model?: Model<Api>, options
     return;
   }
 
-  const nextTools = activeToolsWithExplicitSearchSelection(activeTools, enabledSearchTools);
+  const nextTools = activeToolsWithExplicitNetworkSelection(activeTools, enabledNetworkTools);
   const unchanged = nextTools.length === activeTools.length
     && nextTools.every((name, index) => name === activeTools[index]);
   if (unchanged) return;

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -14,6 +14,7 @@ const { compactXaiInlineImages, MAX_XAI_INLINE_IMAGE_BASE64_BYTES } = jiti(
 );
 const { rewriteXaiResponsesPayload } = jiti(path.join(repoRoot, "extensions", "xai", "payload.ts"));
 const { createXaiResponse } = jiti(path.join(repoRoot, "extensions", "xai", "responses.ts"));
+const { XAI_NETWORK_TOOL_NAMES } = jiti(path.join(repoRoot, "extensions", "xai", "tools", "model-scope.ts"));
 const originalFetch = global.fetch;
 const requests = [];
 let nextXaiResponse;
@@ -27,6 +28,9 @@ const TEST_XAI_MODEL = {
   reasoning: true,
   input: ["text", "image"],
 };
+
+const XAI_NETWORK_TOOLS = [...XAI_NETWORK_TOOL_NAMES];
+const CUSTOM_XAI_NETWORK_TOOLS = XAI_NETWORK_TOOLS.filter((name) => name !== "WebSearch");
 
 function jsonResponse(body, init = {}) {
   return new Response(JSON.stringify(body), {
@@ -361,42 +365,45 @@ async function verifyCursorToolActivation(loadResult) {
   loadResult.setToolRegistryFailures();
 }
 
-async function verifyXaiSearchToolActivation(loadResult) {
+async function verifyXaiNetworkToolActivation(loadResult) {
   const { handlers, tools, getActiveTools, setActiveTools } = loadResult;
-  const customSearchTools = ["xai_web_search", "xai_x_search", "xai_multi_agent", "xai_deep_research"];
-  const searchTools = [...customSearchTools, "WebSearch"];
   const anthropicModel = { provider: "anthropic", id: "claude-opus-4-8" };
   const requestsBeforeLifecycle = requests.length;
 
-  assert.ok(searchTools.every((name) => getActiveTools().includes(name)), "pi activates newly registered extension tools by default");
+  assert.deepStrictEqual(
+    [...tools.keys()].filter((name) => name.startsWith("xai_")).sort(),
+    [...CUSTOM_XAI_NETWORK_TOOLS].sort(),
+    "every registered xai_* tool must be present in the network opt-in catalog",
+  );
+  assert.ok(XAI_NETWORK_TOOLS.every((name) => getActiveTools().includes(name)), "pi activates newly registered extension tools by default");
   await handlers.get("session_start")?.({}, { model: TEST_XAI_MODEL });
-  assert.ok(searchTools.every((name) => !getActiveTools().includes(name)), "session start must make paid xAI search tools opt-in");
+  assert.ok(XAI_NETWORK_TOOLS.every((name) => !getActiveTools().includes(name)), "session start must make every network-backed xAI tool opt-in");
 
   await handlers.get("model_select")?.({ model: TEST_XAI_MODEL }, { model: TEST_XAI_MODEL });
   assert.ok(
-    searchTools.every((name) => !getActiveTools().includes(name)),
-    "selecting an xAI model must not implicitly activate paid search tools",
+    XAI_NETWORK_TOOLS.every((name) => !getActiveTools().includes(name)),
+    "selecting an xAI model must not implicitly activate network-backed tools",
   );
   assert.equal(requests.length, requestsBeforeLifecycle, "session/model lifecycle hooks must never send an xAI request");
 
-  setActiveTools([...getActiveTools(), ...searchTools]);
+  setActiveTools([...getActiveTools(), ...XAI_NETWORK_TOOLS]);
   loadResult.setToolRegistryFailures({ get: true });
   await assert.doesNotReject(
     async () => handlers.get("session_start")?.({}, { model: TEST_XAI_MODEL }),
-    "search-tool reset should tolerate an unavailable registry",
+    "network-tool reset should tolerate an unavailable registry",
   );
   loadResult.setToolRegistryFailures();
   await handlers.get("before_agent_start")?.({}, { model: TEST_XAI_MODEL });
-  assert.ok(searchTools.every((name) => !getActiveTools().includes(name)), "before_agent_start should retry a failed registry read");
+  assert.ok(XAI_NETWORK_TOOLS.every((name) => !getActiveTools().includes(name)), "before_agent_start should retry a failed registry read");
 
-  setActiveTools([...getActiveTools(), ...searchTools]);
+  setActiveTools([...getActiveTools(), ...XAI_NETWORK_TOOLS]);
   loadResult.setToolRegistryFailures({ set: true });
   await handlers.get("session_start")?.({}, { model: TEST_XAI_MODEL });
   await handlers.get("before_agent_start")?.({}, { model: TEST_XAI_MODEL });
   const requestsBeforePersistentSetFailure = requests.length;
-  const persistentFailureResult = await tools.get("xai_web_search").execute(
+  const persistentFailureResult = await tools.get("xai_generate_image").execute(
     "call_persistent_registry_failure",
-    { query: "must fail closed" },
+    { prompt: "must fail closed" },
     undefined,
     () => {},
     authContext(TEST_XAI_MODEL),
@@ -405,52 +412,92 @@ async function verifyXaiSearchToolActivation(loadResult) {
   assert.equal(
     requests.length,
     requestsBeforePersistentSetFailure,
-    "persistent registry write failures must keep paid search tools fail-closed",
+    "persistent registry write failures must keep network-backed tools fail-closed",
   );
   loadResult.setToolRegistryFailures();
   await handlers.get("before_agent_start")?.({}, { model: TEST_XAI_MODEL });
-  assert.ok(searchTools.every((name) => !getActiveTools().includes(name)), "before_agent_start should retry a failed registry write");
+  assert.ok(XAI_NETWORK_TOOLS.every((name) => !getActiveTools().includes(name)), "before_agent_start should retry a failed registry write");
 
-  setActiveTools([...getActiveTools(), ...searchTools]);
+  setActiveTools([...getActiveTools(), ...XAI_NETWORK_TOOLS]);
   await handlers.get("before_agent_start")?.({}, { model: TEST_XAI_MODEL });
   assert.ok(
-    searchTools.every((name) => !getActiveTools().includes(name)),
-    "direct registry additions must not bypass package-owned paid-tool opt-in",
+    XAI_NETWORK_TOOLS.every((name) => !getActiveTools().includes(name)),
+    "direct registry additions must not bypass package-owned network-tool opt-in",
   );
 
   await handlers.get("model_select")?.({ model: anthropicModel }, { model: anthropicModel });
-  assert.ok(searchTools.every((name) => !getActiveTools().includes(name)), "switching away from xAI must disable paid search tools immediately");
+  assert.ok(XAI_NETWORK_TOOLS.every((name) => !getActiveTools().includes(name)), "switching away from xAI must disable network-backed tools immediately");
   await handlers.get("model_select")?.({ model: TEST_XAI_MODEL }, { model: TEST_XAI_MODEL });
-  assert.ok(searchTools.every((name) => !getActiveTools().includes(name)), "switching back to xAI must not silently restore paid search tools");
+  assert.ok(XAI_NETWORK_TOOLS.every((name) => !getActiveTools().includes(name)), "switching back to xAI must not silently restore network-backed tools");
 
-  setActiveTools([...getActiveTools(), ...searchTools]);
+  setActiveTools([...getActiveTools(), ...XAI_NETWORK_TOOLS]);
   const guardedCalls = {
+    xai_generate_text: { prompt: "guard test" },
     xai_web_search: { query: "guard test" },
     xai_x_search: { query: "guard test" },
     xai_multi_agent: { query: "guard test" },
     xai_deep_research: { topic: "guard test" },
+    xai_code_execution: { code: "print('guard test')" },
+    xai_generate_image: { prompt: "guard test" },
+    xai_analyze_image: { image: "https://example.test/guard.png" },
+    xai_critique: { content: "guard test" },
   };
   const requestsBeforeGuards = requests.length;
+  let registryTouches = 0;
+  const guardedContext = {
+    model: TEST_XAI_MODEL,
+    modelRegistry: {
+      find() {
+        registryTouches += 1;
+        throw new Error("disabled tools must not resolve OAuth credentials");
+      },
+    },
+  };
   for (const [name, params] of Object.entries(guardedCalls)) {
-    const result = await tools.get(name).execute("call_guard", params, undefined, () => {}, authContext(anthropicModel));
-    assert.match(result.content[0].text, /is disabled/, `${name} should reject a stale non-xAI invocation`);
+    const result = await tools.get(name).execute("call_guard", params, undefined, () => {}, guardedContext);
+    assert.match(result.content[0].text, /is disabled/, `${name} should reject an unauthorized invocation`);
   }
-  assert.equal(requests.length, requestsBeforeGuards, "non-xAI search-tool guards must run before auth or network access");
+  assert.equal(registryTouches, 0, "disabled network tools must fail before OAuth credential lookup");
+  assert.equal(requests.length, requestsBeforeGuards, "disabled network-tool guards must run before network access");
 
   setActiveTools(getActiveTools().filter((name) => name !== "WebSearch"));
 }
 
 async function verifyXaiToolsCommand(loadResult) {
-  const { commands, handlers, getActiveTools, setToolRegistryFailures } = loadResult;
+  const { commands, handlers, tools, getActiveTools, setToolRegistryFailures } = loadResult;
   const command = commands.get("xai-tools");
   assert.ok(command, "the package should register /xai-tools");
 
   const notifications = [];
   const runCommand = (args, model, select) => command.handler(args, extensionCommandContext(model, notifications, select));
-  const searchTools = ["xai_web_search", "xai_x_search", "xai_multi_agent", "xai_deep_research", "WebSearch"];
 
   await handlers.get("session_start")?.({}, { model: TEST_XAI_MODEL });
-  assert.ok(searchTools.every((name) => !getActiveTools().includes(name)));
+  assert.ok(XAI_NETWORK_TOOLS.every((name) => !getActiveTools().includes(name)));
+
+  const imageTool = tools.get("xai_generate_image");
+  assert.ok(
+    imageTool.promptGuidelines.some((guideline) => /explicitly asks to generate an image/.test(guideline)),
+    "xai_generate_image must require explicit user intent",
+  );
+  await runCommand("enable xai_generate_image", TEST_XAI_MODEL);
+  assert.ok(getActiveTools().includes("xai_generate_image"), "/xai-tools should provide a real image-generation enable path");
+  assert.match(notifications.at(-1).message, /may use xAI credits/);
+  await handlers.get("before_agent_start")?.({}, { model: TEST_XAI_MODEL });
+  assert.ok(getActiveTools().includes("xai_generate_image"), "before-agent sync should preserve deliberate image-generation opt-in");
+
+  const anthropicModel = { provider: "anthropic", id: "claude-opus-4-8" };
+  await handlers.get("model_select")?.({ model: anthropicModel }, { model: anthropicModel });
+  assert.ok(!getActiveTools().includes("xai_generate_image"), "leaving xAI must disable image generation");
+  await handlers.get("model_select")?.({ model: TEST_XAI_MODEL }, { model: TEST_XAI_MODEL });
+  assert.ok(!getActiveTools().includes("xai_generate_image"), "returning to xAI must not restore image generation");
+
+  await runCommand("enable xai_generate_image", TEST_XAI_MODEL);
+  await handlers.get("session_start")?.({}, { model: TEST_XAI_MODEL });
+  assert.ok(!getActiveTools().includes("xai_generate_image"), "a new session must reset image-generation opt-in");
+
+  await runCommand("enable xai_generate_image", TEST_XAI_MODEL);
+  await runCommand("disable xai_generate_image", TEST_XAI_MODEL);
+  assert.ok(!getActiveTools().includes("xai_generate_image"), "/xai-tools should disable image generation");
 
   await runCommand("enable xai_web_search", TEST_XAI_MODEL);
   assert.ok(getActiveTools().includes("xai_web_search"), "/xai-tools should explicitly enable an eligible tool");
@@ -472,7 +519,6 @@ async function verifyXaiToolsCommand(loadResult) {
   await handlers.get("before_agent_start")?.({}, { model: composerModel });
   assert.ok(getActiveTools().includes("WebSearch"), "Grok CLI sync should preserve command-based WebSearch opt-in");
 
-  const anthropicModel = { provider: "anthropic", id: "claude-opus-4-8" };
   await handlers.get("model_select")?.({ model: anthropicModel }, { model: anthropicModel });
   await runCommand("enable xai_x_search", anthropicModel);
   assert.ok(!getActiveTools().includes("xai_x_search"), "non-xAI models must not enable paid xAI tools");
@@ -480,16 +526,33 @@ async function verifyXaiToolsCommand(loadResult) {
 
   await handlers.get("model_select")?.({ model: TEST_XAI_MODEL }, { model: TEST_XAI_MODEL });
   let pickerPass = 0;
-  await runCommand("", TEST_XAI_MODEL, (_title, options) => {
+  let pickerTitle = "";
+  let pickerOptions = [];
+  await runCommand("", TEST_XAI_MODEL, (title, options) => {
+    pickerTitle = title;
+    pickerOptions = options;
     pickerPass += 1;
     return pickerPass === 1
       ? options.find((option) => option.includes("xai_web_search"))
       : "Done";
   });
-  assert.ok(getActiveTools().includes("xai_web_search"), "interactive /xai-tools should toggle the selected paid tool");
+  assert.ok(getActiveTools().includes("xai_web_search"), "interactive /xai-tools should toggle the selected network tool");
+  assert.match(pickerTitle, /explicit opt-in/);
+  assert.ok(
+    pickerOptions.some((option) => option.includes("xai_generate_image") && option.includes("image") && option.includes("per image")),
+    "interactive /xai-tools should expose image generation with category and cost-risk context",
+  );
 
   await runCommand("status", TEST_XAI_MODEL);
   assert.match(notifications.at(-1).message, /xai_web_search=enabled/);
+  assert.match(notifications.at(-1).message, /xai_generate_image=disabled/);
+  for (const toolName of XAI_NETWORK_TOOLS) {
+    assert.match(
+      notifications.at(-1).message,
+      new RegExp(`${toolName}=(?:enabled|disabled|unavailable)`),
+      `/xai-tools status must include ${toolName}`,
+    );
+  }
 
   await runCommand("disable xai_web_search", TEST_XAI_MODEL);
   setToolRegistryFailures({ get: true });
@@ -503,22 +566,22 @@ async function verifyXaiToolsCommand(loadResult) {
   assert.match(notifications.at(-1).message, /could not be updated/);
   setToolRegistryFailures();
 
-  loadResult.setActiveTools([...getActiveTools(), ...searchTools]);
+  loadResult.setActiveTools([...getActiveTools(), ...XAI_NETWORK_TOOLS]);
   setToolRegistryFailures({ set: true });
   await handlers.get("session_start")?.({}, { model: TEST_XAI_MODEL });
   setToolRegistryFailures();
-  assert.ok(searchTools.every((name) => getActiveTools().includes(name)), "the fixture should retain stale default-active tools after a failed reset");
+  assert.ok(XAI_NETWORK_TOOLS.every((name) => getActiveTools().includes(name)), "the fixture should retain stale default-active tools after a failed reset");
   await runCommand("enable xai_web_search", TEST_XAI_MODEL);
   assert.ok(getActiveTools().includes("xai_web_search"), "the deliberately selected tool should be enabled after registry recovery");
   assert.ok(
-    searchTools.filter((name) => name !== "xai_web_search").every((name) => !getActiveTools().includes(name)),
-    "enabling one tool after reset recovery must strip every stale unauthorized paid tool",
+    XAI_NETWORK_TOOLS.filter((name) => name !== "xai_web_search").every((name) => !getActiveTools().includes(name)),
+    "enabling one tool after reset recovery must strip every stale unauthorized network tool",
   );
   await handlers.get("before_agent_start")?.({}, { model: TEST_XAI_MODEL });
   assert.deepStrictEqual(
-    searchTools.filter((name) => getActiveTools().includes(name)),
+    XAI_NETWORK_TOOLS.filter((name) => getActiveTools().includes(name)),
     ["xai_web_search"],
-    "lifecycle sync must preserve only individually authorized paid tools",
+    "lifecycle sync must preserve only individually authorized network tools",
   );
 }
 
@@ -985,7 +1048,7 @@ async function main() {
     assert.equal(provider.models.find((model) => model.id === "grok-4.20-0309-reasoning")?.contextWindow, 2_000_000);
     assert.ok(provider.models.some((model) => model.id === "grok-4.20-multi-agent-0309"));
 
-    await verifyXaiSearchToolActivation(firstLoad);
+    await verifyXaiNetworkToolActivation(firstLoad);
     await verifyXaiToolsCommand(firstLoad);
     await verifyXaiImageLifecycle();
     await verifyXaiImageCompaction();
@@ -1005,7 +1068,12 @@ async function main() {
     await verifyOAuthManualCallbackUrlState(provider);
     await verifyOAuthManualWrongStateIgnored(provider);
 
+    await firstLoad.commands.get("xai-tools").handler(
+      "enable xai_generate_text",
+      extensionCommandContext(TEST_XAI_MODEL),
+    );
     const noAuthResult = await tools.get("xai_generate_text").execute("call_noauth", { prompt: "hi" }, undefined, () => {}, {
+      model: TEST_XAI_MODEL,
       modelRegistry: {
         find: () => undefined,
       },
@@ -1043,7 +1111,7 @@ async function main() {
     assert.equal(headerValue(buildRequest.headers, "x-grok-model-override"), "grok-build");
     assert.ok(headerValue(buildRequest.headers, "x-grok-conv-id"), "Grok Build tool calls should include a Grok conversation id");
 
-    for (const toolName of ["xai_web_search", "xai_x_search", "xai_multi_agent", "xai_deep_research"]) {
+    for (const toolName of CUSTOM_XAI_NETWORK_TOOLS) {
       await firstLoad.commands.get("xai-tools").handler(
         `enable ${toolName}`,
         extensionCommandContext(TEST_XAI_MODEL),
@@ -1088,7 +1156,9 @@ async function main() {
     assert.equal(imageContent[0].type, "input_image");
     assert.equal(imageContent[1].type, "input_text");
 
+    const requestsBeforeImageGeneration = requests.length;
     const { body: imageGenBody } = await runTool(tools, "xai_generate_image", { prompt: "a crisp diagram" }, /Generated 1 image/);
+    assert.equal(requests.length, requestsBeforeImageGeneration + 1, "enabled image generation should send exactly one xAI request");
     assert.equal(imageGenBody.model, "grok-imagine-image-quality");
     const imageTool = tools.get("xai_generate_image");
     assert.equal(Object.hasOwn(imageGenBody, "size"), false, "image generation should not send unsupported size defaults");


### PR DESCRIPTION
## Summary

- expand `/xai-tools` from search-only controls to all ten network-backed xAI helpers
- require an active eligible xAI model and explicit per-tool activation before OAuth or network access
- keep image generation inactive by default and require explicit user intent
- reset tool authorization on new sessions and when leaving xAI without silently restoring it
- document tool categories, cost risk, and the automatic local-shim exception
- add catalog-completeness, fail-closed, lifecycle, command, and image-generation regression coverage

## Root cause

The activation catalog covered only search and research tools. `xai_generate_image` and several other helpers still became active when pi registered them, so they could resolve OAuth credentials and send additional xAI API requests without package-owned authorization.

## User impact

Extra xAI API helpers are now explicit session-scoped opt-ins. Normal conversation with an xAI model and local Grok CLI filesystem/shell shims continue to work without manual activation.

## Validation

- `npm test`
- `npm run typecheck`
- `git diff --check`
- `npm pack --dry-run`
- real pi extension-loader/RPC command and status smoke test
- independent closure review with no findings

Closes #54

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes billing-sensitive tool activation across the full custom xAI surface; behavior is fail-closed and heavily regression-tested, but users must re-enable helpers after each session.
> 
> **Overview**
> Extends the package-owned **opt-in policy** from search/research tools to **every helper that triggers an extra xAI API call** (ten tools including `xai_generate_image`, `xai_generate_text`, `xai_code_execution`, `xai_analyze_image`, and `xai_critique`).
> 
> **`/xai-tools`** now catalogs all network-backed tools with **category and cost-risk** labels; session start still **resets** authorization, and leaving an xAI model **strips** enabled tools without restoring them on return.
> 
> Each custom executor checks **package authorization before OAuth or network I/O**; disabled calls return a local error with **no credentials resolved and no request sent**. Tool descriptions add **`promptGuidelines`** so models should invoke paid helpers only on explicit user intent.
> 
> **Local Grok CLI filesystem/shell shims** stay automatic; only **`WebSearch`** among shims remains opt-in (Grok Build/Composer). README and **`verify-extension.js`** regressions cover catalog completeness, image opt-in lifecycle, and fail-closed guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93a68bb2c8d596f5930b50c52ac5042af4323856. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->