### PR TITLE
Add versioned release changelog

### DIFF
--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -1,7 +1,7 @@
 # Shared Agent Context
 
 **Project:** pi-xai-oauth
-**Branch:** feature/xai-tools-picker-focus
+**Branch:** feature/changelog
 **Date:** 2026-07-15
 
 ## Key Context
@@ -13,8 +13,8 @@
 - Disabled tools must fail before OAuth credential resolution or network access.
 
 ## Current Focus
-- Preserve cursor position inside the `/xai-tools` TUI after toggles.
-- Keep RPC selection and all activation safety semantics unchanged.
-- Preserve the unrelated untracked pi session HTML export.
+- Add a durable version-by-version changelog grounded in Git and npm history.
+- Keep the README focused on current usage while linking to historical release details.
+- Do not invent release claims for early versions that lack reliable per-version notes.
 
 See plan.md for the active phases and progress.md for completed work.

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,31 +1,21 @@
-# Implementation Plan: Preserve /xai-tools Picker Focus
+# Documentation Plan: Add Release Changelog
 
-**Branch:** feature/xai-tools-picker-focus
+**Branch:** feature/changelog
 
 **Date:** 2026-07-15
 
-**Goal:** Keep the highlighted `/xai-tools` row and scroll position stable after toggling a tool.
+**Goal:** Record notable features and fixes by release without bloating the current-usage README.
 
 ## Implementation
-- [x] Reproduce the cursor reset caused by reopening `ctx.ui.select()` after every toggle.
-- [x] Confirm pi's selector API has no supported initial-index option.
-- [x] Replace the TUI loop with one stateful custom component that toggles tools in place.
-- [x] Keep the existing selector fallback for RPC mode.
-- [x] Preserve model eligibility, per-tool authorization, credit warnings, and fail-closed updates.
+- [x] Verify published versions and publication dates from npm.
+- [x] Derive notable changes from version bumps, commits, and merged fixes.
+- [x] Add `CHANGELOG.md` with detailed 1.2.0-1.3.5 entries and a transparent initial-series summary.
+- [x] Link the changelog prominently from README.
 
 ## Verification
-- [x] Add regression coverage proving the selected image-generation row remains highlighted after toggling.
-- [x] Preserve RPC picker coverage.
-- [x] Run the extension test suite.
-- [x] Run final typecheck, diff checks, package inspection, and focused review.
-
-## Release preparation
-- [x] Bump `package.json` and `package-lock.json` to 1.3.5.
-- [x] Update README release and upgrade guidance.
-- [x] Exclude unrelated local artifacts from the npm tarball.
-- [x] Re-run tests, typecheck, diff checks, and package inspection for 1.3.5.
-- [x] Push the release update to PR #57.
+- [x] Review every release claim against repository and npm `gitHead` history.
+- [x] Run Markdown, diff, test, typecheck, and package-content checks.
 
 **Owner:** Main agent
 
-**Next action:** Merge PR #57, sync `main`, then publish `pi-xai-oauth@1.3.5`.
+**Next action:** Commit and open a PR when requested.

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -18,4 +18,4 @@
 
 **Owner:** Main agent
 
-**Next action:** Commit and open a PR when requested.
+**Next action:** Review and merge the changelog PR.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -278,5 +278,6 @@ Update this file frequently during execution.
 - [x] Linked the changelog from the README introduction and table of contents.
 - [x] Corrected release assignments using npm `gitHead` ranges rather than version strings alone.
 - [x] Passed changelog structure, README link, `git diff --check`, `npm test`, `npm run typecheck`, and npm tarball checks.
+- [x] Committed, pushed, and opened the changelog PR.
 
 **Current branch:** feature/changelog

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -270,3 +270,13 @@ Update this file frequently during execution.
 - [x] Committed and pushed the release update to PR #57.
 
 **Current branch:** feature/xai-tools-picker-focus
