### PR TITLE
Fix Page Up/Down no-op when /xai-tools lists ten tools

### DIFF
--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,21 +1,12 @@
-# Documentation Plan: Add Release Changelog
+# Plan: Fix Page Up/Down no-op at ten items (issue #59)
 
-**Branch:** feature/changelog
+**Branch:** cursor/fix-page-keys-ten-items-7537
 
-**Date:** 2026-07-15
+**Goal:** Page Up/Down in `/xai-tools` TUI must wrap when exactly ten eligible tools are shown (Grok Build/Composer + WebSearch).
 
-**Goal:** Record notable features and fixes by release without bloating the current-usage README.
-
-## Implementation
-- [x] Verify published versions and publication dates from npm.
-- [x] Derive notable changes from version bumps, commits, and merged fixes.
-- [x] Add `CHANGELOG.md` with detailed 1.2.0-1.3.5 entries and a transparent initial-series summary.
-- [x] Link the changelog prominently from README.
-
-## Verification
-- [x] Review every release claim against repository and npm `gitHead` history.
-- [x] Run Markdown, diff, test, typecheck, and package-content checks.
-
-**Owner:** Main agent
-
-**Next action:** Review and merge the changelog PR.
+## Steps
+- [x] Reproduce: `moveSelection(±maxVisible)` with `options.length === 10` is a modulo no-op
+- [x] Fix `moveSelection` to fall back to ±1 when `offset % length === 0`
+- [x] Add Composer (10-tool) regression in `scripts/verify-extension.js`
+- [x] Run `npm run typecheck` and `npm test`
+- [x] Commit, push, open PR

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,8 +1,15 @@
 # Execution Progress
 
 **Project:** pi-xai-oauth Repair + Tool Verification  
-**Branch:** feature/xai-tools-picker-focus
+**Branch:** cursor/fix-page-keys-ten-items-7537
 **Started:** 2026-05-27
+
+## Phase: Issue #59 Page keys at ten items
+- [x] Diagnosed modulo no-op in `moveSelection(±maxVisible)` when `options.length === 10`
+- [x] Fixed `extensions/xai/tools/commands.ts` to fall back to ±1 when step would be 0
+- [x] Added Composer 10-tool regression in `scripts/verify-extension.js`
+- [x] Verified `npm run typecheck` and `npm test`
+- [x] Opened PR #61 on `cursor/fix-page-keys-ten-items-7537`
 
 ## Completed
 - [x] Created branch `feature/improved-agent-scaffolding`

--- a/extensions/xai/tools/commands.ts
+++ b/extensions/xai/tools/commands.ts
@@ -113,7 +113,14 @@ async function showXaiToolTuiPicker(
     const refresh = () => tui.requestRender();
     const moveSelection = (offset: number) => {
       if (options.length === 0) return;
-      selectedIndex = ((selectedIndex + offset) % options.length + options.length) % options.length;
+      // When offset is a multiple of the list length (e.g. page size === 10
+      // tools), bare `%` is a no-op. Keep paging moving by one step in the
+      // requested direction so Page Up/Down still wrap.
+      let step = offset % options.length;
+      if (step === 0 && offset !== 0) {
+        step = Math.sign(offset);
+      }
+      selectedIndex = ((selectedIndex + step) % options.length + options.length) % options.length;
       refresh();
     };
     const toggleSelected = () => {

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -550,6 +550,46 @@ async function verifyXaiToolsCommand(loadResult) {
   assert.ok(getActiveTools().includes("xai_generate_image"), "the stateful picker should toggle image generation");
   await runCommand("disable xai_generate_image", TEST_XAI_MODEL);
 
+  // Grok Build/Composer exposes all 10 tools (including WebSearch). Page size
+  // equals list length, so Page Up/Down must still wrap rather than no-op.
+  let selectedAfterTenItemPageWrap = "";
+  let selectedAfterTenItemPageDown = "";
+  await runCommand("", { ...TEST_XAI_MODEL, id: "grok-composer-2.5-fast" }, undefined, async (factory) => {
+    const tui = { requestRender() {} };
+    const theme = {
+      fg: (_color, text) => text,
+      bg: (_color, text) => text,
+      bold: (text) => text,
+    };
+    const bindings = {
+      "tui.select.up": "up",
+      "tui.select.down": "down",
+      "tui.select.pageUp": "pageup",
+      "tui.select.pageDown": "pagedown",
+      "tui.select.confirm": "enter",
+      "tui.select.cancel": "escape",
+    };
+    const keybindings = {
+      matches: (data, id) => bindings[id] === data,
+    };
+    const component = await factory(tui, theme, keybindings, () => {});
+    component.handleInput("pageup");
+    selectedAfterTenItemPageWrap = component.render(160).find((line) => line.startsWith("> ")) || "";
+    component.handleInput("pagedown");
+    selectedAfterTenItemPageDown = component.render(160).find((line) => line.startsWith("> ")) || "";
+    component.handleInput("escape");
+  });
+  assert.match(
+    selectedAfterTenItemPageWrap,
+    /> \[ \] WebSearch/,
+    "Page Up must wrap to the last row when exactly ten tools are listed",
+  );
+  assert.match(
+    selectedAfterTenItemPageDown,
+    /> \[ \] xai_generate_text/,
+    "Page Down must wrap from the last row when exactly ten tools are listed",
+  );
+
   await runCommand("enable xai_web_search", TEST_XAI_MODEL);
   assert.ok(getActiveTools().includes("xai_web_search"), "/xai-tools should explicitly enable an eligible tool");
   assert.match(notifications.at(-1).message, /may use xAI credits/);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Page Up/Down in the `/xai-tools` TUI call `moveSelection` with ±`maxVisible` (10). When Grok Build/Composer expose all ten eligible tools, JavaScript `%` makes that step a no-op, so paging never wraps. Fall back to a ±1 wrap step when the page offset is a multiple of the list length, and cover the ten-item Composer case in verification.

Fixes #59

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] `npm run typecheck`
- [x] `npm test` (includes new ten-item Page Up/Down wrap assertions for Composer)
- [ ] Manual: open `/xai-tools` on a Grok Build/Composer model and confirm Page Up/Down move the highlight

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if appropriate)

N/A — TUI keyboard navigation fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f679f-e172-78b7-9c50-61ba6e577537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f679f-e172-78b7-9c50-61ba6e577537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

