### PR TITLE
Route OAuth session traffic through the Grok CLI proxy

### DIFF
--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -1,15 +1,33 @@
 # Shared Agent Context
 
-**Project:** pi-xai-oauth  
-**Branch:** cursor/fix-disable-clears-all-tools-c1c0  
-**Date:** 2026-07-15
+**Project:** pi-xai-oauth
+**Branch:** feature/issue-63-auth-aware-routing
+**Date:** 2026-07-16
 
-## Key Context
-- Issue #60: `/xai-tools disable` without an active xAI model wiped every authorized network tool.
-- Root cause in `setXaiNetworkToolActive`: when `xaiModel` was missing, `nextSelection` started empty and `explicitlyEnabledXaiNetworkTools.delete(scope)` cleared all opt-ins.
-- Enable without an xAI model still fails closed with an error (unchanged).
-- Lifecycle `syncXaiNetworkToolsForModel` still clears authorization when leaving xAI or on session reset.
+## Issue
+GitHub issue #63 reports that the OAuth-only `xai-auth` provider incorrectly routes ordinary Grok models to `api.x.ai`; only Grok Build and Composer previously used the official session-token proxy.
+
+## Confirmed Contract
+- OAuth/session-token Responses inference → `https://cli-chat-proxy.grok.com/v1`.
+- Explicit external API-key Responses inference → `https://api.x.ai/v1`.
+- Endpoint selection must not depend on model ID or token shape.
+- Grok Build/Composer payload cleanup, Cursor shims, tool eligibility, and existing proxy headers remain model-specific compatibility behavior.
+- Official Grok Build commit `b189869` deliberately sends image generation for both OAuth and BYOK directly to `xai_api_base_url`.
+
+## Completed Implementation
+- Rebased onto current `origin/main`, preserving PR #62's selective `/xai-tools disable` fix.
+- Added one explicit credential/request routing matrix for OAuth-session and API-key Responses plus image generation.
+- Routed provider streaming and all direct OAuth Responses helpers through `cli-chat-proxy.grok.com`.
+- Preserved `api.x.ai` for an explicit future API-key Responses path and both image-generation credential kinds.
+- Kept Build/Composer compatibility payloads, headers, Cursor shims, and WebSearch eligibility model-specific.
+- Added actual-request regression coverage for Grok 4.5, Grok 4.3, Grok 4.20 reasoning, Grok Build, and Composer across streaming and direct helpers.
+- Documented a subscription-only manual smoke test and the image-generation exception.
+
+## Validation
+- `npm test`, `npm run typecheck`, and `git diff --check` pass before the final rebase.
+- `npm pack --dry-run --json` includes the routing module and excludes temporary subagent/scaffold/session artifacts.
+- Two fresh-context review rounds found no remaining code or documentation blockers.
+- Live OAuth smoke: Grok Build and Composer passed; Grok 4.5, Grok 4.3, Grok 4.20 reasoning, and the direct Grok 4.5 helper reached the proxy but failed HTTP 426 because the required Grok client-version header was absent.
 
 ## Current Focus
-- Selective disable preserves sibling authorizations and registry entries.
-- Regression covers enable two tools → disable one with a non-xAI command model → assert the other remains through sync.
+GitHub issue #65 tracks the proxy-header and OAuth-scope alignment exposed by the live smoke. Issue #63 remains focused on endpoint selection.

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,12 +1,30 @@
-# Plan: Fix disable clearing all authorized tools (issue #60)
+# Implementation Plan: Issue #63 OAuth-aware xAI routing
 
-**Branch:** cursor/fix-disable-clears-all-tools-c1c0
+**Branch:** feature/issue-63-auth-aware-routing
+**Date:** 2026-07-16
 
-**Goal:** `/xai-tools disable <tool>` without an active xAI model must remove only the named tool from the opt-in set and active-tool registry, preserving every other authorized network tool.
+## Goal
+Route xAI Responses traffic by credential kind rather than model ID: OAuth/session credentials use the official Grok CLI proxy, while a future explicit API-key path stays on the public xAI API.
 
-## Steps
-- [x] Reproduce: `setXaiNetworkToolActive` starts from an empty set and deletes the WeakMap scope when `!xaiModel`
-- [x] Fix `setXaiNetworkToolActive` to always copy `previousSelection` and persist remaining authorizations
-- [x] Add regression in `scripts/verify-extension.js` for multi-tool disable without an xAI command model
-- [x] Run `npm run typecheck` and `npm test`
-- [x] Commit, push, open PR
+## Implementation
+- [x] Add a credential- and operation-aware routing module.
+- [x] Separate Grok Build/Composer compatibility classification from endpoint selection.
+- [x] Return tagged OAuth credentials from the current OAuth-only auth resolver.
+- [x] Route provider streaming and every direct Responses helper through the shared resolver.
+- [x] Audit image generation through the resolver while preserving the official direct `api.x.ai` exception.
+- [x] Add table-driven regression coverage for Grok 4.5, Grok 4.3, Grok 4.20, Grok Build, Composer, API-key routing, and image generation.
+- [x] Document a subscription-only manual smoke test and update the Unreleased changelog.
+
+## Validation Contract
+- [x] `npm run typecheck`
+- [x] `npm test`
+- [x] `git diff --check`
+- [x] `npm pack --dry-run --json` includes `extensions/xai/routing.ts` and excludes temporary subagent/scaffold/session artifacts.
+- [x] Two fresh-context review rounds completed; round 2 found no code or documentation blockers.
+- [x] Manual subscription-only smoke test is documented.
+- [ ] Live subscription-only smoke passes: executed on 2026-07-16 with OAuth present and `XAI_API_KEY` absent; Grok Build and Composer passed, while Grok 4.5, Grok 4.3, Grok 4.20, and the direct Grok 4.5 helper reached the proxy but failed with HTTP 426 because standard models did not send the required Grok client-version header. Header alignment remains the separately scoped non-goal tracked by GitHub issue #65.
+
+## Scope Decisions
+- Header and OAuth scope alignment remain out of scope per issue #63.
+- Image generation remains at `https://api.x.ai/v1/images/generations` for OAuth and API-key credentials, matching official Grok Build commit `b189869`.
+- This package remains OAuth-only; API-key routing is an internal, explicitly tagged future path.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,15 +1,34 @@
 # Execution Progress
 
-**Project:** pi-xai-oauth  
-**Branch:** cursor/fix-disable-clears-all-tools-c1c0  
-**Started:** 2026-07-15
+**Project:** pi-xai-oauth Issue #63 OAuth-aware endpoint routing
+**Branch:** feature/issue-63-auth-aware-routing
+**Started:** 2026-07-16
 
-## Phase: Issue #60 Disable clears all authorized tools
-- [x] Diagnosed empty-set + WeakMap delete path in `setXaiNetworkToolActive` when `!xaiModel`
-- [x] Fixed `extensions/xai/tools/model-scope.ts` to copy prior selection and keep remaining opt-ins
-- [x] Added multi-tool disable-without-model regression in `scripts/verify-extension.js`
-- [x] Verified `npm run typecheck` and `npm test`
-- [x] Opened PR #62
+## Inherited Mainline Fixes
+- [x] Rebased onto current `origin/main`.
+- [x] Preserved PR #62's fix so disabling one xAI tool without an active xAI model does not clear sibling authorizations.
 
-## Completed
-All validation passed (`verify-extension: ok`, `verify-setup: ok`).
+## Issue #63 Implementation
+- [x] Read issue #63, current provider/request paths, pi custom-provider docs/examples, and official Grok Build routing source.
+- [x] Confirmed baseline `npm run typecheck` and `npm test` pass.
+- [x] Completed parallel local audit, official-source research, and implementation planning.
+- [x] Clarified the image-generation exception: official Grok Build sends OAuth and BYOK Imagine requests directly to `api.x.ai`.
+- [x] Implemented credential-aware Responses routing: OAuth/session traffic uses the CLI proxy and an explicit future API-key path uses `api.x.ai`.
+- [x] Routed image generation through the same abstraction while preserving its official direct `api.x.ai` exception.
+- [x] Renamed the Build/Composer predicate so compatibility behavior remains separate from endpoint selection.
+- [x] Added table-driven actual-request coverage for OAuth streaming/direct helpers across Grok 4.5, Grok 4.3, Grok 4.20, Grok Build, and Composer.
+- [x] Added explicit API-key Responses and OAuth/API-key image-route coverage while preserving Build/Composer-only compatibility headers.
+- [x] Corrected TUI `/login` documentation and documented the subscription-only smoke flow.
+- [x] Completed two fresh-context review rounds and applied accepted documentation/metadata findings.
+- [x] Passed LSP diagnostics, `npm test`, `npm run typecheck`, `git diff --check`, and npm package inspection before the final rebase.
+
+## Live Smoke
+- [x] Installed the local checkout as the only `pi-xai-oauth` package.
+- [x] Verified OAuth credentials are present while `XAI_API_KEY` is absent.
+- [x] Grok Build and Composer returned `OAUTH_PROXY_OK`.
+- [x] Confirmed Grok 4.5, Grok 4.3, Grok 4.20 reasoning, and the direct Grok 4.5 helper reach the proxy.
+- [ ] Standard-model requests currently fail HTTP 426 because the required Grok client-version header is absent; GitHub issue #65 tracks header/scope alignment.
+
+## Next
+- [ ] Re-run full validation after rebase, push the branch, and open the issue #63 PR.
+- [ ] Address issue #65 separately before claiming all standard-model OAuth traffic is end-to-end operational.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Core flow: `bin/setup.js` → `pi install` → provider registration in `extensi
 - Install / setup: `node bin/setup.js` or `npm run setup` (if added)
 - Install as pi extension: `pi install npm:pi-xai-oauth`
 - Run TypeScript: `npx tsc --noEmit` (validate)
