### PR TITLE
Prepare pi-xai-oauth 1.3.4 release

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,4 +13,4 @@ node_modules/
 *.key
 auth.json
 *.local
-
+pi-session-*.html

--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -1,7 +1,7 @@
 # Shared Agent Context
 
 **Project:** pi-xai-oauth
-**Branch:** feature/issue-54-paid-xai-tools
+**Branch:** feature/release-1.3.4
 **Date:** 2026-07-15
 
 ## Key Context
@@ -13,7 +13,8 @@
 - Disabled tools must fail before OAuth credential resolution or network access.
 
 ## Current Focus
-- Implementation and verification are complete; the branch is ready for commit or PR publication.
+- Prepare patch release 1.3.4 from merged PR #55.
+- Validate package metadata and tarball contents before any npm publication.
 - Preserve the unrelated untracked pi session HTML export.
 
 See plan.md for the active phases and progress.md for completed work.

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,31 +1,22 @@
-# Implementation Plan: GitHub Issue #54
+# Release Plan: pi-xai-oauth 1.3.4
 
-**Branch:** feature/issue-54-paid-xai-tools
+**Branch:** feature/release-1.3.4
 
 **Date:** 2026-07-15
 
-**Goal:** Make image generation and every other network-backed xAI helper a model-scoped explicit opt-in, with one package-owned activation policy and fail-closed execution guards.
+**Goal:** Prepare the merged issue #54 safety fix for npm as patch release 1.3.4.
 
-## Phase 1: Audit and policy
-- [x] Read issue #54 and audit every registered custom xAI and Cursor/Grok CLI tool.
-- [x] Run clean baseline tests and TypeScript validation.
-- [x] Independently confirm the policy boundary: extra xAI requests require opt-in; local shims remain automatic.
-
-## Phase 2: Activation boundary
-- [x] Expand the package-owned catalog to all ten network-backed xAI tools.
-- [x] Require an active eligible xAI model plus per-tool package authorization.
-- [x] Guard every custom executor before OAuth credential lookup or network access.
-- [x] Reset authorization on session start and when leaving xAI; never silently restore it.
-- [x] Keep `WebSearch` restricted to Grok Build/Composer models.
-
-## Phase 3: UX, documentation, and verification
-- [x] Add category and cost-risk context to `/xai-tools`.
-- [x] Add explicit-user-intent guidance, especially for `xai_generate_image`.
-- [x] Document the activation policy for every tool and distinguish automatic local shims.
-- [x] Add catalog-completeness, no-auth/no-network, lifecycle, command, and image-generation regressions.
-- [x] Run final tests, package checks, and a real pi loader/RPC smoke.
-- [x] Complete independent diff review with no findings.
+## Release preparation
+- [x] Sync local `main` with merged PR #55.
+- [x] Create a dedicated release branch.
+- [x] Bump `package.json` and `package-lock.json` from 1.3.3 to 1.3.4.
+- [x] Update README release and upgrade guidance.
+- [x] Exclude local `pi-session-*.html` exports from npm packages.
+- [x] Run tests, TypeScript validation, diff checks, and package inspection.
+- [x] Authenticate npm as `blockedredemption`.
+- [ ] Commit and publish the release branch when requested.
+- [ ] After the release PR is merged, publish `pi-xai-oauth@1.3.4` from synced `main`.
 
 **Owner:** Main agent
 
-**Next action:** Hand off the completed branch for commit or PR publication.
+**Next action:** Commit and open the release PR.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,7 +1,7 @@
 # Execution Progress
 
 **Project:** pi-xai-oauth Repair + Tool Verification  
-**Branch:** feature/issue-54-paid-xai-tools
+**Branch:** feature/release-1.3.4
 **Started:** 2026-05-27
 
 ## Completed
@@ -235,3 +235,17 @@ Update this file frequently during execution.
 - [x] Independent closure review reported no findings.
 
 **Current branch:** feature/issue-54-paid-xai-tools
+
+## Phase 22: npm patch release 1.3.4
+- [x] Synced merged PR #55 into local `main`.
+- [x] Created `feature/release-1.3.4`.
+- [x] Bumped package and lockfile versions to 1.3.4.
+- [x] Updated README release notes and npm upgrade guidance.
+- [x] Added a narrow npm exclusion so local pi session HTML exports cannot leak into releases.
+- [x] Passed `npm test`, `npm run typecheck`, `git diff --check`, and `npm pack --dry-run`.
+- [x] Confirmed the 1.3.4 tarball excludes the untracked session export.
+- [x] Confirmed npm currently serves 1.3.3.
+- [x] Confirmed npm authentication as `blockedredemption`.
+- [ ] Commit, push, and publish only when explicitly requested.
+
+**Current branch:** feature/release-1.3.4

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pi --model grok-4.5:low "Quick status check"   # fast mode
 
 This package adds **Grok 4.5** (default), **Grok 4.3**, **Grok Build**, and **Composer 2.5** as fully-integrated xAI OAuth models in pi, with proper OAuth login, automatic token refresh, and a suite of custom tools (`xai_generate_text`, `xai_web_search`, `xai_x_search`, etc.).
 
