### PR TITLE
Preserve xAI tool picker selection and prepare 1.3.5

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,4 @@ node_modules/
 auth.json
 *.local
 pi-session-*.html
+cat.svg

--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -1,7 +1,7 @@
 # Shared Agent Context
 
 **Project:** pi-xai-oauth
-**Branch:** feature/release-1.3.4
+**Branch:** feature/xai-tools-picker-focus
 **Date:** 2026-07-15
 
 ## Key Context
@@ -13,8 +13,8 @@
 - Disabled tools must fail before OAuth credential resolution or network access.
 
 ## Current Focus
-- Prepare patch release 1.3.4 from merged PR #55.
-- Validate package metadata and tarball contents before any npm publication.
+- Preserve cursor position inside the `/xai-tools` TUI after toggles.
+- Keep RPC selection and all activation safety semantics unchanged.
 - Preserve the unrelated untracked pi session HTML export.
 
 See plan.md for the active phases and progress.md for completed work.

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -19,6 +19,13 @@
 - [x] Run the extension test suite.
 - [x] Run final typecheck, diff checks, package inspection, and focused review.
 
+## Release preparation
+- [x] Bump `package.json` and `package-lock.json` to 1.3.5.
+- [x] Update README release and upgrade guidance.
+- [x] Exclude unrelated local artifacts from the npm tarball.
+- [x] Re-run tests, typecheck, diff checks, and package inspection for 1.3.5.
+- [ ] Push the release update to PR #57.
+
 **Owner:** Main agent
 
-**Next action:** Commit and open a PR when requested.
+**Next action:** Validate and push the 1.3.5 release update to PR #57.

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,22 +1,24 @@
-# Release Plan: pi-xai-oauth 1.3.4
+# Implementation Plan: Preserve /xai-tools Picker Focus
 
-**Branch:** feature/release-1.3.4
+**Branch:** feature/xai-tools-picker-focus
 
 **Date:** 2026-07-15
 
-**Goal:** Prepare the merged issue #54 safety fix for npm as patch release 1.3.4.
+**Goal:** Keep the highlighted `/xai-tools` row and scroll position stable after toggling a tool.
 
-## Release preparation
-- [x] Sync local `main` with merged PR #55.
-- [x] Create a dedicated release branch.
-- [x] Bump `package.json` and `package-lock.json` from 1.3.3 to 1.3.4.
-- [x] Update README release and upgrade guidance.
-- [x] Exclude local `pi-session-*.html` exports from npm packages.
-- [x] Run tests, TypeScript validation, diff checks, and package inspection.
-- [x] Authenticate npm as `blockedredemption`.
-- [ ] Commit and publish the release branch when requested.
-- [ ] After the release PR is merged, publish `pi-xai-oauth@1.3.4` from synced `main`.
+## Implementation
+- [x] Reproduce the cursor reset caused by reopening `ctx.ui.select()` after every toggle.
+- [x] Confirm pi's selector API has no supported initial-index option.
+- [x] Replace the TUI loop with one stateful custom component that toggles tools in place.
+- [x] Keep the existing selector fallback for RPC mode.
+- [x] Preserve model eligibility, per-tool authorization, credit warnings, and fail-closed updates.
+
+## Verification
+- [x] Add regression coverage proving the selected image-generation row remains highlighted after toggling.
+- [x] Preserve RPC picker coverage.
+- [x] Run the extension test suite.
+- [x] Run final typecheck, diff checks, package inspection, and focused review.
 
 **Owner:** Main agent
 
-**Next action:** Commit and open the release PR.
+**Next action:** Commit and open a PR when requested.

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -24,8 +24,8 @@
 - [x] Update README release and upgrade guidance.
 - [x] Exclude unrelated local artifacts from the npm tarball.
 - [x] Re-run tests, typecheck, diff checks, and package inspection for 1.3.5.
-- [ ] Push the release update to PR #57.
+- [x] Push the release update to PR #57.
 
 **Owner:** Main agent
 
-**Next action:** Validate and push the 1.3.5 release update to PR #57.
+**Next action:** Merge PR #57, sync `main`, then publish `pi-xai-oauth@1.3.5`.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -267,6 +267,6 @@ Update this file frequently during execution.
 - [x] Confirmed npm still serves 1.3.4 and 1.3.5 is available for publication.
 - [x] Excluded the unrelated local `cat.svg` artifact from npm packages without modifying the file.
 - [x] Passed tests, typecheck, diff checks, and 1.3.5 tarball inspection.