-- Git: Always work on feature branches. Current branch for this work: `feature/issue-19-api-guard`
+- Git: Always work on feature branches. Current branch for this work: `feature/issue-63-auth-aware-routing`
 
 ## Architecture & Boundaries (MUST / MUST NOT)
 **MUST:**
@@ -36,11 +36,12 @@ pi-xai-oauth/
 │   ├── xai-oauth.ts      # Thin entrypoint: provider registration + tool orchestration
 │   └── xai/              # Focused implementation modules
 │       ├── constants.ts  # URLs, defaults, OAuth constants
-│       ├── models.ts     # Model catalog + routing helpers
+│       ├── models.ts     # Model catalog + model compatibility helpers
 │       ├── oauth.ts      # OAuth discovery/login/refresh/callback helpers
 │       ├── auth.ts       # Credential reuse + token resolution helpers
 │       ├── payload.ts    # Responses payload normalization
 │       ├── responses.ts  # xAI request/stream helpers
+│       ├── routing.ts    # Credential-aware Responses/Images endpoint routing
 │       └── tools/        # Custom xAI tools + Cursor/Grok CLI shims
 ├── package.json
 ├── tsconfig.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 
 ## Unreleased
 
+### Changed
+
+- Centralized xAI endpoint selection around explicit OAuth-session versus API-key credential provenance instead of model IDs.
+- Kept Grok Build and Composer payload, header, and tool compatibility separate from transport routing.
+
+### Fixed
+
+- Routed normal streaming and separate Responses helpers for every `xai-auth` model through the official Grok CLI session-token proxy, matching the intended OAuth/session-token transport contract for Responses traffic.
+- Preserved the official direct `api.x.ai` Images endpoint for OAuth-backed image generation while keeping a future explicit API-key Responses route on the public API.
+
 ## 1.3.5 - 2026-07-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and
 - **Coding models** — Grok Build and Composer 2.5 Fast are available from the same `xai-auth` provider
 - **Reasoning support** — configurable thinking levels: `low` / `medium` / `high`
 - **Custom xAI tools** — generate text, web search, X/Twitter search, multi-agent research, code analysis
-- **Modern API** — uses OpenAI's `responses` API format via `https://api.x.ai/v1`, with Grok CLI endpoint routing for CLI-only models
+- **Credential-aware Responses routing** — OAuth/session traffic uses the official `https://cli-chat-proxy.grok.com/v1` endpoint for every Grok model; the public `api.x.ai` Responses endpoint is reserved for a future explicit API-key path
 
 > **✅ Verified (May 2026)**: All custom xAI tools (`xai_generate_text`, `xai_x_search`, `xai_web_search`, `xai_code_execution`, `xai_critique`, `xai_multi_agent`, `xai_deep_research`, image tools, etc.) have been tested end-to-end after the OAuth + payload repair. The provider now correctly handles mixed-model requests and native xAI tool shapes.
 
@@ -85,7 +85,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and
 
 ## How It Works
 
-`pi-xai-oauth` registers an OAuth provider called `xai-auth` in pi's provider registry. When you run `pi /login xai-auth`:
+`pi-xai-oauth` registers an OAuth provider called `xai-auth` in pi's provider registry. When you launch `pi` and run `/login xai-auth` in the TUI:
 
 1. pi starts a local HTTP callback server on `127.0.0.1`
 2. It builds an xAI OAuth authorize URL with PKCE challenge
@@ -93,6 +93,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and
 4. After you approve, xAI redirects to the local callback server
 5. The authorization code is exchanged for access + refresh tokens
 6. Tokens are persisted and refreshed automatically
+7. All OAuth-backed Responses traffic—normal streaming and separate Responses helpers—uses xAI's session-token proxy (`https://cli-chat-proxy.grok.com/v1`) rather than the public Responses endpoint on `https://api.x.ai/v1`
 
 If localhost callbacks are blocked (VPN, Docker, remote dev), the TUI shows a text field where you can paste the redirect URL manually.
 
@@ -158,7 +159,13 @@ Then optionally configure it as default:
 ## Authentication
 
 ```bash
-pi /login xai-auth
+pi
+```
+
+Then, in the pi TUI:
+
+```text
+/login xai-auth
 ```
 
 **What happens:**
@@ -176,7 +183,13 @@ pi /login xai-auth
 Tokens are refreshed automatically, but if you want to force a fresh login:
 
 ```bash
-pi /login xai-auth
+pi
+```
+
+Then, in the pi TUI:
+
+```text
+/login xai-auth
 ```
 
 The existing `~/.grok/auth.json` prompt lets you either reuse or re-authenticate.
@@ -203,8 +216,8 @@ pi --model grok-4.5 "Write a poem about Rust"
 |----------|-------------|
 | `grok-4.5` | **Default.** xAI flagship for coding, agentic tasks, and knowledge work; reasoning low (**fast**) / medium / high (default), 500K context, text+image. |
 | `grok-4.3` | Full reasoning, 1M context. |
-| `grok-build` | Grok Build coding model via the Grok CLI OAuth endpoint, 512K context. |
-| `grok-composer-2.5-fast` | Composer 2.5 Fast coding model via the Grok CLI OAuth endpoint, 200K context. |
+| `grok-build` | Grok Build coding model with Cursor/Grok CLI tool compatibility, 512K context. |
+| `grok-composer-2.5-fast` | Composer 2.5 Fast coding model with Cursor/Grok CLI tool compatibility, 200K context. |
 | `grok-4.20-0309-reasoning` | Grok 4.20 with automatic reasoning, 2M context. |
 | `grok-4.20-0309-non-reasoning` | Grok 4.20 fast responses, 2M context. |
 | `grok-4.20-multi-agent-0309` | Grok 4.20 multi-agent research model, 2M context. |
@@ -254,7 +267,7 @@ pi --model grok-4.5:low "What's the weather?"   # fast / latency-sensitive
 | **`medium`** | Balanced thinking vs latency | Analysis and longer-context work |
 | **`low`** (**fast mode**) | Some reasoning, still fast | Latency-sensitive agents and simple tool calling |
 
-`grok-4.5` defaults to **high** when no effort is specified; reasoning **cannot be disabled** (`/think off` is not supported for this model). `grok-build` and `grok-composer-2.5-fast` are routed through xAI's Grok CLI OAuth endpoint using the same X account OAuth token. `grok-composer-2.5-fast` does not accept configurable reasoning effort. `grok-4.20-0309-reasoning` reasons automatically and does not accept a configurable effort parameter. `grok-4.20-multi-agent-0309` uses `medium` for 4 agents and `high` for 16 agents.
+`grok-4.5` defaults to **high** when no effort is specified; reasoning **cannot be disabled** (`/think off` is not supported for this model). Because `xai-auth` is OAuth-only, Grok 4.5, Grok 4.3, every Grok 4.20 variant, Grok Build, and Composer all send Responses traffic through xAI's Grok CLI session endpoint using the same X account OAuth token. Grok Build and Composer still receive their model-specific compatibility payloads, headers, and local tool shims. `grok-composer-2.5-fast` does not accept configurable reasoning effort. `grok-4.20-0309-reasoning` reasons automatically and does not accept a configurable effort parameter. `grok-4.20-multi-agent-0309` uses `medium` for 4 agents and `high` for 16 agents.
 
 ### Grok 4.5 source notes
 
@@ -418,7 +431,7 @@ Opt-in research using the active xAI model plus native web and X search tools. E
 }
 ```
 
-> **Note:** Every tool in this section makes a separate xAI request and can consume credits or rate limits. Image generation is charged per generated image. See [xAI pricing](https://docs.x.ai/developers/pricing) for current rates.
+> **Note:** Every tool in this section makes a separate xAI request and can consume subscription allowances, credits, or rate limits. Responses-based helpers use the OAuth session proxy. Image generation is the intentional exception: matching official Grok Build behavior, it sends the OAuth bearer directly to `https://api.x.ai/v1/images/generations` and is charged per generated image. See [xAI pricing](https://docs.x.ai/developers/pricing) for current rates.
 
 ---
 
@@ -429,7 +442,7 @@ Opt-in research using the active xAI model plus native web and X search tools. E
 | Install | `pi install npm:pi-xai-oauth` |
 | One-command setup | `npx pi-xai-oauth` |
 | Try ephemeral | `pi -e npm:pi-xai-oauth` |