+
+## Phase 25: Versioned changelog
+- [x] Confirmed npm publication dates, `gitHead` values, and the published-version list through 1.3.5.
+- [x] Audited exact Git ranges between published revisions for notable user-facing changes.
+- [x] Added `CHANGELOG.md` with detailed modern releases and a grouped early-history summary.
+- [x] Linked the changelog from the README introduction and table of contents.
+- [x] Corrected release assignments using npm `gitHead` ranges rather than version strings alone.
+- [x] Passed changelog structure, README link, `git diff --check`, `npm test`, `npm run typecheck`, and npm tarball checks.
+
+**Current branch:** feature/changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,171 @@
+# Changelog
+
+All notable user-facing changes to `pi-xai-oauth` are recorded here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and version numbers follow [Semantic Versioning](https://semver.org/).
+
+Dates below are npm publication dates. The earliest rapid-release series is grouped where the repository did not preserve reliable per-version release notes.
+
+## Unreleased
+
+## 1.3.5 - 2026-07-15
+
+### Changed
+
+- Replaced the repeated `/xai-tools` TUI selector with one persistent picker.
+- Added arrow and page navigation, Enter or Space toggling, and Escape-to-close controls without rebuilding the list.
+- Updated TypeScript and Node.js development type dependencies.
+
+### Fixed
+
+- Preserved the highlighted tool and scroll position after enabling or disabling a tool.
+- Kept the existing selector behavior for RPC clients.
+- Tightened npm package exclusions for local development artifacts.
+
+## 1.3.4 - 2026-07-15
+
+### Added
+
+- Added the package-owned `/xai-tools` command with an interactive picker plus `status`, `enable`, and `disable` arguments.
+- Added category and cost-risk context for all network-backed xAI tools:
+  - `xai_generate_text`
+  - `xai_web_search`
+  - `xai_x_search`
+  - `xai_multi_agent`
+  - `xai_deep_research`
+  - `xai_code_execution`
+  - `xai_generate_image`
+  - `xai_analyze_image`
+  - `xai_critique`
+  - `WebSearch` for Grok Build and Composer models
+
+### Changed
+
+- Made every helper that sends an additional xAI request inactive by default and explicitly opt-in for the current session.
+- Kept local filesystem and shell compatibility shims automatic for eligible Grok Build and Composer models because they do not make additional xAI requests.
+- Reset outbound-tool activation at session start and when switching away from eligible xAI models.
+
+### Fixed
+
+- Isolated the xAI Responses transport from unsupported root-module assumptions.
+- Blocked disabled tools before OAuth credential resolution or network access.
+- Made tool-registry failures fail closed and prevented stale activation from bypassing explicit authorization.
+- Fixed paid web, X, multi-agent, deep-research, and `WebSearch` gating.
+- Fixed repeated screenshot and image replay in long Responses conversations.
+- Added consumed-image cleanup, safe image compaction, and a 3 MiB aggregate inline-image transport budget with clear local failures.
+- Normalized multimodal Responses payloads, image-bearing tool results, and active-model routing.
+
+## 1.3.3 - 2026-07-11
+
+### Fixed
+
+- Routed xAI Responses streaming through pi-ai's compatibility dispatcher so pi 0.80's extension loader no longer rewrites a subpath into an invalid module path.
+
+## 1.3.2 - 2026-07-11
+
+### Fixed
+
+- Added initial compatibility with the pi-ai 0.80 Responses API.
+- Scoped Cursor/Grok CLI compatibility shims to eligible models so they no longer leaked into normal Grok requests.
+
+## 1.3.1 - 2026-07-09
+
+### Fixed
+
+- Improved setup cleanup so duplicate local and npm installations are detected and pruned instead of causing tool-name conflicts.
+
+## 1.3.0 - 2026-07-08
+
+### Added
+
+- Added Grok 4.5 with text and image input, a 500K context window, and `low`, `medium`, and `high` reasoning levels.
+- Added Grok 4.5 fast mode through `low` reasoning effort on the same model ID.
+
+### Changed
+
+- Made Grok 4.5 the default model across provider registration, setup, and documentation.
+- Added stable Responses cache and conversation identifiers for more reliable multi-turn cache reuse.
+- Hardened Grep argument normalization and missing-pattern errors for Grok CLI compatibility.
+
+## 1.2.6 - 2026-07-07
+
+### Fixed
+
+- Corrected xAI image-generation request parameters and rejected the unsupported `size` option locally.
+- Preserved support for generating one to four images with the active xAI image model.
+
+## 1.2.5 - 2026-06-20
+
+### Fixed
+
+- Refreshed the npm compatibility guidance and Node.js development type dependency.
+
+## 1.2.4 - 2026-06-20
+
+### Fixed
+
+- Added the xAI API guard delegate required by pi 0.79.8+ for OpenAI Responses streaming.
+- Added direct verification against pi 0.79's guarded provider path.
+- Hardened OAuth wrong-state verification timeout behavior.
+- Resolved repository CodeQL findings.
+- Excluded agent worktrees from npm packages.
+
+## 1.2.3 - 2026-06-04
+
+### Fixed
+
+- Corrected manual OAuth callback-code parsing.
+
+## 1.2.2 - 2026-06-04
+
+### Added
+
+- Added Grok Build and Composer 2.5 Fast through the Grok CLI OAuth endpoint.
+- Added Grok 4.20 reasoning, non-reasoning, and multi-agent model variants.
+- Added Cursor/Grok CLI compatibility shims for filesystem, search, shell, todo, and native `WebSearch` tool calls.
+
+### Changed
+
+- Split the original monolithic extension into focused OAuth, authentication, model, payload, Responses, and tool modules.
+
+### Fixed
+
+- Repaired xAI OAuth provider registration, token reuse and refresh, Responses streaming, payload normalization, and custom-tool integration.
+- Added automated extension verification for provider, model, tool, authentication, and streaming behavior.
+
+## 1.2.1 - 2026-05-17
+
+- Republished the same Git revision as 1.2.0. The repository records no source difference between these two npm versions.
+
+## 1.2.0 - 2026-05-17
+
+- Short-lived publishing transition superseded by 1.2.1. The npm package metadata points to the same Git revision for both versions.
+
+## Initial series - 2026-05-16 to 2026-05-17
+
+### 1.0.25-1.0.26
+
+- Added OAuth-first image generation, image analysis, critique, and deep-research tools.
+- Added advanced X-search filters and moved remaining custom tools to shared OAuth token resolution.
+- Added provider payload sanitization, repository security policy, contribution templates, and agent scaffolding support.
+- Removed an erroneous package self-dependency and cleaned npm package contents.
+
+### 1.0.19-1.0.22
+
+- Added the one-command installer and automatic settings configuration.
+- Fixed browser-based OAuth launch and duplicate authorization URLs.
+- Improved native web and X search prompting and added multimodal image input support.
+- Fixed xAI image Responses payload serialization.
+
+### 1.0.12-1.0.17
+
+- Reworked the extension structure, completed the OAuth flow, improved tool registration, and added automatic browser opening.
+- Added clean npm packaging and the first setup experience.
+
+### 1.0.1-1.0.9
+
+- Added Responses API transport, reuse of `~/.grok/auth.json`, device-code authentication, and refresh-token support.
+- Added text generation, multi-agent research, web search, X search, and code-execution tools.
+- Added initial agentic model-change behavior and expanded usage documentation.
+
+### 0.1.0
+
+- Initial npm release with the `xai-auth` OAuth provider, Grok 4.3, and configurable thinking levels.

--- a/README.md
+++ b/README.md
@@ -39,12 +39,15 @@ This package adds **Grok 4.5** (default), **Grok 4.3**, **Grok Build**, and **Co
 >
 > **Compatibility note:** 1.2.4+ supports pi 0.79.8+'s OpenAI Responses API guard for Grok/xAI streaming.
 
+See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and fix history.
+
 ---
 
 ## Table of Contents
 
 - [✨ New: Grok 4.5](#-new-grok-45)
 - [Features](#features)
+- [Changelog](CHANGELOG.md)
 - [How It Works](#how-it-works)
 - [Installation](#installation)
 - [Authentication](#authentication)


### PR DESCRIPTION
## What changed

- add `CHANGELOG.md` with detailed release entries from 1.2.0 through 1.3.5
- summarize the rapid initial 0.1.0–1.0.26 release series where reliable per-version notes do not exist
- link the changelog from the README introduction and table of contents
- record additions, behavior changes, fixes, compatibility work, and release dates

## Why

The README documents current behavior but is the wrong place for an expanding version history. The repository previously had release details scattered across commit messages, README notes, and scaffold state, making it difficult to determine when features and fixes shipped.

## Accuracy method

- use npm publication dates rather than commit timestamps
- map modern releases using npm `gitHead` values
- audit exact Git ranges between published revisions
- explicitly group early releases instead of inventing unsupported per-version claims
- note that npm 1.2.0 and 1.2.1 point to the same Git revision

## Impact

Users and maintainers get one durable release-history document while the README remains focused on installation and current usage. `CHANGELOG.md` is included in the npm tarball.

## Validation

- `npm test`
- `npm run typecheck`
- `git diff --check`
- changelog heading and README link validation
- `npm pack --dry-run --json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only: new markdown and README/scaffold links with no runtime, auth, or packaging behavior changes beyond including `CHANGELOG.md` in the repo (and npm tarball per PR description).
> 
> **Overview**
> Adds **`CHANGELOG.md`** as the canonical release history for `pi-xai-oauth`, using Keep a Changelog layout and npm publication dates. **1.2.0–1.3.5** get per-version Added/Changed/Fixed notes (tools, OAuth, pi compatibility, `/xai-tools`, Grok models, etc.); the rapid **0.1.0–1.0.26** era is summarized in grouped bands so early releases are not over-specified. **1.2.0** and **1.2.1** are called out as the same Git revision.
> 
> The **README** now points readers to the changelog from the intro and table of contents so current-usage docs stay lean. **`.scaffold/`** plan, context, and progress reflect the changelog workstream instead of the prior picker-focus branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7bccec83d2e8f9ac84d23b58d322af0a810d650. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->