-- [ ] Commit and push the release update to PR #57.
+- [x] Committed and pushed the release update to PR #57.
 
 **Current branch:** feature/xai-tools-picker-focus

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -260,3 +260,13 @@ Update this file frequently during execution.
 - [x] Completed focused review of TUI navigation, toggling, close behavior, and RPC fallback.
 
 **Current branch:** feature/xai-tools-picker-focus
+
+## Phase 24: npm patch release 1.3.5
+- [x] Bumped package and lockfile versions from 1.3.4 to 1.3.5.
+- [x] Updated README release and npm upgrade guidance for the picker-focus fix.
+- [x] Confirmed npm still serves 1.3.4 and 1.3.5 is available for publication.
+- [x] Excluded the unrelated local `cat.svg` artifact from npm packages without modifying the file.
+- [x] Passed tests, typecheck, diff checks, and 1.3.5 tarball inspection.
+- [ ] Commit and push the release update to PR #57.
+
+**Current branch:** feature/xai-tools-picker-focus

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,7 +1,7 @@
 # Execution Progress
 
 **Project:** pi-xai-oauth Repair + Tool Verification  
-**Branch:** feature/release-1.3.4
+**Branch:** feature/xai-tools-picker-focus
 **Started:** 2026-05-27
 
 ## Completed
@@ -244,8 +244,19 @@ Update this file frequently during execution.
 - [x] Added a narrow npm exclusion so local pi session HTML exports cannot leak into releases.
 - [x] Passed `npm test`, `npm run typecheck`, `git diff --check`, and `npm pack --dry-run`.
 - [x] Confirmed the 1.3.4 tarball excludes the untracked session export.
-- [x] Confirmed npm currently serves 1.3.3.
+- [x] Confirmed npm served 1.3.3 before publication.
 - [x] Confirmed npm authentication as `blockedredemption`.
-- [ ] Commit, push, and publish only when explicitly requested.
+- [x] Committed and merged release PR #56, then published and verified `pi-xai-oauth@1.3.4` as `latest`.
 
 **Current branch:** feature/release-1.3.4
+
+## Phase 23: Preserve /xai-tools picker focus
+- [x] Confirmed repeated `ctx.ui.select()` calls reset the TUI cursor to row one.
+- [x] Added a persistent custom TUI picker that toggles the highlighted tool in place.
+- [x] Kept the existing selection loop as the RPC fallback.
+- [x] Added regression coverage for cursor preservation, Escape close, activation, and RPC behavior.
+- [x] Updated README controls.
+- [x] Passed `npm test`, `npm run typecheck`, `git diff --check`, and `npm pack --dry-run`.
+- [x] Completed focused review of TUI navigation, toggling, close behavior, and RPC fallback.
+
+**Current branch:** feature/xai-tools-picker-focus

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pi --model grok-4.5:low "Quick status check"   # fast mode
 
 This package adds **Grok 4.5** (default), **Grok 4.3**, **Grok Build**, and **Composer 2.5** as fully-integrated xAI OAuth models in pi, with proper OAuth login, automatic token refresh, and a suite of custom tools (`xai_generate_text`, `xai_web_search`, `xai_x_search`, etc.).
 
-> **Latest release:** `pi-xai-oauth` **1.3.4** makes every network-backed xAI helper an explicit, session-scoped opt-in through `/xai-tools`, including paid image generation. Disabled tools now fail before OAuth credential lookup or network access. This release also includes the 1.3.3 pi 0.80 Responses transport fix and **Grok 4.5** as the default model (500K context, low/medium/high reasoning; fast mode = `low`). Existing npm installs should run `pi update npm:pi-xai-oauth`; local checkout installs should keep only one copy with `pi remove npm:pi-xai-oauth && pi install .`.
+> **Latest release:** `pi-xai-oauth` **1.3.5** keeps the highlighted `/xai-tools` row in place after toggling, so multiple tools can be configured without repeatedly navigating from the top. Version 1.3.4 made every network-backed xAI helper an explicit, session-scoped opt-in through `/xai-tools`, including paid image generation, and made disabled tools fail before OAuth credential lookup or network access. Existing npm installs should run `pi update npm:pi-xai-oauth`; local checkout installs should keep only one copy with `pi remove npm:pi-xai-oauth && pi install .`.
 >
 > **Compatibility note:** 1.2.4+ supports pi 0.79.8+'s OpenAI Responses API guard for Grok/xAI streaming.
 