-| Authenticate | `pi /login xai-auth` |
+| Authenticate | Launch `pi`, then run `/login xai-auth` in the TUI |
 | Update | `pi update npm:pi-xai-oauth` |
 | Remove | `pi remove npm:pi-xai-oauth` |
 | List packages | `pi list` |
@@ -490,14 +503,22 @@ If an image cannot be decoded or compacted safely, the request fails locally wit
 Tokens refresh automatically, but if something goes wrong:
 
 ```bash
-pi /login xai-auth
+pi
+```
+
+Then, in the pi TUI:
+
+```text
+/login xai-auth
 ```
 
 This re-runs the full OAuth flow and replaces your stored tokens.
 
 ### "Does this need an xAI API key?"
 
-**No.** This uses OAuth — the same authentication as the official Grok CLI and chat interface. You sign in with your xAI / Grok account credentials. No API key required.
+**No.** This uses OAuth — the same authentication as the official Grok CLI and chat interface. You sign in with your xAI / Grok account credentials. No API key required. Responses requests use the OAuth session proxy; this package does not fall back to `XAI_API_KEY` or expose an API-key provider.
+
+The paid `xai_generate_image` helper is a deliberate transport exception: the official Grok Build client sends both OAuth and BYOK Imagine requests directly to the public Images endpoint. This does not change normal chat or Responses-helper routing.
 
 If you have the official Grok CLI installed and authenticated (`~/.grok/auth.json`), this package detects and reuses those credentials automatically.
 
@@ -621,6 +642,40 @@ pi install .
 git checkout -b feature/your-task
 ```
 
+### Subscription-only OAuth routing smoke test
+
+Use an account with an active SuperGrok/subscription entitlement but **no API-team credits or spending limit configured**. Install this checkout once, authenticate through `xai-auth` in the pi TUI, then run one short streaming request for each model family:
+
+```bash
+pi remove npm:pi-xai-oauth && pi install .
+pi
+```
+
+Then, in the pi TUI:
+
+```text
+/login xai-auth
+```
+
+After login completes, from your shell run:
+
+```bash
+pi -p --model grok-4.5 "Reply exactly: OAUTH_PROXY_OK"
+pi -p --model grok-4.3 "Reply exactly: OAUTH_PROXY_OK"
+pi -p --model grok-4.20-0309-reasoning "Reply exactly: OAUTH_PROXY_OK"
+pi -p --model grok-build "Reply exactly: OAUTH_PROXY_OK"
+pi -p --model grok-composer-2.5-fast "Reply exactly: OAUTH_PROXY_OK"
+```
+
+Expected passing result for this manual smoke test: each command returns `OAUTH_PROXY_OK` without an API-team credit or spending-limit error. Then verify the separate direct Responses helper in a Grok 4.5 TUI session:
+
+```text
+/xai-tools enable xai_generate_text
+Use xai_generate_text with model grok-4.5 and prompt "Reply exactly: DIRECT_OAUTH_PROXY_OK".
+```
+
+Do not enable `xai_generate_image` for this smoke test. Image generation intentionally uses the direct public Images endpoint, is billed/limited separately, and is not evidence for subscription-only Responses routing. Never print or record OAuth tokens while testing.
+
 ### Project Structure
 
 ```
@@ -630,10 +685,11 @@ pi-xai-oauth/
 │   └── xai/                  # Domain modules: OAuth, auth, models, payloads, tools
 │       ├── auth.ts           # Grok CLI credential reuse + token resolution
 │       ├── constants.ts      # URLs, OAuth constants, defaults
-│       ├── models.ts         # Model catalog + routing helpers
+│       ├── models.ts         # Model catalog + model-specific compatibility helpers
 │       ├── oauth.ts          # OAuth discovery/login/refresh/callback helpers
 │       ├── payload.ts        # xAI Responses payload normalization
 │       ├── responses.ts      # xAI request + streaming helpers
+│       ├── routing.ts        # Credential-aware Responses and Images endpoints
 │       └── tools/            # Custom xAI tools + Cursor/Grok CLI shims
 ├── bin/
 │   └── setup.js              # One-command setup (npx pi-xai-oauth)

--- a/extensions/xai-oauth.ts
+++ b/extensions/xai-oauth.ts
@@ -1,15 +1,17 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getGrokAuthCredentials } from "./xai/auth";
-import { XAI_API_BASE_URL, XAI_PROVIDER_ID } from "./xai/constants";
+import { XAI_PROVIDER_ID } from "./xai/constants";
 import { MODELS } from "./xai/models";
 import { createXaiOAuth } from "./xai/oauth";
 import { streamSimpleXaiResponses } from "./xai/responses";