-> **Latest release:** `pi-xai-oauth` **1.3.3** fixes xAI Responses streaming under pi 0.80's extension loader and includes **Grok 4.5** as the default model (500K context, low/medium/high reasoning; fast mode = `low`). Existing npm installs should run `pi update npm:pi-xai-oauth`; local checkout installs should keep only one copy with `pi remove npm:pi-xai-oauth && pi install .`.
+> **Latest release:** `pi-xai-oauth` **1.3.4** makes every network-backed xAI helper an explicit, session-scoped opt-in through `/xai-tools`, including paid image generation. Disabled tools now fail before OAuth credential lookup or network access. This release also includes the 1.3.3 pi 0.80 Responses transport fix and **Grok 4.5** as the default model (500K context, low/medium/high reasoning; fast mode = `low`). Existing npm installs should run `pi update npm:pi-xai-oauth`; local checkout installs should keep only one copy with `pi remove npm:pi-xai-oauth && pi install .`.
 >
 > **Compatibility note:** 1.2.4+ supports pi 0.79.8+'s OpenAI Responses API guard for Grok/xAI streaming.
 
@@ -545,7 +545,7 @@ pi update npm:pi-xai-oauth
 
 This pulls the latest version from npm and updates your installed extension.
 
-pi 0.79.8+ enforces an OpenAI Responses API guard. `pi-xai-oauth` 1.2.4+ handles that guard for Grok/xAI streaming; **1.3.3** also fixes Responses transport resolution under pi 0.80's extension loader and includes Grok 4.5 as the default model. If you installed the published npm package, update with the command above. If you are testing a local checkout instead, reinstall the checkout:
+pi 0.79.8+ enforces an OpenAI Responses API guard. `pi-xai-oauth` 1.2.4+ handles that guard for Grok/xAI streaming; 1.3.3 fixes Responses transport resolution under pi 0.80's extension loader and includes Grok 4.5 as the default model. **1.3.4** additionally makes all network-backed xAI helpers explicit opt-ins through `/xai-tools`. If you installed the published npm package, update with the command above. If you are testing a local checkout instead, reinstall the checkout:
 
 ```bash
 pi remove npm:pi-xai-oauth && pi install .

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-xai-oauth",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-xai-oauth",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "MIT",
       "bin": {
         "pi-xai-oauth": "bin/setup.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-xai-oauth",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "One-command installer for xAI OAuth provider + Grok 4.5, Grok Build, and Composer models in pi",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
## Summary

- bump package and lockfile versions from 1.3.3 to 1.3.4
- document the all-network-tool opt-in safety changes merged in PR #55
- exclude local `pi-session-*.html` exports from npm tarballs
- update persistent release state for the 1.3.4 publication workflow

## Why

PR #55 changes every network-backed xAI helper, including image generation, to a fail-closed explicit opt-in. This patch release makes that fix available to npm users.

Package inspection also found that local pi session HTML exports could be included by npm when present in the working directory. The narrow `.npmignore` rule prevents those session files from leaking into releases.

## User impact

After 1.3.4 is published, users can update with:

```bash
pi update npm:pi-xai-oauth
```

Normal xAI chat and local Grok CLI filesystem/shell shims remain unaffected. Extra xAI API helpers require explicit activation through `/xai-tools`.

## Validation

- `npm test`
- `npm run typecheck`
- `git diff --check`
- `npm pack --dry-run`
- confirmed tarball version is 1.3.4
- confirmed local pi session HTML export is excluded
- confirmed npm authentication as `blockedredemption`
- confirmed npm currently serves 1.3.3

Publication will happen from synced `main` after this PR is merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata and packaging ignore only; no auth, tool execution, or provider logic changes.
> 
> **Overview**
> Prepares **patch release 1.3.4** on npm by bumping `package.json` and `package-lock.json` from **1.3.3** to **1.3.4**.
> 
> **README** now calls **1.3.4** the latest release and documents the merged PR #55 behavior: network-backed xAI helpers are session-scoped opt-ins via `/xai-tools`, with disabled tools failing before OAuth or network access. The Updating section notes that **1.3.4** adds that policy on top of the **1.3.3** pi 0.80 Responses transport fix.
> 
> Adds **`pi-session-*.html`** to **`.npmignore`** so local pi session HTML exports are not packaged in the tarball.
> 
> **`.scaffold/`** context, plan, and progress files are retargeted to the **1.3.4** release branch and publication checklist; no extension runtime code changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ffb3f50acdb786b04e2574f4b153724a2a32111. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->