@@ -545,7 +545,7 @@ pi update npm:pi-xai-oauth
 
 This pulls the latest version from npm and updates your installed extension.
 
-pi 0.79.8+ enforces an OpenAI Responses API guard. `pi-xai-oauth` 1.2.4+ handles that guard for Grok/xAI streaming; 1.3.3 fixes Responses transport resolution under pi 0.80's extension loader and includes Grok 4.5 as the default model. **1.3.4** additionally makes all network-backed xAI helpers explicit opt-ins through `/xai-tools`. If you installed the published npm package, update with the command above. If you are testing a local checkout instead, reinstall the checkout:
+pi 0.79.8+ enforces an OpenAI Responses API guard. `pi-xai-oauth` 1.2.4+ handles that guard for Grok/xAI streaming; 1.3.3 fixes Responses transport resolution under pi 0.80's extension loader and includes Grok 4.5 as the default model. Version 1.3.4 makes all network-backed xAI helpers explicit opt-ins through `/xai-tools`, and **1.3.5** preserves the highlighted row while tools are toggled. If you installed the published npm package, update with the command above. If you are testing a local checkout instead, reinstall the checkout:
 
 ```bash
 pi remove npm:pi-xai-oauth && pi install .

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ In the pi TUI, select an `xai-auth` model and run:
 /xai-tools
 ```
 