+import { resolveXaiRoute } from "./xai/routing";
 import { registerXaiTools, syncXaiToolsForModel } from "./xai/tools";
 
 export default function (pi: ExtensionAPI) {
+  const oauthResponsesRoute = resolveXaiRoute("oauth-session", "responses");
   pi.registerProvider(XAI_PROVIDER_ID, {
     name: "xAI (OAuth)",
-    baseUrl: XAI_API_BASE_URL,
+    baseUrl: oauthResponsesRoute.baseUrl,
     api: "xai-responses",
     models: MODELS as any,
     authHeader: true,

--- a/extensions/xai/auth.ts
+++ b/extensions/xai/auth.ts
@@ -11,6 +11,7 @@ import {
   XAI_PROVIDER_ID,
 } from "./constants";
 import { ensureFreshXaiCredentials } from "./oauth";
+import type { XaiCredential } from "./routing";
 
 function parseExpiry(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) return value;
@@ -77,18 +78,20 @@ export function getGrokAuthCredentials(): OAuthCredentials | null {
   return null;
 }
 
-/** Resolve an xAI OAuth access token from pi context or reusable Grok CLI credentials. */
-export async function resolveXaiAuthToken(ctx: any): Promise<string | null> {
+/** Resolve a tagged xAI OAuth credential from pi context or reusable Grok CLI credentials. */
+export async function resolveXaiCredential(ctx: any): Promise<XaiCredential | null> {
   const registryModel = ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, DEFAULT_XAI_MODEL);
   if (registryModel && typeof ctx?.modelRegistry?.getApiKeyAndHeaders === "function") {
     const auth = await ctx.modelRegistry.getApiKeyAndHeaders(registryModel);
-    if (auth?.ok && auth.apiKey) return auth.apiKey;
+    if (auth?.ok && auth.apiKey) return { kind: "oauth-session", token: auth.apiKey };
     const authorization = auth?.ok && typeof auth.headers?.Authorization === "string" ? auth.headers.Authorization : "";
-    if (authorization.toLowerCase().startsWith("bearer ")) return authorization.slice("bearer ".length);
+    if (authorization.toLowerCase().startsWith("bearer ")) {
+      return { kind: "oauth-session", token: authorization.slice("bearer ".length) };
+    }
   }
-  if (ctx?.apiKey) return ctx.apiKey;
+  if (ctx?.apiKey) return { kind: "oauth-session", token: ctx.apiKey };
 
   const credentials = getGrokAuthCredentials();
   if (!credentials?.access) return null;
-  return (await ensureFreshXaiCredentials(credentials)).access;
+  return { kind: "oauth-session", token: (await ensureFreshXaiCredentials(credentials)).access };
 }

--- a/extensions/xai/models.ts
+++ b/extensions/xai/models.ts
@@ -1,13 +1,6 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
-import {
-  DEFAULT_XAI_MODEL,
-  XAI_API_BASE_URL,
-  XAI_CLI_BASE_URL,
-  XAI_CLI_RESPONSES_URL,
-  XAI_GROK_CLIENT_VERSION,
-  XAI_PROVIDER_ID,
-  XAI_RESPONSES_URL,
-} from "./constants";
+import { DEFAULT_XAI_MODEL, XAI_GROK_CLIENT_VERSION, XAI_PROVIDER_ID } from "./constants";
+import { resolveXaiRoute, type XaiCredentialKind } from "./routing";
 
 export const MODELS = [
   {
@@ -93,8 +86,8 @@ export const MODELS = [
   },
 ];
 
-/** Build a pi model object for direct xAI tool requests. */
-export function xaiModelForRequest(modelId?: string): Model<Api> {
+/** Build a pi model object for a credential-aware direct xAI request. */
+export function xaiModelForRequest(modelId: string | undefined, credentialKind: XaiCredentialKind): Model<Api> {
   const id = modelId || DEFAULT_XAI_MODEL;
   const model =
     MODELS.find((candidate) => candidate.id === id) ||
@@ -105,29 +98,19 @@ export function xaiModelForRequest(modelId?: string): Model<Api> {
     id,
     provider: XAI_PROVIDER_ID,
     api: "xai-responses",
-    baseUrl: xaiBaseUrlForModel(id),
+    baseUrl: resolveXaiRoute(credentialKind, "responses").baseUrl,
   } as any;
 }
 
-/** Normalize provider/model-prefixed xAI model ids for routing comparisons. */
+/** Normalize provider/model-prefixed xAI model ids for capability comparisons. */
 export function normalizedXaiModelId(modelId: string): string {
   return (modelId || "").toLowerCase().split("/").pop() || "";
 }
 
-/** Return true for models that must route through xAI's Grok CLI proxy. */
-export function isGrokCliProxyModel(modelId: string): boolean {
+/** Return true for models that need Grok CLI compatibility behavior. */
+export function isGrokCliCompatibilityModel(modelId: string): boolean {
   const normalized = normalizedXaiModelId(modelId);
   return normalized === "grok-build" || normalized === "grok-composer-2.5-fast";
-}
-
-/** Resolve the base URL used by a model. */
-export function xaiBaseUrlForModel(modelId: string): string {
-  return isGrokCliProxyModel(modelId) ? XAI_CLI_BASE_URL : XAI_API_BASE_URL;
-}
-
-/** Resolve the Responses endpoint used by a model. */
-export function xaiResponsesUrlForModel(modelId: string): string {
-  return isGrokCliProxyModel(modelId) ? XAI_CLI_RESPONSES_URL : XAI_RESPONSES_URL;
 }
 
 /** Build Grok CLI proxy headers for Composer/Grok Build requests. */
@@ -142,9 +125,15 @@ export function grokCliProxyHeaders(modelId: string, sessionId?: string): Record
   return headers;
 }
 
-/** Build extra request headers needed for a given xAI model. */
-export function xaiModelRequestHeaders(modelId: string, sessionId?: string): Record<string, string> {
-  return isGrokCliProxyModel(modelId) ? grokCliProxyHeaders(modelId, sessionId) : {};
+/** Build extra request headers needed for a credential and xAI model. */
+export function xaiModelRequestHeaders(
+  modelId: string,
+  credentialKind: XaiCredentialKind,
+  sessionId?: string,
+): Record<string, string> {
+  return credentialKind === "oauth-session" && isGrokCliCompatibilityModel(modelId)
+    ? grokCliProxyHeaders(modelId, sessionId)
+    : {};
 }
 
 /** Return true when xAI accepts an explicit Responses reasoning effort. */

--- a/extensions/xai/payload.ts
+++ b/extensions/xai/payload.ts
@@ -1,6 +1,6 @@
 import type { Api, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
 import { normalizeXaiImageInput } from "./images";
-import { grokSupportsReasoningEffort, isGrokCliProxyModel } from "./models";
+import { grokSupportsReasoningEffort, isGrokCliCompatibilityModel } from "./models";
 import { textFromResponsesContent } from "./text";
 
 function normalizeResponsesImageParts(value: unknown): unknown {
@@ -119,7 +119,7 @@ export function rewriteXaiResponsesPayload(payload: unknown, model: Model<Api>, 
   if (!payload || typeof payload !== "object") return payload;
   const body: Record<string, any> = { ...(payload as Record<string, any>) };
   const modelId = String(body.model || model.id);
-  const usesGrokCliProxy = isGrokCliProxyModel(modelId);
+  const usesGrokCliCompatibility = isGrokCliCompatibilityModel(modelId);
 
   // xAI's Responses API matches the OpenAI surface but has a few stricter
   // edges than pi's generic OpenAI Responses serializer. Hermes solves the
@@ -129,7 +129,7 @@ export function rewriteXaiResponsesPayload(payload: unknown, model: Model<Api>, 
     let input = normalizeXaiResponsesInput([...body.input], model) as Record<string, any>[];
     const instructionParts: string[] = [];
 
-    if (usesGrokCliProxy) {
+    if (usesGrokCliCompatibility) {
       input = input.filter((item) => {
         if (!item || typeof item !== "object") return true;
         if (item.type === "reasoning") return false;
@@ -171,7 +171,7 @@ export function rewriteXaiResponsesPayload(payload: unknown, model: Model<Api>, 
     }
   }
 
-  if (usesGrokCliProxy && Array.isArray(body.include)) {
+  if (usesGrokCliCompatibility && Array.isArray(body.include)) {
     body.include = body.include.filter((item: unknown) => item !== "reasoning.encrypted_content");
     if (body.include.length === 0) delete body.include;
   }

--- a/extensions/xai/responses.ts
+++ b/extensions/xai/responses.ts
@@ -2,8 +2,9 @@ import type { Api, Context, Model, SimpleStreamOptions } from "@earendil-works/p
 import { openAIResponsesApi } from "@earendil-works/pi-ai/compat";
 import { randomUUID } from "crypto";
 import { compactXaiInlineImages } from "./images";
-import { isGrokCliProxyModel, xaiBaseUrlForModel, xaiModelForRequest, xaiModelRequestHeaders, xaiResponsesUrlForModel } from "./models";
+import { isGrokCliCompatibilityModel, xaiModelForRequest, xaiModelRequestHeaders } from "./models";
 import { rewriteXaiResponsesPayload } from "./payload";
+import { resolveXaiRoute, type XaiCredential } from "./routing";
 
 type AssistantStreamEvent = Record<string, any>;
 
@@ -103,9 +104,9 @@ function streamErrorMessage(model: Model<Api>, error: unknown) {
   };
 }
 
-/** POST a JSON body to an xAI endpoint with OAuth bearer auth. */
+/** POST a JSON body to an xAI endpoint with bearer authentication. */
 export async function postXaiJson(
-  apiKey: string,
+  authToken: string,
   url: string,
   body: Record<string, any>,
   signal?: AbortSignal,
@@ -115,7 +116,7 @@ export async function postXaiJson(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
+      Authorization: `Bearer ${authToken}`,
       ...headers,
     },
     body: JSON.stringify(body),
@@ -132,21 +133,27 @@ export async function postXaiJson(
   return response.json();
 }
 
-/** Create a single xAI Responses API response with model-aware routing. */
-export async function createXaiResponse(apiKey: string, body: Record<string, any>, signal?: AbortSignal): Promise<any> {
-  const model = xaiModelForRequest(typeof body.model === "string" ? body.model : undefined);
+/** Create one xAI Responses result using explicit credential-aware routing. */
+export async function createXaiResponse(
+  credential: XaiCredential,
+  body: Record<string, any>,
+  signal?: AbortSignal,
+): Promise<any> {
+  const model = xaiModelForRequest(typeof body.model === "string" ? body.model : undefined, credential.kind);
+  const route = resolveXaiRoute(credential.kind, "responses");
   const rewritten = rewriteXaiResponsesPayload(body, model);
   const payload = (await compactXaiInlineImages(rewritten)) as Record<string, any>;
-  const usesGrokCliProxy = isGrokCliProxyModel(model.id);
-  const grokCliSessionId = usesGrokCliProxy
+  const usesGrokCliCompatibility =
+    credential.kind === "oauth-session" && isGrokCliCompatibilityModel(model.id);
+  const grokCliSessionId = usesGrokCliCompatibility
     ? (typeof body.previous_response_id === "string" && body.previous_response_id) || randomUUID()
     : undefined;
   return postXaiJson(
-    apiKey,
-    xaiResponsesUrlForModel(model.id),
+    credential.token,
+    route.url,
     payload,
     signal,
-    xaiModelRequestHeaders(model.id, grokCliSessionId),
+    xaiModelRequestHeaders(model.id, credential.kind, grokCliSessionId),
   );
 }
 
@@ -167,19 +174,25 @@ export async function createXaiResponse(apiKey: string, body: Record<string, any
  * @returns A forwarding assistant stream compatible with pi's async iterator and `result()` contract.
  */
 export function streamSimpleXaiResponses(model: Model<Api>, context: Context, options?: SimpleStreamOptions) {
-  // Prefer pi's stable session id for cache routing. For Grok CLI proxy only,
-  // fall back to a per-stream id so x-grok-conv-id is always present.
-  // Docs: Responses API uses body.prompt_cache_key; Chat Completions / CLI
-  // proxy also benefit from the x-grok-conv-id header.
+  // The registered xai-auth provider is OAuth-only, so bind its stream to
+  // session-token routing instead of inferring credential provenance from the
+  // bearer string. Build/Composer keep their separate compatibility headers.
+  const credentialKind = "oauth-session" as const;
+  const route = resolveXaiRoute(credentialKind, "responses");
+
+  // Prefer pi's stable session id for cache routing. For Grok CLI compatibility
+  // models, fall back to a per-stream id so x-grok-conv-id is always present.
+  // Docs: Responses API uses body.prompt_cache_key; the proxy also benefits
+  // from the x-grok-conv-id header.
   // https://docs.x.ai/developers/advanced-api-usage/prompt-caching/maximizing-cache-hits
   const sessionId = options?.sessionId;
-  const routingSessionId = sessionId || (isGrokCliProxyModel(model.id) ? randomUUID() : undefined);
+  const routingSessionId = sessionId || (isGrokCliCompatibilityModel(model.id) ? randomUUID() : undefined);
   const streamModel = {
     ...model,
-    baseUrl: xaiBaseUrlForModel(model.id),
+    baseUrl: route.baseUrl,
     headers: {
       ...(model as any).headers,
-      ...xaiModelRequestHeaders(model.id, routingSessionId),
+      ...xaiModelRequestHeaders(model.id, credentialKind, routingSessionId),
     },
   };
   // Keep the xAI stream model for routing/payload rewriting, but delegate with

--- a/extensions/xai/routing.ts
+++ b/extensions/xai/routing.ts
@@ -1,0 +1,39 @@
+import {
+  XAI_API_BASE_URL,
+  XAI_CLI_BASE_URL,
+  XAI_CLI_RESPONSES_URL,
+  XAI_IMAGES_GENERATIONS_URL,
+  XAI_RESPONSES_URL,
+} from "./constants";
+
+export type XaiCredentialKind = "oauth-session" | "api-key";
+
+export interface XaiCredential {
+  kind: XaiCredentialKind;
+  token: string;
+}
+
+export type XaiRequestKind = "responses" | "image-generation";
+
+export interface XaiRoute {
+  baseUrl: string;
+  url: string;
+}
+
+const XAI_ROUTES: Record<XaiCredentialKind, Record<XaiRequestKind, XaiRoute>> = {
+  "oauth-session": {
+    responses: { baseUrl: XAI_CLI_BASE_URL, url: XAI_CLI_RESPONSES_URL },
+    // Official Grok Build sends Imagine requests directly to api.x.ai for
+    // both OAuth sessions and BYOK credentials rather than via the chat proxy.
+    "image-generation": { baseUrl: XAI_API_BASE_URL, url: XAI_IMAGES_GENERATIONS_URL },
+  },
+  "api-key": {
+    responses: { baseUrl: XAI_API_BASE_URL, url: XAI_RESPONSES_URL },
+    "image-generation": { baseUrl: XAI_API_BASE_URL, url: XAI_IMAGES_GENERATIONS_URL },
+  },
+};
+
+/** Resolve an xAI endpoint from credential provenance and request kind. */
+export function resolveXaiRoute(credentialKind: XaiCredentialKind, requestKind: XaiRequestKind): XaiRoute {
+  return { ...XAI_ROUTES[credentialKind][requestKind] };
+}

--- a/extensions/xai/tools/commands.ts
+++ b/extensions/xai/tools/commands.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import type { Api, Model } from "@earendil-works/pi-ai";
-import { isGrokCliProxyModel } from "../models";
+import { isGrokCliCompatibilityModel } from "../models";
 import {
   activeXaiModel,
   isXaiNetworkToolActive,
@@ -40,13 +40,13 @@ function commandToolName(value: string | undefined): XaiNetworkToolName | undefi
 
 function eligibleToolOptions(model: Model<Api>): readonly NetworkToolOption[] {
   return NETWORK_TOOL_OPTIONS.filter(
-    ({ name }) => name !== "WebSearch" || isGrokCliProxyModel(model.id),
+    ({ name }) => name !== "WebSearch" || isGrokCliCompatibilityModel(model.id),
   );
 }
 
 function activeToolStatus(pi: ExtensionAPI, model: Model<Api> | undefined): string {
   return NETWORK_TOOL_OPTIONS.map(({ name }) => {
-    const unavailable = name === "WebSearch" && (!model || !isGrokCliProxyModel(model.id));
+    const unavailable = name === "WebSearch" && (!model || !isGrokCliCompatibilityModel(model.id));
     if (unavailable) return `${name}=unavailable`;
     return `${name}=${isXaiNetworkToolActive(pi, name) ? "enabled" : "disabled"}`;
   }).join(", ");

--- a/extensions/xai/tools/cursor-shims.ts
+++ b/extensions/xai/tools/cursor-shims.ts
@@ -11,9 +11,9 @@ import type { Api, Model } from "@earendil-works/pi-ai";
 import { readdir, readFile, rm, stat } from "fs/promises";
 import { join, relative, sep } from "path";
 import { Type } from "typebox";
-import { resolveXaiAuthToken } from "../auth";
+import { resolveXaiCredential } from "../auth";
 import { XAI_CURSOR_AUTO_TOOL_NAMES, XAI_PROVIDER_ID } from "../constants";
-import { isGrokCliProxyModel } from "../models";
+import { isGrokCliCompatibilityModel } from "../models";
 import { createXaiResponse } from "../responses";
 import { extractResponsesText, messageFromError, statusFromError } from "../text";
 import { xaiToolError } from "./common";
@@ -328,7 +328,7 @@ export function syncCursorToolShimsForModel(api: any, model?: Model<Api>) {
     return;
   }
   const withoutCursorShims = activeTools.filter((toolName) => !XAI_CURSOR_AUTO_TOOL_NAMES.includes(toolName));
-  const shouldEnableCursorShims = model?.provider === XAI_PROVIDER_ID && isGrokCliProxyModel(model.id);
+  const shouldEnableCursorShims = model?.provider === XAI_PROVIDER_ID && isGrokCliCompatibilityModel(model.id);
   const nextTools = shouldEnableCursorShims
     ? uniqueToolNames([...withoutCursorShims, ...XAI_CURSOR_AUTO_TOOL_NAMES])
     : withoutCursorShims;
@@ -542,18 +542,18 @@ export function registerCursorToolShims(pi: ExtensionAPI) {
       execute: async (_toolCallId: string, params: any, _signal: any, _onUpdate: any, ctx: any) => {
         const query = firstString(params?.query, params?.search_term, params?.value);
         if (!query) return xaiToolError("Error: WebSearch requires a query.");
-        if (ctx?.model?.provider !== XAI_PROVIDER_ID || !isGrokCliProxyModel(ctx.model.id)) {
+        if (ctx?.model?.provider !== XAI_PROVIDER_ID || !isGrokCliCompatibilityModel(ctx.model.id)) {
           return xaiToolError("Error: WebSearch requires an active xAI Grok Build or Composer model. No xAI request was sent.");
         }
         if (!isXaiNetworkToolActive(pi, "WebSearch")) {
           return xaiToolError("Error: WebSearch is disabled. Run /xai-tools to enable it and request it explicitly. No xAI request was sent.");
         }
-        const apiKey = await resolveXaiAuthToken(ctx);
-        if (!apiKey) return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.");
+        const credential = await resolveXaiCredential(ctx);
+        if (!credential) return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.");
 
         try {
           const data = await createXaiResponse(
-            apiKey,
+            credential,
             {
               model: ctx.model.id,
               input: `Search the web for: ${query}\n\nSummarize the key results with sources where available.`,

--- a/extensions/xai/tools/custom-tools.ts
+++ b/extensions/xai/tools/custom-tools.ts
@@ -1,9 +1,10 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { resolveXaiAuthToken } from "../auth";
-import { DEFAULT_XAI_IMAGE_MODEL, DEFAULT_XAI_MODEL, XAI_IMAGES_GENERATIONS_URL } from "../constants";
+import { resolveXaiCredential } from "../auth";
+import { DEFAULT_XAI_IMAGE_MODEL, DEFAULT_XAI_MODEL } from "../constants";
 import { normalizeXaiImageInput } from "../images";
 import { grokSupportsReasoningEffort, normalizedXaiModelId } from "../models";
 import { createXaiResponse, postXaiJson } from "../responses";
+import { resolveXaiRoute } from "../routing";
 import { extractResponsesText, messageFromError, statusFromError } from "../text";
 import { xaiTextInput, xaiToolError } from "./common";
 import { activeXaiModel, isXaiNetworkToolActive, type XaiNetworkToolName } from "./model-scope";
@@ -49,8 +50,8 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
         if (!activeModelForXaiTool(pi, ctx, "xai_generate_text")) {
           return xaiToolDisabledError("xai_generate_text", { prompt: params?.prompt });
         }
-        const apiKey = await resolveXaiAuthToken(ctx);
-        if (!apiKey) {
+        const credential = await resolveXaiCredential(ctx);
+        if (!credential) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { reasoning: "", response_id: "" });
         }
 
@@ -87,7 +88,7 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
 
         let data: any;
         try {
-          data = await createXaiResponse(apiKey, body, _signal);
+          data = await createXaiResponse(credential, body, _signal);
         } catch (error) {
           const status = statusFromError(error);
           return xaiToolError(`xAI API Error${status ? ` ${status}` : ""}: ${messageFromError(error)}`, {
@@ -127,8 +128,8 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
         if (!activeModelForXaiTool(pi, ctx, "xai_multi_agent")) {
           return xaiToolDisabledError("xai_multi_agent", { query: params?.query });
         }
-        const apiKey = await resolveXaiAuthToken(ctx);
-        if (!apiKey) {
+        const credential = await resolveXaiCredential(ctx);
+        if (!credential) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { agents_used: 0, response_id: "" });
         }
 
@@ -138,7 +139,7 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
         const prompt = `You are leading a team of ${agentsUsed} researchers. Research: ${params.query}`;
         let data: any;
         try {
-          data = await createXaiResponse(apiKey, {
+          data = await createXaiResponse(credential, {
             model: "grok-4.20-multi-agent-0309",
             input: xaiTextInput(prompt),
             reasoning: { effort },
@@ -179,14 +180,14 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
       execute: async (_toolCallId: string, params: { query?: string }, _signal: any, _onUpdate: any, ctx: any) => {
         const activeModel = activeModelForXaiTool(pi, ctx, "xai_web_search");
         if (!activeModel) return xaiToolDisabledError("xai_web_search", { query: params?.query });
-        const apiKey = await resolveXaiAuthToken(ctx);
-        if (!apiKey) {
+        const credential = await resolveXaiCredential(ctx);
+        if (!credential) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { query: params?.query });
         }
         const prompt = `Search the web for: ${params.query}. Summarize the top results with sources, key facts, dates, and recent developments. Prioritize authoritative sources.`;
         let data: any;
         try {
-          data = await createXaiResponse(apiKey, {
+          data = await createXaiResponse(credential, {
             model: activeModel.id,
             input: xaiTextInput(prompt),
             reasoning: { effort: "medium" },
@@ -219,8 +220,8 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
       execute: async (_toolCallId: string, params: { query?: string; count?: number; since?: string; until?: string }, _signal: any, _onUpdate: any, ctx: any) => {
         const activeModel = activeModelForXaiTool(pi, ctx, "xai_x_search");
         if (!activeModel) return xaiToolDisabledError("xai_x_search", { query: params?.query });
-        const apiKey = await resolveXaiAuthToken(ctx);
-        if (!apiKey) {
+        const credential = await resolveXaiCredential(ctx);
+        if (!credential) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { query: params?.query });
         }
         let prompt = `You have native real-time access to X (Twitter) posts and trends via Grok's built-in X search. Use it to find the most relevant recent posts about: ${params.query}.
@@ -243,7 +244,7 @@ Be specific and cite examples where helpful.`;
         if (params.until) xSearchTool.to_date = params.until;
         let data: any;
         try {
-          data = await createXaiResponse(apiKey, {
+          data = await createXaiResponse(credential, {
             model: activeModel.id,
             input: xaiTextInput(prompt),
             reasoning: { effort: "medium" },
@@ -272,14 +273,14 @@ Be specific and cite examples where helpful.`;
         if (!activeModelForXaiTool(pi, ctx, "xai_code_execution")) {
           return xaiToolDisabledError("xai_code_execution", { code: params?.code });
         }
-        const apiKey = await resolveXaiAuthToken(ctx);
-        if (!apiKey) {
+        const credential = await resolveXaiCredential(ctx);
+        if (!credential) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { code: params?.code });
         }
         const prompt = `Execute this Python code and show the result or output:\n\n${params.code}`;
         let data: any;
         try {
-          data = await createXaiResponse(apiKey, {
+          data = await createXaiResponse(credential, {
             model: DEFAULT_XAI_MODEL,
             input: xaiTextInput(prompt),
             reasoning: { effort: "low" },
@@ -326,8 +327,8 @@ Be specific and cite examples where helpful.`;
           });
         }
 
-        const apiKey = await resolveXaiAuthToken(ctx);
-        if (!apiKey) {
+        const credential = await resolveXaiCredential(ctx);
+        if (!credential) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { prompt: params?.prompt });
         }
         const body: Record<string, any> = {
@@ -340,7 +341,8 @@ Be specific and cite examples where helpful.`;
 
         let data: any;
         try {
-          data = await postXaiJson(apiKey, XAI_IMAGES_GENERATIONS_URL, body, _signal);
+          const route = resolveXaiRoute(credential.kind, "image-generation");
+          data = await postXaiJson(credential.token, route.url, body, _signal);
         } catch (error) {
           const status = statusFromError(error);
           return xaiToolError(`xAI Image API Error${status ? ` ${status}` : ""}: ${messageFromError(error)}`, { error: true, status, prompt: params.prompt });
@@ -373,8 +375,8 @@ Be specific and cite examples where helpful.`;
         if (!activeModelForXaiTool(pi, ctx, "xai_critique")) {
           return xaiToolDisabledError("xai_critique", { content: params?.content });
         }
-        const apiKey = await resolveXaiAuthToken(ctx);
-        if (!apiKey) {
+        const credential = await resolveXaiCredential(ctx);
+        if (!credential) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { content: params?.content });
         }
         const aspect = params.aspect || "overall quality and correctness";
@@ -382,7 +384,7 @@ Be specific and cite examples where helpful.`;
         const prompt = `Provide a ${tone} critique focused on ${aspect}.\n\nContent to critique:\n${params.content}\n\nStructure your response with:\n- Strengths\n- Weaknesses / Issues\n- Specific suggestions for improvement\n- Overall assessment (score 1-10)\nUse step-by-step reasoning.`;
         let data: any;
         try {
-          data = await createXaiResponse(apiKey, { model: DEFAULT_XAI_MODEL, input: xaiTextInput(prompt), reasoning: { effort: "high" } }, _signal);
+          data = await createXaiResponse(credential, { model: DEFAULT_XAI_MODEL, input: xaiTextInput(prompt), reasoning: { effort: "high" } }, _signal);
         } catch (error) {
           const status = statusFromError(error);
           return xaiToolError(`xAI API Error${status ? ` ${status}` : ""}: ${messageFromError(error)}`, { error: true, status });
@@ -409,8 +411,8 @@ Be specific and cite examples where helpful.`;
         if (!activeModelForXaiTool(pi, ctx, "xai_analyze_image")) {
           return xaiToolDisabledError("xai_analyze_image", { image: params?.image });
         }
-        const apiKey = await resolveXaiAuthToken(ctx);
-        if (!apiKey) {
+        const credential = await resolveXaiCredential(ctx);
+        if (!credential) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { image: params?.image });
         }
         const question = params.question || "Describe this image in detail, including objects, text, style, and any notable details.";
@@ -418,7 +420,7 @@ Be specific and cite examples where helpful.`;
         const input = [{ role: "user", content: [{ type: "input_image", image_url: imageInput, detail: "high" }, { type: "input_text", text: question }] }];
         let data: any;
         try {
-          data = await createXaiResponse(apiKey, { model: DEFAULT_XAI_MODEL, input, reasoning: { effort: "medium" } }, _signal);
+          data = await createXaiResponse(credential, { model: DEFAULT_XAI_MODEL, input, reasoning: { effort: "medium" } }, _signal);
         } catch (error) {
           const status = statusFromError(error);
           return xaiToolError(`xAI API Error${status ? ` ${status}` : ""}: ${messageFromError(error)}`, { error: true, status, image: params.image });
@@ -444,15 +446,15 @@ Be specific and cite examples where helpful.`;
       execute: async (_toolCallId: string, params: { topic?: string; depth?: string }, _signal: any, _onUpdate: any, ctx: any) => {
         const activeModel = activeModelForXaiTool(pi, ctx, "xai_deep_research");
         if (!activeModel) return xaiToolDisabledError("xai_deep_research", { topic: params?.topic });
-        const apiKey = await resolveXaiAuthToken(ctx);
-        if (!apiKey) {
+        const credential = await resolveXaiCredential(ctx);
+        if (!credential) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { topic: params?.topic });
         }
         const depth = params.depth || "high";
         const prompt = `Conduct deep ${depth} research on: ${params.topic}.\n\nSteps:\n1. Gather key facts, recent developments, and authoritative sources.\n2. Analyze different perspectives and potential biases.\n3. Synthesize findings into clear conclusions.\n4. Provide actionable insights and open questions.\n\nUse step-by-step reasoning and cite sources where possible.`;
         let data: any;
         try {
-          data = await createXaiResponse(apiKey, {
+          data = await createXaiResponse(credential, {
             model: activeModel.id,
             input: xaiTextInput(prompt),
             reasoning: { effort: depth === "high" ? "high" : "medium" },

--- a/extensions/xai/tools/model-scope.ts
+++ b/extensions/xai/tools/model-scope.ts
@@ -1,7 +1,7 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { XAI_PROVIDER_ID } from "../constants";
-import { isGrokCliProxyModel } from "../models";
+import { isGrokCliCompatibilityModel } from "../models";
 
 /** Network-backed xAI tools that make an additional authenticated API request. */
 export const XAI_NETWORK_TOOL_NAMES = [
@@ -72,7 +72,7 @@ export function setXaiNetworkToolActive(
       error: "Select an xAI/Grok model before enabling a network-backed xAI tool.",
     };
   }
-  if (active && toolName === "WebSearch" && !isGrokCliProxyModel(xaiModel!.id)) {
+  if (active && toolName === "WebSearch" && !isGrokCliCompatibilityModel(xaiModel!.id)) {
     return {
       ok: false,
       active: false,
@@ -93,7 +93,7 @@ export function setXaiNetworkToolActive(
   // remove only the named tool — never replace the whole authorization set with
   // an empty set or delete every remaining opt-in.
   const nextSelection = new Set(previousSelection);
-  if (xaiModel && !isGrokCliProxyModel(xaiModel.id)) nextSelection.delete("WebSearch");
+  if (xaiModel && !isGrokCliCompatibilityModel(xaiModel.id)) nextSelection.delete("WebSearch");
   if (active) nextSelection.add(toolName);
   else nextSelection.delete(toolName);
 
@@ -145,7 +145,7 @@ export function syncXaiNetworkToolsForModel(api: any, model?: Model<Api>, option
     enabledNetworkTools = new Set();
   } else {
     enabledNetworkTools = new Set(explicitlyEnabledXaiNetworkTools.get(scope) ?? []);
-    if (!isGrokCliProxyModel(xaiModel.id)) enabledNetworkTools.delete("WebSearch");
+    if (!isGrokCliCompatibilityModel(xaiModel.id)) enabledNetworkTools.delete("WebSearch");
     explicitlyEnabledXaiNetworkTools.set(scope, enabledNetworkTools);
   }
 

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -14,6 +14,7 @@ const { compactXaiInlineImages, MAX_XAI_INLINE_IMAGE_BASE64_BYTES } = jiti(
 );
 const { rewriteXaiResponsesPayload } = jiti(path.join(repoRoot, "extensions", "xai", "payload.ts"));
 const { createXaiResponse } = jiti(path.join(repoRoot, "extensions", "xai", "responses.ts"));
+const { resolveXaiRoute } = jiti(path.join(repoRoot, "extensions", "xai", "routing.ts"));
 const { XAI_NETWORK_TOOL_NAMES } = jiti(path.join(repoRoot, "extensions", "xai", "tools", "model-scope.ts"));
 const originalFetch = global.fetch;
 const requests = [];
@@ -23,12 +24,22 @@ const TEST_XAI_MODEL = {
   id: "grok-4.5",
   provider: "xai-auth",
   api: "xai-responses",
-  baseUrl: "https://api.x.ai/v1",
+  baseUrl: "https://cli-chat-proxy.grok.com/v1",
   headers: {},
   reasoning: true,
   input: ["text", "image"],
 };
 
+const OAUTH_CREDENTIAL = { kind: "oauth-session", token: "oauth-token" };
+const API_KEY_CREDENTIAL = { kind: "api-key", token: "api-key-token" };
+const OAUTH_RESPONSES_MODEL_IDS = [
+  "grok-4.5",
+  "grok-4.3",
+  "grok-4.20-0309-reasoning",
+  "grok-build",
+  "grok-composer-2.5-fast",
+];
+const GROK_CLI_COMPATIBILITY_MODEL_IDS = new Set(["grok-build", "grok-composer-2.5-fast"]);
 const XAI_NETWORK_TOOLS = [...XAI_NETWORK_TOOL_NAMES];
 const CUSTOM_XAI_NETWORK_TOOLS = XAI_NETWORK_TOOLS.filter((name) => name !== "WebSearch");
 
@@ -66,7 +77,7 @@ function installFetchMock() {
 
     const body = init.body ? JSON.parse(String(init.body)) : undefined;
     requests.push({ url: href, headers: init.headers || {}, body, signal: init.signal });
-    if (nextXaiResponse && urlOriginIs(href, "https://api.x.ai")) {
+    if (nextXaiResponse && href.endsWith("/responses")) {
       const response = nextXaiResponse;
       nextXaiResponse = undefined;
       return jsonResponse(response.body, { status: response.status });
@@ -183,7 +194,7 @@ async function runTool(
   name,
   params = {},
   expectedText = "OK",
-  requestOrigin = "https://api.x.ai",
+  requestOrigin = "https://cli-chat-proxy.grok.com",
   model = TEST_XAI_MODEL,
 ) {
   const controller = new AbortController();
@@ -849,7 +860,7 @@ async function verifyXaiImageTransport(provider) {
   ];
 
   const beforeDirect = requests.length;
-  await createXaiResponse("oauth-token", { model: TEST_XAI_MODEL.id, input, max_output_tokens: 32 });
+  await createXaiResponse(OAUTH_CREDENTIAL, { model: TEST_XAI_MODEL.id, input, max_output_tokens: 32 });
   const directRequest = requests.slice(beforeDirect).find((entry) => entry.url?.endsWith("/responses"));
   assert.ok(directRequest, "createXaiResponse should send the prepared payload");
   assert.ok(inlineImageBase64Bytes(directRequest.body) <= MAX_XAI_INLINE_IMAGE_BASE64_BYTES);
@@ -972,7 +983,7 @@ async function verifyXaiResponsesTransport(provider) {
           id: "grok-4.3",
           provider: "xai-auth",
           api: "xai-responses",
-          baseUrl: "https://api.x.ai/v1",
+          baseUrl: "https://cli-chat-proxy.grok.com/v1",
           headers: {},
           reasoning: true,
           input: ["text", "image"],
@@ -987,35 +998,115 @@ async function verifyXaiResponsesTransport(provider) {
   assert.ok(typeof message === "string", "xAI provider stream should expose a terminal result message");
   assert.equal(compatDispatcherCalled, false, "xAI stream should bypass conflicting compat API registrations");
   assert.ok(
-    requests.slice(before).some((entry) => entry.url && urlOriginIs(entry.url, "https://api.x.ai")),
-    "xAI stream should reach the xAI endpoint through the OpenAI Responses transport",
+    requests.slice(before).some((entry) => entry.url && urlOriginIs(entry.url, "https://cli-chat-proxy.grok.com")),
+    "xAI OAuth streams should reach the session-token proxy through the OpenAI Responses transport",
   );
 }
 
 
-async function verifyCliModelStreamRouting(provider) {
-  const composer = provider.models.find((model) => model.id === "grok-composer-2.5-fast");
-  const model = {
-    ...composer,
-    provider: "xai-auth",
-    api: provider.api,
-    baseUrl: provider.baseUrl,
-  };
+function verifyCredentialAwareRouteMatrix() {
+  const oauthResponses = resolveXaiRoute("oauth-session", "responses");
+  assert.equal(oauthResponses.baseUrl, "https://cli-chat-proxy.grok.com/v1");
+  assert.equal(oauthResponses.url, "https://cli-chat-proxy.grok.com/v1/responses");
+
+  const apiKeyResponses = resolveXaiRoute("api-key", "responses");
+  assert.equal(apiKeyResponses.baseUrl, "https://api.x.ai/v1");
+  assert.equal(apiKeyResponses.url, "https://api.x.ai/v1/responses");
+
+  for (const credentialKind of ["oauth-session", "api-key"]) {
+    const imageRoute = resolveXaiRoute(credentialKind, "image-generation");
+    assert.equal(imageRoute.baseUrl, "https://api.x.ai/v1", `${credentialKind} image generation should stay direct`);
+    assert.equal(
+      imageRoute.url,
+      "https://api.x.ai/v1/images/generations",
+      `${credentialKind} image generation should use the public Images endpoint`,
+    );
+  }
+}
+
+async function verifyOAuthResponsesRouting(provider) {
+  for (const modelId of OAUTH_RESPONSES_MODEL_IDS) {
+    const catalogModel = provider.models.find((model) => model.id === modelId);
+    assert.ok(catalogModel, `${modelId} should exist in the provider catalog`);
+    const model = {
+      ...catalogModel,
+      provider: "xai-auth",
+      api: provider.api,
+      baseUrl: provider.baseUrl,
+    };
+    const isCompatibilityModel = GROK_CLI_COMPATIBILITY_MODEL_IDS.has(modelId);
+    const sessionId = `stream-${modelId}`;
+
+    const beforeStream = requests.length;
+    const stream = provider.streamSimple(
+      model,
+      { messages: [{ role: "user", content: "hello", timestamp: Date.now() }] },
+      { apiKey: OAUTH_CREDENTIAL.token, sessionId },
+    );
+    await stream.result();
+    const streamRequest = requests
+      .slice(beforeStream)
+      .find((entry) => entry.url?.endsWith("/responses"));
+    assert.ok(streamRequest, `${modelId} provider stream should send a Responses request`);
+    assert.ok(
+      urlOriginIs(streamRequest.url, "https://cli-chat-proxy.grok.com"),
+      `${modelId} OAuth provider stream should use the session-token proxy`,
+    );
+    assert.equal(streamRequest.body.model, modelId);
+    assert.equal(headerValue(streamRequest.headers, "Authorization"), "Bearer oauth-token");
+    assert.equal(
+      headerValue(streamRequest.headers, "x-xai-token-auth"),
+      isCompatibilityModel ? "xai-grok-cli" : undefined,
+      `${modelId} should ${isCompatibilityModel ? "receive" : "not receive"} Grok CLI token headers`,
+    );
+    assert.equal(
+      headerValue(streamRequest.headers, "x-grok-model-override"),
+      isCompatibilityModel ? modelId : undefined,
+      `${modelId} should ${isCompatibilityModel ? "receive" : "not receive"} a model override header`,
+    );
+    if (isCompatibilityModel) {
+      assert.equal(headerValue(streamRequest.headers, "x-grok-conv-id"), sessionId);
+    }
+    if (modelId === "grok-composer-2.5-fast") {
+      assert.equal(streamRequest.body.reasoning, undefined, "Composer 2.5 provider streams should omit reasoning effort");
+    }
+
+    const beforeDirect = requests.length;
+    await createXaiResponse(OAUTH_CREDENTIAL, { model: modelId, input: "hello" });
+    const directRequest = requests
+      .slice(beforeDirect)
+      .find((entry) => entry.url?.endsWith("/responses"));
+    assert.ok(directRequest, `${modelId} direct helper should send a Responses request`);
+    assert.ok(
+      urlOriginIs(directRequest.url, "https://cli-chat-proxy.grok.com"),
+      `${modelId} OAuth direct helper should use the session-token proxy`,
+    );
+    assert.equal(directRequest.body.model, modelId);
+    assert.equal(headerValue(directRequest.headers, "Authorization"), "Bearer oauth-token");
+    assert.equal(
+      headerValue(directRequest.headers, "x-xai-token-auth"),
+      isCompatibilityModel ? "xai-grok-cli" : undefined,
+    );
+    assert.equal(
+      headerValue(directRequest.headers, "x-grok-model-override"),
+      isCompatibilityModel ? modelId : undefined,
+    );
+    if (isCompatibilityModel) {
+      assert.ok(headerValue(directRequest.headers, "x-grok-conv-id"));
+    }
+  }
+}
+
+async function verifyApiKeyResponsesRouting() {
   const before = requests.length;
-  const stream = provider.streamSimple(
-    model,
-    { messages: [{ role: "user", content: "hello", timestamp: Date.now() }] },
-    { apiKey: "oauth-token", sessionId: "session-test" },
-  );
-  await stream.result();
-  const request = requests.slice(before).find((entry) => entry.url && urlOriginIs(entry.url, "https://cli-chat-proxy.grok.com"));
-  assert.ok(request, "Composer 2.5 provider streams should route to the Grok CLI endpoint");
-  assert.equal(request.body.model, "grok-composer-2.5-fast");
-  assert.equal(request.body.reasoning, undefined, "Composer 2.5 provider streams should not send reasoning effort");
-  assert.equal(headerValue(request.headers, "Authorization"), "Bearer oauth-token");
-  assert.equal(headerValue(request.headers, "x-xai-token-auth"), "xai-grok-cli");
-  assert.equal(headerValue(request.headers, "x-grok-model-override"), "grok-composer-2.5-fast");
-  assert.equal(headerValue(request.headers, "x-grok-conv-id"), "session-test");
+  await createXaiResponse(API_KEY_CREDENTIAL, { model: "grok-build", input: "hello" });
+  const request = requests.slice(before).find((entry) => entry.url?.endsWith("/responses"));
+  assert.ok(request, "explicit API-key routing should send a Responses request");
+  assert.ok(urlOriginIs(request.url, "https://api.x.ai"), "explicit API-key Responses should use api.x.ai");
+  assert.equal(headerValue(request.headers, "Authorization"), "Bearer api-key-token");
+  assert.equal(headerValue(request.headers, "x-xai-token-auth"), undefined);
+  assert.equal(headerValue(request.headers, "x-grok-model-override"), undefined);
+  assert.equal(headerValue(request.headers, "x-grok-conv-id"), undefined);
 }
 
 async function verifyOAuthCallbackState(provider) {
@@ -1146,6 +1237,7 @@ async function main() {
     assert.ok(firstLoad.commands.has("xai-tools"), "the xAI paid-tool command should be registered");
     assert.equal(secondLoad.commands.size, firstLoad.commands.size, "extension reloads should register commands on the new pi API object");
     assert.equal(provider.api, "xai-responses");
+    assert.equal(provider.baseUrl, "https://cli-chat-proxy.grok.com/v1", "xai-auth should register the OAuth session endpoint");
     const grok45 = provider.models.find((model) => model.id === "grok-4.5");
     assert.ok(grok45, "grok-4.5 should be registered in the xAI model catalog");
     assert.equal(grok45?.contextWindow, 500_000);
@@ -1166,13 +1258,15 @@ async function main() {
     await verifyXaiImageLifecycle();
     await verifyXaiImageCompaction();
 
+    verifyCredentialAwareRouteMatrix();
     await verifyOpenAIResponsesTransport();
     await verifyXaiResponsesTransport(provider);
+    await verifyOAuthResponsesRouting(provider);
+    await verifyApiKeyResponsesRouting();
 
     await verifyXaiImageTransport(provider);
     await verifyXaiStreamErrorPrefix(provider);
 
-    await verifyCliModelStreamRouting(provider);
     await verifyCursorToolActivation(firstLoad);
     await verifyCursorToolShims(firstLoad);
 
@@ -1248,7 +1342,9 @@ async function main() {
       authContext(selectedGrok43),
     );
     assert.match(providerErrorResult.content[0].text, /xAI API Error 403/);
-    const providerErrorRequests = requests.slice(beforeProviderError).filter((entry) => urlOriginIs(entry.url, "https://api.x.ai"));
+    const providerErrorRequests = requests
+      .slice(beforeProviderError)
+      .filter((entry) => urlOriginIs(entry.url, "https://cli-chat-proxy.grok.com"));
     assert.equal(providerErrorRequests.length, 1, "a provider failure should result in one xAI request, not an implicit retry loop");
     assert.equal(providerErrorRequests[0].body.model, selectedGrok43.id, "provider errors should still use the active selected model");
 
@@ -1270,7 +1366,13 @@ async function main() {
     assert.equal(imageContent[1].type, "input_text");
 
     const requestsBeforeImageGeneration = requests.length;
-    const { body: imageGenBody } = await runTool(tools, "xai_generate_image", { prompt: "a crisp diagram" }, /Generated 1 image/);
+    const { body: imageGenBody } = await runTool(
+      tools,
+      "xai_generate_image",
+      { prompt: "a crisp diagram" },
+      /Generated 1 image/,
+      "https://api.x.ai",
+    );
     assert.equal(requests.length, requestsBeforeImageGeneration + 1, "enabled image generation should send exactly one xAI request");
     assert.equal(imageGenBody.model, "grok-imagine-image-quality");
     const imageTool = tools.get("xai_generate_image");
@@ -1286,6 +1388,7 @@ async function main() {
       "xai_generate_image",
       { prompt: "three crisp diagrams", n: 3 },
       /Generated 1 image/,
+      "https://api.x.ai",
     );
     assert.equal(imageBatchBody.n, 3, "image generation should forward an explicit n value");
     assert.equal(Object.hasOwn(imageBatchBody, "size"), false, "explicit n requests should still omit size");


### PR DESCRIPTION
## Description

Route xAI Responses requests by explicit credential provenance instead of model ID:

- OAuth/session-token Responses traffic now uses `https://cli-chat-proxy.grok.com/v1` for every `xai-auth` model.
- A future explicitly tagged API-key path remains on `https://api.x.ai/v1`.
- Streaming and direct Responses helpers share the same routing resolver.
- Grok Build/Composer payload, header, Cursor-shim, and tool compatibility remains model-specific.
- Image generation remains intentionally direct to `api.x.ai`, matching the official Grok Build client.
- Regression coverage exercises actual outgoing requests for Grok 4.5, Grok 4.3, Grok 4.20, Grok Build, Composer, API-key routing, and image generation.
- README and changelog document the routing contract and subscription-only smoke procedure.

Closes #63

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] `npm test`
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] `npm pack --dry-run --json` (new routing module included; temporary scaffold/subagent/session artifacts excluded)
- [x] Two fresh-context review rounds; final round found no source, test, or documentation blockers
- [x] Live OAuth smoke with `XAI_API_KEY` absent

Live smoke results:

- Grok Build: `OAUTH_PROXY_OK`
- Composer 2.5: `OAUTH_PROXY_OK`
- Grok 4.5, Grok 4.3, Grok 4.20 reasoning, and the direct Grok 4.5 helper reached the CLI proxy but received HTTP 426 because the required client-version metadata is not yet sent for standard models.

The HTTP 426 is the separately scoped proxy-header/OAuth-scope work tracked by #65; endpoint selection is intentionally isolated in this PR, matching #63's non-goal.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Screenshots

Not applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core xAI request routing for all OAuth chat and tool Responses paths; wrong endpoints would break subscription OAuth usage, though regression tests cover the routing matrix.
> 
> **Overview**
> **OAuth/session Responses traffic** now uses the Grok CLI session proxy (`cli-chat-proxy.grok.com`) for every `xai-auth` model, instead of sending only Grok Build/Composer to the proxy and routing standard Grok models to `api.x.ai`.
> 
> A new **`routing.ts`** module centralizes endpoint choice by **credential kind** (`oauth-session` vs future `api-key`) and **request kind** (Responses vs image generation). Provider registration, streaming (`streamSimpleXaiResponses`), direct helpers (`createXaiResponse`), and custom tools all go through this resolver. **`resolveXaiCredential`** returns tagged OAuth credentials instead of a bare token string.
> 
> **Grok Build/Composer behavior** is split from transport: `isGrokCliCompatibilityModel` still drives payload cleanup, Cursor shims, WebSearch eligibility, and Grok CLI proxy headers—without deciding the base URL. Image generation **stays on** direct `api.x.ai` for both credential kinds, matching official Grok Build.
> 
> Docs and **table-driven tests** in `verify-extension.js` assert actual outgoing URLs and headers across model families; live smoke notes standard models may still hit HTTP 426 until proxy headers are addressed separately (#65).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f98126780b8e5e12e80ebf70c0a8ae9421e6d274. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->