-The picker shows each tool's category and cost-risk context, warns that calls may use xAI credits, and applies changes only to the current xAI session. You can also manage one tool directly:
+The picker shows each tool's category and cost-risk context, warns that calls may use xAI credits, and applies changes only to the current xAI session. Use ↑/↓ to move, Enter or Space to toggle a tool in place, and Escape when done; the highlighted row stays put after each toggle. You can also manage one tool directly:
 
 ```text
 /xai-tools status

--- a/extensions/xai/tools/commands.ts
+++ b/extensions/xai/tools/commands.ts
@@ -70,16 +70,11 @@ function notifyUpdate(
   );
 }
 
-async function showXaiToolPicker(
+async function showXaiToolSelectLoop(
   pi: ExtensionAPI,
   ctx: ExtensionCommandContext,
   model: Model<Api>,
 ) {
-  if (!ctx.hasUI) {
-    ctx.ui.notify(`${XAI_TOOLS_USAGE} Interactive selection requires TUI or RPC mode.`, "error");
-    return;
-  }
-
   while (true) {
     const labels = new Map<string, XaiNetworkToolName>();
     for (const option of eligibleToolOptions(model)) {
@@ -103,6 +98,100 @@ async function showXaiToolPicker(
     notifyUpdate(ctx, toolName, result.active, result.error);
     if (!result.ok) return;
   }
+}
+
+async function showXaiToolTuiPicker(
+  pi: ExtensionAPI,
+  ctx: ExtensionCommandContext,
+  model: Model<Api>,
+) {
+  const options = eligibleToolOptions(model);
+  await ctx.ui.custom<void>((tui, theme, keybindings, done) => {
+    let selectedIndex = 0;
+    const maxVisible = 10;
+
+    const refresh = () => tui.requestRender();
+    const moveSelection = (offset: number) => {
+      if (options.length === 0) return;
+      selectedIndex = ((selectedIndex + offset) % options.length + options.length) % options.length;
+      refresh();
+    };
+    const toggleSelected = () => {
+      const option = options[selectedIndex];
+      if (!option) return;
+      const nextActive = !isXaiNetworkToolActive(pi, option.name);
+      const result = setXaiNetworkToolActive(pi, model, option.name, nextActive);
+      notifyUpdate(ctx, option.name, result.active, result.error);
+      refresh();
+    };
+
+    return {
+      render(width: number) {
+        const lines = [
+          theme.fg("accent", theme.bold("xAI API tools — explicit opt-in; calls may use xAI credits")),
+          "",
+        ];
+        const startIndex = Math.max(
+          0,
+          Math.min(selectedIndex - Math.floor(maxVisible / 2), options.length - maxVisible),
+        );
+        const endIndex = Math.min(startIndex + maxVisible, options.length);
+        const maxRowWidth = Math.max(1, width - 2);
+
+        for (let index = startIndex; index < endIndex; index += 1) {
+          const option = options[index];
+          if (!option) continue;
+          const active = isXaiNetworkToolActive(pi, option.name);
+          const marker = index === selectedIndex ? "> " : "  ";
+          const text = `${marker}${active ? "[x]" : "[ ]"} ${option.name} — ${option.category}; ${option.costRisk}; ${option.summary}`
+            .slice(0, maxRowWidth);
+          lines.push(
+            index === selectedIndex
+              ? theme.bg("selectedBg", theme.fg("accent", text))
+              : theme.fg(active ? "success" : "text", text),
+          );
+        }
+
+        if (startIndex > 0 || endIndex < options.length) {
+          lines.push(theme.fg("dim", `  (${selectedIndex + 1}/${options.length})`));
+        }
+        lines.push("", theme.fg("muted", "  ↑/↓ move · Enter/Space toggle · Esc done"));
+        return lines;
+      },
+      invalidate() {},
+      handleInput(data: string) {
+        if (keybindings.matches(data, "tui.select.up")) {
+          moveSelection(-1);
+        } else if (keybindings.matches(data, "tui.select.down")) {
+          moveSelection(1);
+        } else if (keybindings.matches(data, "tui.select.pageUp")) {
+          moveSelection(-maxVisible);
+        } else if (keybindings.matches(data, "tui.select.pageDown")) {
+          moveSelection(maxVisible);
+        } else if (keybindings.matches(data, "tui.select.confirm") || data === " ") {
+          toggleSelected();
+        } else if (keybindings.matches(data, "tui.select.cancel")) {
+          done();
+        }
+      },
+    };
+  });
+}
+
+async function showXaiToolPicker(
+  pi: ExtensionAPI,
+  ctx: ExtensionCommandContext,
+  model: Model<Api>,
+) {
+  if (!ctx.hasUI) {
+    ctx.ui.notify(`${XAI_TOOLS_USAGE} Interactive selection requires TUI or RPC mode.`, "error");
+    return;
+  }
+  if (ctx.mode === "tui") {
+    await showXaiToolTuiPicker(pi, ctx, model);
+    return;
+  }
+  await showXaiToolSelectLoop(pi, ctx, model);
 }
 
 /** Register the package-owned command for explicitly managing network-backed xAI tools. */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-xai-oauth",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-xai-oauth",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "MIT",
       "bin": {
         "pi-xai-oauth": "bin/setup.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-xai-oauth",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "One-command installer for xAI OAuth provider + Grok 4.5, Grok Build, and Composer models in pi",
   "keywords": [
     "pi-package",

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -159,10 +159,10 @@ function authContext(model = TEST_XAI_MODEL) {
   };
 }
 
-function extensionCommandContext(model, notifications = [], select) {
+function extensionCommandContext(model, notifications = [], select, custom, mode = "tui") {
   return {
     model,
-    mode: "tui",
+    mode,
     hasUI: true,
     ui: {
       notify(message, type) {
@@ -170,6 +170,9 @@ function extensionCommandContext(model, notifications = [], select) {
       },
       async select(title, options) {
         return select?.(title, options);
+      },
+      async custom(factory) {
+        return custom?.(factory);
       },
     },
   };
@@ -469,7 +472,10 @@ async function verifyXaiToolsCommand(loadResult) {
   assert.ok(command, "the package should register /xai-tools");
 
   const notifications = [];
-  const runCommand = (args, model, select) => command.handler(args, extensionCommandContext(model, notifications, select));
+  const runCommand = (args, model, select, custom, mode) => command.handler(
+    args,
+    extensionCommandContext(model, notifications, select, custom, mode),
+  );
 
   await handlers.get("session_start")?.({}, { model: TEST_XAI_MODEL });
   assert.ok(XAI_NETWORK_TOOLS.every((name) => !getActiveTools().includes(name)));
@@ -498,6 +504,51 @@ async function verifyXaiToolsCommand(loadResult) {
   await runCommand("enable xai_generate_image", TEST_XAI_MODEL);
   await runCommand("disable xai_generate_image", TEST_XAI_MODEL);
   assert.ok(!getActiveTools().includes("xai_generate_image"), "/xai-tools should disable image generation");
+
+  let tuiPickerClosed = false;
+  let selectedAfterPageWrap = "";
+  let selectedBeforeToggle = "";
+  let selectedAfterToggle = "";
+  await runCommand("", TEST_XAI_MODEL, undefined, async (factory) => {
+    let component;
+    const tui = {
+      requestRender() {},
+    };
+    const theme = {
+      fg: (_color, text) => text,
+      bg: (_color, text) => text,
+      bold: (text) => text,
+    };
+    const bindings = {
+      "tui.select.up": "up",
+      "tui.select.down": "down",
+      "tui.select.pageUp": "pageup",
+      "tui.select.pageDown": "pagedown",
+      "tui.select.confirm": "enter",
+      "tui.select.cancel": "escape",
+    };
+    const keybindings = {
+      matches: (data, id) => bindings[id] === data,
+    };
+    component = await factory(tui, theme, keybindings, () => {
+      tuiPickerClosed = true;
+    });
+
+    component.handleInput("pageup");
+    selectedAfterPageWrap = component.render(160).find((line) => line.startsWith("> ")) || "";
+    component.handleInput("pagedown");
+    for (let index = 0; index < 6; index += 1) component.handleInput("down");
+    selectedBeforeToggle = component.render(160).find((line) => line.startsWith("> ")) || "";
+    component.handleInput("enter");
+    selectedAfterToggle = component.render(160).find((line) => line.startsWith("> ")) || "";
+    component.handleInput("escape");
+  });
+  assert.match(selectedAfterPageWrap, /> \[ \] xai_critique/);
+  assert.match(selectedBeforeToggle, /> \[ \] xai_generate_image/);
+  assert.match(selectedAfterToggle, /> \[x\] xai_generate_image/);
+  assert.ok(tuiPickerClosed, "Escape should close the stateful xAI tool picker");
+  assert.ok(getActiveTools().includes("xai_generate_image"), "the stateful picker should toggle image generation");
+  await runCommand("disable xai_generate_image", TEST_XAI_MODEL);
 
   await runCommand("enable xai_web_search", TEST_XAI_MODEL);
   assert.ok(getActiveTools().includes("xai_web_search"), "/xai-tools should explicitly enable an eligible tool");
@@ -535,8 +586,8 @@ async function verifyXaiToolsCommand(loadResult) {
     return pickerPass === 1
       ? options.find((option) => option.includes("xai_web_search"))
       : "Done";
-  });
-  assert.ok(getActiveTools().includes("xai_web_search"), "interactive /xai-tools should toggle the selected network tool");
+  }, undefined, "rpc");
+  assert.ok(getActiveTools().includes("xai_web_search"), "RPC /xai-tools should toggle the selected network tool");
   assert.match(pickerTitle, /explicit opt-in/);
   assert.ok(
     pickerOptions.some((option) => option.includes("xai_generate_image") && option.includes("image") && option.includes("per image")),


### PR DESCRIPTION
## What changed

- replace the repeated TUI selector loop with one persistent custom picker
- preserve the highlighted row and scroll position when a tool is toggled
- support arrow keys, page navigation, Enter/Space toggling, and Escape to close
- retain the existing selector behavior for RPC mode
- document the picker controls and add regression coverage
- bump package and lockfile metadata to `1.3.5`
- update release and upgrade guidance
- exclude unrelated local artifacts from the npm package

## Why

The picker recreated `ctx.ui.select()` after every toggle. Pi's selector starts at the first row and has no initial-index option, so enabling or disabling a tool moved the cursor back to the top.

## Impact

Users can enable or disable multiple xAI tools without repeatedly navigating back down the list. Tool eligibility, credit warnings, activation safety checks, and RPC behavior are unchanged.

After merge, `pi-xai-oauth@1.3.5` can be published to npm as the patch release for this fix. npm currently serves `1.3.4`, and `1.3.5` is available.

## Validation

- `npm test`
- `npm run typecheck`
- `git diff --check`
- `npm pack --dry-run --json` — 34 intended files; local `cat.svg` and session HTML excluded

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI UX change in `/xai-tools`; activation, OAuth guards, and RPC paths are intentionally unchanged.
> 
> **Overview**
> **TUI `/xai-tools` no longer jumps to the first row after each toggle.** In TUI mode the command uses a single stateful `ctx.ui.custom` picker instead of reopening `ctx.ui.select()` in a loop, so highlight and scroll position stay on the current tool while users move, page, toggle with Enter/Space, and exit with Escape.
> 
> **RPC and safety behavior are unchanged.** Non-TUI interactive mode still uses the existing `select` loop; tool eligibility, credit warnings, and `setXaiNetworkToolActive` semantics are the same.
> 
> The release is packaged as **1.3.5** with README picker controls and upgrade notes, `cat.svg` excluded from npm, and extension verification that mocks the custom picker (focus after toggle, Escape) and runs RPC picker tests with `mode: "rpc"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c901e72980221a965e674bed90312cf1db85367a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->