### PR TITLE
Align OAuth scopes and Grok proxy headers

### DIFF
--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -30,5 +30,5 @@ Older credentials may continue refreshing and working, but refresh does not add 
 - Live OAuth smoke with `XAI_API_KEY` unset returned `OAUTH_PROXY_OK` for Grok 4.5, Grok Build, and Composer. Grok Build retried one transient upstream 503 before succeeding.
 - Independent review found and fixed client-mode parsing and authorization-spoof gaps; focused regression coverage passes.
 
-## Remaining Work
-Commit, push, and open the issue #65 PR against `main` without merging it. Do not invoke paid image generation.
+## Delivery
+The reviewed implementation is committed on `feature/issue-65-proxy-headers`, pushed to `origin`, and open against `main` as PR #71: https://github.com/BlockedPath/pi-xai-oauth/pull/71. The PR is intentionally unmerged; no paid image generation was invoked.

--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -1,33 +1,34 @@
 # Shared Agent Context
 
 **Project:** pi-xai-oauth
-**Branch:** feature/issue-63-auth-aware-routing
+**Branch:** feature/issue-65-proxy-headers
 **Date:** 2026-07-16
 
 ## Issue
-GitHub issue #63 reports that the OAuth-only `xai-auth` provider incorrectly routes ordinary Grok models to `api.x.ai`; only Grok Build and Composer previously used the official session-token proxy.
+GitHub issue #65 reports that fresh OAuth scopes and CLI-proxy request metadata lag the official Grok Build client. PR #70 already made Responses routing credential-aware; this issue changes the protocol metadata sent after routing, not endpoint selection.
 
-## Confirmed Contract
-- OAuth/session-token Responses inference → `https://cli-chat-proxy.grok.com/v1`.
-- Explicit external API-key Responses inference → `https://api.x.ai/v1`.
-- Endpoint selection must not depend on model ID or token shape.
-- Grok Build/Composer payload cleanup, Cursor shims, tool eligibility, and existing proxy headers remain model-specific compatibility behavior.
-- Official Grok Build commit `b189869` deliberately sends image generation for both OAuth and BYOK directly to `xai_api_base_url`.
+## Pinned Official Contract
+- Fresh personal OAuth grants request, in order: `openid profile email offline_access grok-cli:access api:access conversations:read conversations:write`.
+- Refresh exchanges send the existing refresh token and client ID without a new scope parameter.
+- Authenticated CLI-proxy requests require package/client version, `X-XAI-Token-Auth: xai-grok-cli`, `x-authenticateresponse: authenticate-response`, and client mode.
+- Official sampling transport also emits conversation, request, model override, and session identifiers per request.
+- Client mode is `headless` for pi print/explicit non-TUI mode and `interactive` otherwise.
 
-## Completed Implementation
-- Rebased onto current `origin/main`, preserving PR #62's selective `/xai-tools disable` fix.
-- Added one explicit credential/request routing matrix for OAuth-session and API-key Responses plus image generation.
-- Routed provider streaming and all direct OAuth Responses helpers through `cli-chat-proxy.grok.com`.
-- Preserved `api.x.ai` for an explicit future API-key Responses path and both image-generation credential kinds.
-- Kept Build/Composer compatibility payloads, headers, Cursor shims, and WebSearch eligibility model-specific.
-- Added actual-request regression coverage for Grok 4.5, Grok 4.3, Grok 4.20 reasoning, Grok Build, and Composer across streaming and direct helpers.
-- Documented a subscription-only manual smoke test and the image-generation exception.
+## Implementation
+- `extensions/xai/constants.ts` derives client name/version from module-relative `package.json` and carries the eight-scope fresh-login string.
+- `extensions/xai/models.ts` builds the complete OAuth proxy header set for all OAuth models and keeps API-key requests header-free.
+- `extensions/xai/responses.ts` applies stable stream session IDs (with UUID fallback), fresh request IDs, and coherent direct-call conversation/session UUIDs. Required metadata wins over caller headers.
+- Build/Composer capability checks remain limited to payload/tool/shim compatibility; `routing.ts` remains unchanged.
+- `scripts/verify-extension.js` asserts exact actual-fetch request shapes, scope order, legacy refresh forms, client modes, spoof resistance, and API-key absence.
 
-## Validation
-- `npm test`, `npm run typecheck`, and `git diff --check` pass before the final rebase.
-- `npm pack --dry-run --json` includes the routing module and excludes temporary subagent/scaffold/session artifacts.
-- Two fresh-context review rounds found no remaining code or documentation blockers.
-- Live OAuth smoke: Grok Build and Composer passed; Grok 4.5, Grok 4.3, Grok 4.20 reasoning, and the direct Grok 4.5 helper reached the proxy but failed HTTP 426 because the required Grok client-version header was absent.
+## User Migration
+Older credentials may continue refreshing and working, but refresh does not add `conversations:read` or `conversations:write`. To obtain the expanded grant, run `/login xai-auth` and answer `n` if prompted to reuse `~/.grok/auth.json`, forcing a fresh browser authorization.
 
-## Current Focus
-GitHub issue #65 tracks the proxy-header and OAuth-scope alignment exposed by the live smoke. Issue #63 remains focused on endpoint selection.
+## Validation State
+- LSP diagnostics, locked TypeScript 7.0.2 typecheck, `npm test`, and `git diff --check` pass.
+- Package inspection includes the changed runtime files and package metadata and excludes scaffold, subagent, credential, and session artifacts.
+- Live OAuth smoke with `XAI_API_KEY` unset returned `OAUTH_PROXY_OK` for Grok 4.5, Grok Build, and Composer. Grok Build retried one transient upstream 503 before succeeding.
+- Independent review found and fixed client-mode parsing and authorization-spoof gaps; focused regression coverage passes.
+
+## Remaining Work
+Commit, push, and open the issue #65 PR against `main` without merging it. Do not invoke paid image generation.

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -33,3 +33,8 @@ Align fresh xAI OAuth grants and every OAuth Responses request with the pinned o
 - Existing refresh tokens continue using their original grant; only a fresh login can add newly requested scopes.
 - Direct Responses calls mint their own coherent conversation/session UUID instead of treating `previous_response_id` as a session identifier.
 - The OAuth-only provider does not add API-key fallback and never logs or exposes bearer tokens.
+
+## Delivery
+- [x] Committed and pushed `feature/issue-65-proxy-headers`.
+- [x] Opened PR #71 against `main`: https://github.com/BlockedPath/pi-xai-oauth/pull/71
+- [x] Left the PR unmerged for external review.

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,30 +1,35 @@
-# Implementation Plan: Issue #63 OAuth-aware xAI routing
+# Implementation Plan: Issue #65 OAuth scopes and proxy metadata
 
-**Branch:** feature/issue-63-auth-aware-routing
+**Branch:** feature/issue-65-proxy-headers
 **Date:** 2026-07-16
 
 ## Goal
-Route xAI Responses traffic by credential kind rather than model ID: OAuth/session credentials use the official Grok CLI proxy, while a future explicit API-key path stays on the public xAI API.
+Align fresh xAI OAuth grants and every OAuth Responses request with the pinned official Grok Build scope and CLI-proxy metadata contracts without changing credential-aware endpoint routing.
 
 ## Implementation
-- [x] Add a credential- and operation-aware routing module.
-- [x] Separate Grok Build/Composer compatibility classification from endpoint selection.
-- [x] Return tagged OAuth credentials from the current OAuth-only auth resolver.
-- [x] Route provider streaming and every direct Responses helper through the shared resolver.
-- [x] Audit image generation through the resolver while preserving the official direct `api.x.ai` exception.
-- [x] Add table-driven regression coverage for Grok 4.5, Grok 4.3, Grok 4.20, Grok Build, Composer, API-key routing, and image generation.
-- [x] Document a subscription-only manual smoke test and update the Unreleased changelog.
+- [x] Request the frozen eight-scope OAuth contract for fresh browser logins.
+- [x] Preserve legacy refresh behavior without scope renegotiation.
+- [x] Derive the truthful `pi-xai-oauth` client identifier and version from package metadata.
+- [x] Add required auth-response and interactive/headless client-mode headers to every OAuth proxy request.
+- [x] Add request, conversation, session, and model headers for streaming and direct Responses calls.
+- [x] Keep required proxy metadata authoritative over caller-supplied headers.
+- [x] Keep API-key Responses free of OAuth proxy-only metadata.
+- [x] Add exact outgoing-request, OAuth-scope, refresh-body, spoof-protection, and client-mode regression coverage.
+- [x] Document refresh compatibility and the fresh re-login path for new scopes.
 
 ## Validation Contract
-- [x] `npm run typecheck`
-- [x] `npm test`
-- [x] `git diff --check`
-- [x] `npm pack --dry-run --json` includes `extensions/xai/routing.ts` and excludes temporary subagent/scaffold/session artifacts.
-- [x] Two fresh-context review rounds completed; round 2 found no code or documentation blockers.
-- [x] Manual subscription-only smoke test is documented.
-- [ ] Live subscription-only smoke passes: executed on 2026-07-16 with OAuth present and `XAI_API_KEY` absent; Grok Build and Composer passed, while Grok 4.5, Grok 4.3, Grok 4.20, and the direct Grok 4.5 helper reached the proxy but failed with HTTP 426 because standard models did not send the required Grok client-version header. Header alignment remains the separately scoped non-goal tracked by GitHub issue #65.
+- [x] Focused extension verification passes.
+- [x] `npm run typecheck` passes.
+- [x] Full `npm test` passes.
+- [x] `git diff --check` passes after documentation/scaffold updates.
+- [x] Parent-owned LSP diagnostics pass on the final TypeScript source (the persistent server cache was cross-checked with fresh exact-source copies).
+- [x] `npm pack --dry-run --json` contains package metadata and changed runtime files while excluding scaffold, subagent, credential, and session artifacts.
+- [x] Parent-owned safe live OAuth smoke returned `OAUTH_PROXY_OK` for Grok 4.5, Grok Build, and Composer; no image generation was invoked.
+- [x] Independent focused review/fix passes completed; client-mode parsing and authorization-spoof findings were fixed and revalidated.
 
 ## Scope Decisions
-- Header and OAuth scope alignment remain out of scope per issue #63.
-- Image generation remains at `https://api.x.ai/v1/images/generations` for OAuth and API-key credentials, matching official Grok Build commit `b189869`.
-- This package remains OAuth-only; API-key routing is an internal, explicitly tagged future path.
+- Endpoint selection remains credential-aware in `extensions/xai/routing.ts`; model checks do not select transport.
+- Grok Build/Composer payload and local tool compatibility remain model-specific and unchanged.
+- Existing refresh tokens continue using their original grant; only a fresh login can add newly requested scopes.
+- Direct Responses calls mint their own coherent conversation/session UUID instead of treating `previous_response_id` as a session identifier.
+- The OAuth-only provider does not add API-key fallback and never logs or exposes bearer tokens.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,34 +1,36 @@
 # Execution Progress
 
-**Project:** pi-xai-oauth Issue #63 OAuth-aware endpoint routing
-**Branch:** feature/issue-63-auth-aware-routing
+**Project:** pi-xai-oauth Issue #65 OAuth scopes and proxy metadata
+**Branch:** feature/issue-65-proxy-headers
 **Started:** 2026-07-16
 
-## Inherited Mainline Fixes
-- [x] Rebased onto current `origin/main`.
-- [x] Preserved PR #62's fix so disabling one xAI tool without an active xAI model does not clear sibling authorizations.
+## Research and Baseline
+- [x] Started from current `main` after merged PR #70.
+- [x] Read issue #65, provider/OAuth/routing/Responses code, tests, setup, and package documentation.
+- [x] Read pinned official Grok Build scope, proxy middleware, sampling-header, and client-mode sources at commit `b189869b7755d2b482969acf6c92da3ecfeffd36`.
+- [x] Confirmed baseline `npm test` and `npm run typecheck` pass.
 
-## Issue #63 Implementation
-- [x] Read issue #63, current provider/request paths, pi custom-provider docs/examples, and official Grok Build routing source.
-- [x] Confirmed baseline `npm run typecheck` and `npm test` pass.
-- [x] Completed parallel local audit, official-source research, and implementation planning.
-- [x] Clarified the image-generation exception: official Grok Build sends OAuth and BYOK Imagine requests directly to `api.x.ai`.
-- [x] Implemented credential-aware Responses routing: OAuth/session traffic uses the CLI proxy and an explicit future API-key path uses `api.x.ai`.
-- [x] Routed image generation through the same abstraction while preserving its official direct `api.x.ai` exception.
-- [x] Renamed the Build/Composer predicate so compatibility behavior remains separate from endpoint selection.
-- [x] Added table-driven actual-request coverage for OAuth streaming/direct helpers across Grok 4.5, Grok 4.3, Grok 4.20, Grok Build, and Composer.
-- [x] Added explicit API-key Responses and OAuth/API-key image-route coverage while preserving Build/Composer-only compatibility headers.
-- [x] Corrected TUI `/login` documentation and documented the subscription-only smoke flow.
-- [x] Completed two fresh-context review rounds and applied accepted documentation/metadata findings.
-- [x] Passed LSP diagnostics, `npm test`, `npm run typecheck`, `git diff --check`, and npm package inspection before the final rebase.
+## Implementation
+- [x] Added `conversations:read` and `conversations:write` to fresh OAuth authorization requests in official order.
+- [x] Preserved legacy refresh forms with no scope renegotiation.
+- [x] Replaced the stale Grok CLI version with package-derived `pi-xai-oauth` identity/version.
+- [x] Added complete auth, client-mode, conversation, request, model, and session metadata for every OAuth Responses proxy request.
+- [x] Kept explicit API-key Responses free of proxy-only metadata.
+- [x] Added stable stream IDs, UUID fallback, coherent direct-call IDs, and caller-spoof protection.
+- [x] Kept endpoint routing independent from model compatibility checks.
+- [x] Added exact actual-request and OAuth regression coverage.
+- [x] Updated README re-login guidance, Unreleased changelog, and scaffold state.
 
-## Live Smoke
-- [x] Installed the local checkout as the only `pi-xai-oauth` package.
-- [x] Verified OAuth credentials are present while `XAI_API_KEY` is absent.
-- [x] Grok Build and Composer returned `OAUTH_PROXY_OK`.
-- [x] Confirmed Grok 4.5, Grok 4.3, Grok 4.20 reasoning, and the direct Grok 4.5 helper reach the proxy.
-- [ ] Standard-model requests currently fail HTTP 426 because the required Grok client-version header is absent; GitHub issue #65 tracks header/scope alignment.
+## Validation
+- [x] Focused `node scripts/verify-extension.js` passes after implementation and review fixes.
+- [x] Locked TypeScript 7.0.2 `npm run typecheck` passes.
+- [x] Full `npm test` passes.
+- [x] Parent-owned LSP diagnostics pass on final TypeScript source; fresh exact-source copies bypassed a stale persistent-server buffer after the locked dependency reinstall.
+- [x] `git diff --check` passes after final edits.
+- [x] npm package inspection includes package metadata and runtime files and excludes scaffold, subagent, credential, and session artifacts.
+- [x] Safe live OAuth smoke with `XAI_API_KEY` unset returned `OAUTH_PROXY_OK` for Grok 4.5, Grok Build, and Composer; Grok Build recovered from one transient upstream 503.
+- [x] Independent focused review/fix passes completed; fixed truthful pi mode resolution and case-insensitive Authorization spoofing.
+- [x] No paid image generation was invoked.
 
 ## Next
-- [ ] Re-run full validation after rebase, push the branch, and open the issue #63 PR.
-- [ ] Address issue #65 separately before claiming all standard-model OAuth traffic is end-to-end operational.
+- [ ] Commit, push, and open a PR against `main` without merging it.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -32,5 +32,11 @@
 - [x] Independent focused review/fix passes completed; fixed truthful pi mode resolution and case-insensitive Authorization spoofing.
 - [x] No paid image generation was invoked.
 
+## Delivery
+- [x] Committed the reviewed implementation as `d01cb5e`.
+- [x] Pushed `feature/issue-65-proxy-headers` to `origin`.
+- [x] Opened PR #71 against `main`: https://github.com/BlockedPath/pi-xai-oauth/pull/71
+- [x] Left the PR unmerged.
+
 ## Next
-- [ ] Commit, push, and open a PR against `main` without merging it.
+- [ ] Await external PR review; preserve issue #65 scope when addressing feedback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 
 - Centralized xAI endpoint selection around explicit OAuth-session versus API-key credential provenance instead of model IDs.
 - Kept Grok Build and Composer payload, header, and tool compatibility separate from transport routing.
+- Updated fresh OAuth logins to request xAI's current eight-scope Grok client grant, including conversation read/write access, while leaving existing refresh grants compatible.
+- Derived the proxy client identifier and version from this package's own metadata instead of impersonating a stale Grok CLI release.
 
 ### Fixed
 
 - Routed normal streaming and separate Responses helpers for every `xai-auth` model through the official Grok CLI session-token proxy, matching the intended OAuth/session-token transport contract for Responses traffic.
 - Preserved the official direct `api.x.ai` Images endpoint for OAuth-backed image generation while keeping a future explicit API-key Responses route on the public API.
+- Added the complete CLI-proxy authentication, client-mode, request, conversation, session, and model metadata to every OAuth Responses request, with required values protected from caller overrides.
 
 ## 1.3.5 - 2026-07-15
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and
 5. The authorization code is exchanged for access + refresh tokens
 6. Tokens are persisted and refreshed automatically
 7. All OAuth-backed Responses traffic—normal streaming and separate Responses helpers—uses xAI's session-token proxy (`https://cli-chat-proxy.grok.com/v1`) rather than the public Responses endpoint on `https://api.x.ai/v1`
+8. Proxy requests identify this client as `pi-xai-oauth` at the installed package version and include xAI's required auth, client-mode, request, conversation, session, and model metadata
 
 If localhost callbacks are blocked (VPN, Docker, remote dev), the TUI shows a text field where you can paste the redirect URL manually.
 
@@ -176,6 +177,10 @@ Then, in the pi TUI:
 4. The browser redirects back to pi's local server — you can close the browser tab.
 5. Tokens are stored and refreshed automatically.
 
+Fresh logins request xAI's current eight-scope Grok client grant, including `conversations:read` and `conversations:write`. Credentials created before those scopes were added remain refreshable: refresh preserves the existing grant and does not renegotiate scopes.
+
+> **Need the new conversation scopes?** Run `/login xai-auth` for a fresh authorization grant. If pi finds `~/.grok/auth.json` and asks whether to reuse it, answer **`n`** so the browser login runs; reusing or refreshing an older credential will not add scopes. You do not need to re-login merely to keep using an older credential that already works for your requests.
+>
 > **Choosing a different browser/profile?** The instructions in the TUI explain how. You can copy the shown URL, open your preferred browser manually, and paste it there.
 
 ### Re-authenticating

--- a/extensions/xai/constants.ts
+++ b/extensions/xai/constants.ts
@@ -1,7 +1,10 @@
+import packageMetadata from "../../package.json";
+
 export const XAI_OAUTH_ISSUER = "https://auth.x.ai";
 export const XAI_OAUTH_DISCOVERY_URL = `${XAI_OAUTH_ISSUER}/.well-known/openid-configuration`;
 export const XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
-export const XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:access";
+export const XAI_OAUTH_SCOPE =
+  "openid profile email offline_access grok-cli:access api:access conversations:read conversations:write";
 export const XAI_OAUTH_REDIRECT_HOST = "127.0.0.1";
 export const XAI_OAUTH_REDIRECT_PORT = 56121;
 export const XAI_OAUTH_REDIRECT_PATH = "/callback";
@@ -12,8 +15,9 @@ export const XAI_CLI_BASE_URL = "https://cli-chat-proxy.grok.com/v1";
 export const XAI_RESPONSES_URL = "https://api.x.ai/v1/responses";
 export const XAI_CLI_RESPONSES_URL = "https://cli-chat-proxy.grok.com/v1/responses";
 export const XAI_IMAGES_GENERATIONS_URL = "https://api.x.ai/v1/images/generations";
-export const XAI_GROK_CLIENT_VERSION = "0.2.16";
 
+export const XAI_CLIENT_IDENTIFIER = packageMetadata.name;
+export const XAI_CLIENT_VERSION = packageMetadata.version;
 export const XAI_PROVIDER_ID = "xai-auth";
 export const DEFAULT_XAI_MODEL = "grok-4.5";
 export const DEFAULT_XAI_IMAGE_MODEL = "grok-imagine-image-quality";

--- a/extensions/xai/models.ts
+++ b/extensions/xai/models.ts
@@ -1,5 +1,10 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
-import { DEFAULT_XAI_MODEL, XAI_GROK_CLIENT_VERSION, XAI_PROVIDER_ID } from "./constants";
+import {
+  DEFAULT_XAI_MODEL,
+  XAI_CLIENT_IDENTIFIER,
+  XAI_CLIENT_VERSION,
+  XAI_PROVIDER_ID,
+} from "./constants";
 import { resolveXaiRoute, type XaiCredentialKind } from "./routing";
 
 export const MODELS = [
@@ -113,27 +118,55 @@ export function isGrokCliCompatibilityModel(modelId: string): boolean {
   return normalized === "grok-build" || normalized === "grok-composer-2.5-fast";
 }
 
-/** Build Grok CLI proxy headers for Composer/Grok Build requests. */
-export function grokCliProxyHeaders(modelId: string, sessionId?: string): Record<string, string> {
-  const headers: Record<string, string> = {
-    "x-grok-client-identifier": "pi-xai-oauth",
-    "x-grok-client-version": XAI_GROK_CLIENT_VERSION,
-    "x-xai-token-auth": "xai-grok-cli",
-    "x-grok-model-override": normalizedXaiModelId(modelId),
-  };
-  if (sessionId) headers["x-grok-conv-id"] = sessionId;
-  return headers;
+export type XaiClientMode = "interactive" | "headless";
+
+export interface XaiProxyRequestMetadata {
+  conversationId: string;
+  requestId: string;
+  sessionId: string;
 }
 
-/** Build extra request headers needed for a credential and xAI model. */
-export function xaiModelRequestHeaders(
+/** Resolve truthful Grok proxy client mode from pi's arguments and terminal state. */
+export function resolveXaiClientMode(
+  argv: readonly string[] = process.argv.slice(2),
+  stdinIsTTY = process.stdin.isTTY === true,
+  stdoutIsTTY = process.stdout.isTTY === true,
+): XaiClientMode {
+  let outputMode: "text" | "json" | "rpc" | undefined;
+  let printRequested = false;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--mode" && index + 1 < argv.length) {
+      const candidate = argv[++index];
+      if (candidate === "text" || candidate === "json" || candidate === "rpc") outputMode = candidate;
+    } else if (arg === "-p" || arg === "--print") {
+      printRequested = true;
+    }
+  }
+
+  if (outputMode === "json" || outputMode === "rpc" || printRequested) return "headless";
+  return stdinIsTTY && stdoutIsTTY ? "interactive" : "headless";
+}
+
+/** Build the complete metadata contract for an OAuth request to the Grok CLI proxy. */
+export function xaiProxyRequestHeaders(
   modelId: string,
   credentialKind: XaiCredentialKind,
-  sessionId?: string,
+  metadata: XaiProxyRequestMetadata,
 ): Record<string, string> {
-  return credentialKind === "oauth-session" && isGrokCliCompatibilityModel(modelId)
-    ? grokCliProxyHeaders(modelId, sessionId)
-    : {};
+  if (credentialKind !== "oauth-session") return {};
+
+  return {
+    "x-grok-client-identifier": XAI_CLIENT_IDENTIFIER,
+    "x-grok-client-version": XAI_CLIENT_VERSION,
+    "X-XAI-Token-Auth": "xai-grok-cli",
+    "x-authenticateresponse": "authenticate-response",
+    "x-grok-client-mode": resolveXaiClientMode(),
+    "x-grok-conv-id": metadata.conversationId,
+    "x-grok-req-id": metadata.requestId,
+    "x-grok-model-override": normalizedXaiModelId(modelId),
+    "x-grok-session-id": metadata.sessionId,
+  };
 }
 
 /** Return true when xAI accepts an explicit Responses reasoning effort. */

--- a/extensions/xai/responses.ts
+++ b/extensions/xai/responses.ts
@@ -2,7 +2,7 @@ import type { Api, Context, Model, SimpleStreamOptions } from "@earendil-works/p
 import { openAIResponsesApi } from "@earendil-works/pi-ai/compat";
 import { randomUUID } from "crypto";
 import { compactXaiInlineImages } from "./images";
-import { isGrokCliCompatibilityModel, xaiModelForRequest, xaiModelRequestHeaders } from "./models";
+import { xaiModelForRequest, xaiProxyRequestHeaders } from "./models";
 import { rewriteXaiResponsesPayload } from "./payload";
 import { resolveXaiRoute, type XaiCredential } from "./routing";
 
@@ -28,6 +28,14 @@ function normalizeXaiStreamEvent(event: AssistantStreamEvent): AssistantStreamEv
     ...event,
     error: { ...error, errorMessage: normalizeXaiErrorText(error.errorMessage) },
   };
+}
+
+function withoutAuthorizationHeader(
+  headers: Record<string, string | null> | undefined,
+): Record<string, string | null> {
+  return Object.fromEntries(
+    Object.entries(headers || {}).filter(([name]) => name.toLowerCase() !== "authorization"),
+  );
 }
 
 function createForwardingAssistantStream() {
@@ -143,18 +151,13 @@ export async function createXaiResponse(
   const route = resolveXaiRoute(credential.kind, "responses");
   const rewritten = rewriteXaiResponsesPayload(body, model);
   const payload = (await compactXaiInlineImages(rewritten)) as Record<string, any>;
-  const usesGrokCliCompatibility =
-    credential.kind === "oauth-session" && isGrokCliCompatibilityModel(model.id);
-  const grokCliSessionId = usesGrokCliCompatibility
-    ? (typeof body.previous_response_id === "string" && body.previous_response_id) || randomUUID()
-    : undefined;
-  return postXaiJson(
-    credential.token,
-    route.url,
-    payload,
-    signal,
-    xaiModelRequestHeaders(model.id, credential.kind, grokCliSessionId),
-  );
+  const requestSessionId = randomUUID();
+  const requestHeaders = xaiProxyRequestHeaders(model.id, credential.kind, {
+    conversationId: requestSessionId,
+    requestId: randomUUID(),
+    sessionId: requestSessionId,
+  });
+  return postXaiJson(credential.token, route.url, payload, signal, requestHeaders);
 }
 
 /**
@@ -176,24 +179,24 @@ export async function createXaiResponse(
 export function streamSimpleXaiResponses(model: Model<Api>, context: Context, options?: SimpleStreamOptions) {
   // The registered xai-auth provider is OAuth-only, so bind its stream to
   // session-token routing instead of inferring credential provenance from the
-  // bearer string. Build/Composer keep their separate compatibility headers.
+  // bearer string.
   const credentialKind = "oauth-session" as const;
   const route = resolveXaiRoute(credentialKind, "responses");
 
-  // Prefer pi's stable session id for cache routing. For Grok CLI compatibility
-  // models, fall back to a per-stream id so x-grok-conv-id is always present.
-  // Docs: Responses API uses body.prompt_cache_key; the proxy also benefits
-  // from the x-grok-conv-id header.
+  // Prefer pi's stable session id for cache and proxy routing. A UUID fallback
+  // keeps every OAuth proxy request fully attributed when pi has no session id.
   // https://docs.x.ai/developers/advanced-api-usage/prompt-caching/maximizing-cache-hits
   const sessionId = options?.sessionId;
-  const routingSessionId = sessionId || (isGrokCliCompatibilityModel(model.id) ? randomUUID() : undefined);
+  const routingSessionId = sessionId || randomUUID();
+  const requestHeaders = xaiProxyRequestHeaders(model.id, credentialKind, {
+    conversationId: routingSessionId,
+    requestId: randomUUID(),
+    sessionId: routingSessionId,
+  });
   const streamModel = {
     ...model,
     baseUrl: route.baseUrl,
-    headers: {
-      ...(model as any).headers,
-      ...xaiModelRequestHeaders(model.id, credentialKind, routingSessionId),
-    },
+    headers: withoutAuthorizationHeader((model as any).headers) as Record<string, string>,
   };
   // Keep the xAI stream model for routing/payload rewriting, but delegate with
   // the API tag expected by pi's OpenAI Responses transport.
@@ -201,8 +204,9 @@ export function streamSimpleXaiResponses(model: Model<Api>, context: Context, op
     ...streamModel,
     api: "openai-responses" as const,
   };
-  const headers = { ...(options?.headers || {}) };
-  if (routingSessionId && !headers["x-grok-conv-id"]) headers["x-grok-conv-id"] = routingSessionId;
+  // The OAuth bearer comes only from options.apiKey. Required proxy metadata
+  // is merged last so callers cannot spoof authentication or attribution.
+  const headers = { ...withoutAuthorizationHeader(options?.headers), ...requestHeaders };
 
   const stream = createForwardingAssistantStream();
   void (async () => {

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -6,6 +6,7 @@ const fs = require("fs/promises");
 const { createJiti } = require("jiti");
 
 const repoRoot = path.resolve(__dirname, "..");
+const packageMetadata = require(path.join(repoRoot, "package.json"));
 const jiti = createJiti(__filename, { interopDefault: true });
 const extensionModule = jiti(path.join(repoRoot, "extensions", "xai-oauth.ts"));
 const extension = extensionModule.default || extensionModule;
@@ -13,6 +14,7 @@ const { compactXaiInlineImages, MAX_XAI_INLINE_IMAGE_BASE64_BYTES } = jiti(
   path.join(repoRoot, "extensions", "xai", "images.ts"),
 );
 const { rewriteXaiResponsesPayload } = jiti(path.join(repoRoot, "extensions", "xai", "payload.ts"));
+const { resolveXaiClientMode } = jiti(path.join(repoRoot, "extensions", "xai", "models.ts"));
 const { createXaiResponse } = jiti(path.join(repoRoot, "extensions", "xai", "responses.ts"));
 const { resolveXaiRoute } = jiti(path.join(repoRoot, "extensions", "xai", "routing.ts"));
 const { XAI_NETWORK_TOOL_NAMES } = jiti(path.join(repoRoot, "extensions", "xai", "tools", "model-scope.ts"));
@@ -39,7 +41,33 @@ const OAUTH_RESPONSES_MODEL_IDS = [
   "grok-build",
   "grok-composer-2.5-fast",
 ];
-const GROK_CLI_COMPATIBILITY_MODEL_IDS = new Set(["grok-build", "grok-composer-2.5-fast"]);
+const XAI_OAUTH_SCOPES = [
+  "openid",
+  "profile",
+  "email",
+  "offline_access",
+  "grok-cli:access",
+  "api:access",
+  "conversations:read",
+  "conversations:write",
+];
+const XAI_PROXY_HEADER_NAMES = [
+  "x-grok-client-identifier",
+  "x-grok-client-version",
+  "x-xai-token-auth",
+  "x-authenticateresponse",
+  "x-grok-client-mode",
+  "x-grok-conv-id",
+  "x-grok-req-id",
+  "x-grok-model-override",
+  "x-grok-session-id",
+];
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const TEST_PROCESS_CLIENT_MODE = resolveXaiClientMode(
+  process.argv.slice(2),
+  process.stdin.isTTY === true,
+  process.stdout.isTTY === true,
+);
 const XAI_NETWORK_TOOLS = [...XAI_NETWORK_TOOL_NAMES];
 const CUSTOM_XAI_NETWORK_TOOLS = XAI_NETWORK_TOOLS.filter((name) => name !== "WebSearch");
 
@@ -66,7 +94,7 @@ function installFetchMock() {
 
     if (href === "https://auth.x.ai/oauth2/token") {
       const params = new URLSearchParams(String(init.body || ""));
-      requests.push({ url: href, body: Object.fromEntries(params) });
+      requests.push({ url: href, method: init.method, body: Object.fromEntries(params) });
       return jsonResponse({
         access_token: `access-${params.get("code") || "refresh"}`,
         refresh_token: "refresh-token",
@@ -76,7 +104,7 @@ function installFetchMock() {
     }
 
     const body = init.body ? JSON.parse(String(init.body)) : undefined;
-    requests.push({ url: href, headers: init.headers || {}, body, signal: init.signal });
+    requests.push({ url: href, method: init.method, headers: init.headers || {}, body, signal: init.signal });
     if (nextXaiResponse && href.endsWith("/responses")) {
       const response = nextXaiResponse;
       nextXaiResponse = undefined;
@@ -100,7 +128,37 @@ function respondToNextXaiRequest(status, body) {
 function headerValue(headers, name) {
   if (!headers) return undefined;
   if (typeof headers.get === "function") return headers.get(name);
-  return headers[name] || headers[name.toLowerCase()];
+  const expected = name.toLowerCase();
+  const entry = Object.entries(headers).find(([key]) => key.toLowerCase() === expected);
+  return entry?.[1];
+}
+
+function proxyHeaderShape(request) {
+  const shape = {};
+  for (const name of XAI_PROXY_HEADER_NAMES) {
+    const value = headerValue(request.headers, name);
+    if (value !== undefined && value !== null) shape[name] = value;
+  }
+  return shape;
+}
+
+function assertOAuthProxyRequestShape(request, modelId, conversationId, label) {
+  assert.equal(headerValue(request.headers, "Content-Type"), "application/json", `${label} should send JSON`);
+  assert.equal(headerValue(request.headers, "Authorization"), "Bearer oauth-token", `${label} should use the OAuth bearer`);
+  const requestId = headerValue(request.headers, "x-grok-req-id");
+  assert.match(requestId || "", UUID_PATTERN, `${label} should include a fresh UUID request id`);
+  assert.deepStrictEqual(proxyHeaderShape(request), {
+    "x-grok-client-identifier": packageMetadata.name,
+    "x-grok-client-version": packageMetadata.version,
+    "x-xai-token-auth": "xai-grok-cli",
+    "x-authenticateresponse": "authenticate-response",
+    "x-grok-client-mode": TEST_PROCESS_CLIENT_MODE,
+    "x-grok-conv-id": conversationId,
+    "x-grok-req-id": requestId,
+    "x-grok-model-override": modelId,
+    "x-grok-session-id": conversationId,
+  });
+  return requestId;
 }
 
 function urlOriginIs(url, expectedOrigin) {
@@ -259,8 +317,8 @@ async function verifyCursorToolShims(loadResult) {
     context: 1,
     limit: 1,
   });
-  assert.match(grepContextResult.content[0].text, /constants\.ts-17-.*XAI_PROVIDER_ID/, "Grep shim should include leading context lines");
-  assert.match(grepContextResult.content[0].text, /constants\.ts:18:.*DEFAULT_XAI_MODEL/, "Grep shim should mark the matched line");
+  assert.match(grepContextResult.content[0].text, /constants\.ts-\d+-.*XAI_PROVIDER_ID/, "Grep shim should include leading context lines");
+  assert.match(grepContextResult.content[0].text, /constants\.ts:\d+:.*DEFAULT_XAI_MODEL/, "Grep shim should mark the matched line");
   await assert.rejects(
     () => runCursorTool(tools, "Grep", { query: "(a+)+$", include: "constants.ts", path: "extensions/xai" }),
     /Unsafe regex pattern/,
@@ -1034,7 +1092,6 @@ async function verifyOAuthResponsesRouting(provider) {
       api: provider.api,
       baseUrl: provider.baseUrl,
     };
-    const isCompatibilityModel = GROK_CLI_COMPATIBILITY_MODEL_IDS.has(modelId);
     const sessionId = `stream-${modelId}`;
 
     const beforeStream = requests.length;
@@ -1048,53 +1105,87 @@ async function verifyOAuthResponsesRouting(provider) {
       .slice(beforeStream)
       .find((entry) => entry.url?.endsWith("/responses"));
     assert.ok(streamRequest, `${modelId} provider stream should send a Responses request`);
+    assert.equal(streamRequest.method, "POST");
     assert.ok(
       urlOriginIs(streamRequest.url, "https://cli-chat-proxy.grok.com"),
       `${modelId} OAuth provider stream should use the session-token proxy`,
     );
     assert.equal(streamRequest.body.model, modelId);
     assert.equal(headerValue(streamRequest.headers, "Authorization"), "Bearer oauth-token");
-    assert.equal(
-      headerValue(streamRequest.headers, "x-xai-token-auth"),
-      isCompatibilityModel ? "xai-grok-cli" : undefined,
-      `${modelId} should ${isCompatibilityModel ? "receive" : "not receive"} Grok CLI token headers`,
+    const streamRequestId = assertOAuthProxyRequestShape(
+      streamRequest,
+      modelId,
+      sessionId,
+      `${modelId} provider stream`,
     );
-    assert.equal(
-      headerValue(streamRequest.headers, "x-grok-model-override"),
-      isCompatibilityModel ? modelId : undefined,
-      `${modelId} should ${isCompatibilityModel ? "receive" : "not receive"} a model override header`,
-    );
-    if (isCompatibilityModel) {
-      assert.equal(headerValue(streamRequest.headers, "x-grok-conv-id"), sessionId);
-    }
     if (modelId === "grok-composer-2.5-fast") {
       assert.equal(streamRequest.body.reasoning, undefined, "Composer 2.5 provider streams should omit reasoning effort");
     }
 
     const beforeDirect = requests.length;
-    await createXaiResponse(OAUTH_CREDENTIAL, { model: modelId, input: "hello" });
+    await createXaiResponse(OAUTH_CREDENTIAL, {
+      model: modelId,
+      input: "hello",
+      previous_response_id: "resp_must_not_be_used_as_session_metadata",
+    });
     const directRequest = requests
       .slice(beforeDirect)
       .find((entry) => entry.url?.endsWith("/responses"));
     assert.ok(directRequest, `${modelId} direct helper should send a Responses request`);
+    assert.equal(directRequest.method, "POST");
     assert.ok(
       urlOriginIs(directRequest.url, "https://cli-chat-proxy.grok.com"),
       `${modelId} OAuth direct helper should use the session-token proxy`,
     );
     assert.equal(directRequest.body.model, modelId);
     assert.equal(headerValue(directRequest.headers, "Authorization"), "Bearer oauth-token");
-    assert.equal(
-      headerValue(directRequest.headers, "x-xai-token-auth"),
-      isCompatibilityModel ? "xai-grok-cli" : undefined,
+    const directConversationId = headerValue(directRequest.headers, "x-grok-conv-id");
+    assert.match(directConversationId || "", UUID_PATTERN, `${modelId} direct helper should mint a conversation UUID`);
+    assert.notEqual(directConversationId, directRequest.body.previous_response_id);
+    const directRequestId = assertOAuthProxyRequestShape(
+      directRequest,
+      modelId,
+      directConversationId,
+      `${modelId} direct helper`,
     );
-    assert.equal(
-      headerValue(directRequest.headers, "x-grok-model-override"),
-      isCompatibilityModel ? modelId : undefined,
-    );
-    if (isCompatibilityModel) {
-      assert.ok(headerValue(directRequest.headers, "x-grok-conv-id"));
-    }
+    assert.notEqual(directRequestId, streamRequestId, `${modelId} stream and direct calls need distinct request ids`);
   }
+}
+
+async function verifyOAuthFallbackAndSpoofProtection(provider) {
+  const modelId = "grok-4.5";
+  const catalogModel = provider.models.find((model) => model.id === modelId);
+  const spoofedHeaders = {
+    "x-grok-client-identifier": "spoofed-client",
+    "x-grok-client-version": "999.0.0",
+    "X-XAI-Token-Auth": "spoofed-token-mode",
+    "x-authenticateresponse": "spoofed-auth-response",
+    "x-grok-client-mode": "spoofed-mode",
+    "x-grok-conv-id": "spoofed-conversation",
+    "x-grok-req-id": "spoofed-request",
+    "x-grok-model-override": "spoofed-model",
+    "x-grok-session-id": "spoofed-session",
+    aUtHoRiZaTiOn: "Bearer spoofed-token",
+  };
+  const model = {
+    ...catalogModel,
+    provider: "xai-auth",
+    api: provider.api,
+    baseUrl: provider.baseUrl,
+    headers: spoofedHeaders,
+  };
+  const before = requests.length;
+  const stream = provider.streamSimple(
+    model,
+    { messages: [{ role: "user", content: "hello", timestamp: Date.now() }] },
+    { apiKey: OAUTH_CREDENTIAL.token, headers: spoofedHeaders },
+  );
+  await stream.result();
+  const request = requests.slice(before).find((entry) => entry.url?.endsWith("/responses"));
+  assert.ok(request, "sessionless OAuth stream should send a Responses request");
+  const conversationId = headerValue(request.headers, "x-grok-conv-id");
+  assert.match(conversationId || "", UUID_PATTERN, "sessionless OAuth stream should mint a conversation UUID");
+  assertOAuthProxyRequestShape(request, modelId, conversationId, "sessionless OAuth stream");
 }
 
 async function verifyApiKeyResponsesRouting() {
@@ -1102,11 +1193,26 @@ async function verifyApiKeyResponsesRouting() {
   await createXaiResponse(API_KEY_CREDENTIAL, { model: "grok-build", input: "hello" });
   const request = requests.slice(before).find((entry) => entry.url?.endsWith("/responses"));
   assert.ok(request, "explicit API-key routing should send a Responses request");
+  assert.equal(request.method, "POST");
   assert.ok(urlOriginIs(request.url, "https://api.x.ai"), "explicit API-key Responses should use api.x.ai");
+  assert.equal(headerValue(request.headers, "Content-Type"), "application/json");
   assert.equal(headerValue(request.headers, "Authorization"), "Bearer api-key-token");
-  assert.equal(headerValue(request.headers, "x-xai-token-auth"), undefined);
-  assert.equal(headerValue(request.headers, "x-grok-model-override"), undefined);
-  assert.equal(headerValue(request.headers, "x-grok-conv-id"), undefined);
+  assert.deepStrictEqual(proxyHeaderShape(request), {}, "explicit API-key Responses must omit proxy-only metadata");
+}
+
+function verifyXaiClientModeResolution() {
+  assert.equal(resolveXaiClientMode([], true, true), "interactive");
+  assert.equal(resolveXaiClientMode(["--model", "grok-4.5"], true, true), "interactive");
+  assert.equal(resolveXaiClientMode(["--mode", "text"], true, true), "interactive");
+  assert.equal(resolveXaiClientMode(["-p", "hello"], true, true), "headless");
+  assert.equal(resolveXaiClientMode(["--print", "hello"], true, true), "headless");
+  assert.equal(resolveXaiClientMode(["--mode", "json"], true, true), "headless");
+  assert.equal(resolveXaiClientMode(["--mode", "rpc"], true, true), "headless");
+  assert.equal(resolveXaiClientMode([], false, true), "headless");
+  assert.equal(resolveXaiClientMode([], true, false), "headless");
+  assert.equal(resolveXaiClientMode(["--mode", "text"], false, true), "headless");
+  assert.equal(resolveXaiClientMode(["--mode=json"], true, true), "interactive");
+  assert.equal(resolveXaiClientMode(["--mode", "--print"], true, true), "interactive");
 }
 
 async function verifyOAuthCallbackState(provider) {
@@ -1136,6 +1242,34 @@ async function verifyOAuthCallbackState(provider) {
   const credentials = await login;
   assert.equal(credentials.access, "access-good-code", "login should ignore the bad callback and exchange the good code");
   assert.ok(authUrl, "login should provide an authorization URL");
+  assert.deepStrictEqual(
+    authUrl.searchParams.get("scope")?.split(" "),
+    XAI_OAUTH_SCOPES,
+    "fresh xAI login should request the frozen eight-scope contract in order",
+  );
+}
+
+async function verifyLegacyOAuthRefresh(provider) {
+  const before = requests.length;
+  const credentials = await provider.oauth.refreshToken({
+    access: "legacy-access-token",
+    refresh: "legacy-refresh-token",
+    expires: Date.now() - 1,
+    tokenEndpoint: "https://auth.x.ai/oauth2/token",
+    tokenType: "Bearer",
+  });
+  const refreshRequest = requests
+    .slice(before)
+    .find((entry) => entry.url === "https://auth.x.ai/oauth2/token" && entry.body?.grant_type === "refresh_token");
+  assert.ok(refreshRequest, "legacy OAuth credentials should refresh through the existing token endpoint");
+  assert.equal(refreshRequest.method, "POST");
+  assert.deepStrictEqual(refreshRequest.body, {
+    grant_type: "refresh_token",
+    refresh_token: "legacy-refresh-token",
+    client_id: "b1a00492-073a-47ea-816f-4c329264a828",
+  });
+  assert.equal(Object.hasOwn(refreshRequest.body, "scope"), false, "refresh must not renegotiate fresh-login scopes");
+  assert.equal(credentials.access, "access-refresh");
 }
 
 async function verifyOAuthManualRawCode(provider) {
@@ -1259,9 +1393,11 @@ async function main() {
     await verifyXaiImageCompaction();
 
     verifyCredentialAwareRouteMatrix();
+    verifyXaiClientModeResolution();
     await verifyOpenAIResponsesTransport();
     await verifyXaiResponsesTransport(provider);
     await verifyOAuthResponsesRouting(provider);
+    await verifyOAuthFallbackAndSpoofProtection(provider);
     await verifyApiKeyResponsesRouting();
 
     await verifyXaiImageTransport(provider);
@@ -1271,6 +1407,7 @@ async function main() {
     await verifyCursorToolShims(firstLoad);
 
     await verifyOAuthCallbackState(provider);
+    await verifyLegacyOAuthRefresh(provider);
     await verifyOAuthManualRawCode(provider);
     await verifyOAuthManualCallbackUrlState(provider);
     await verifyOAuthManualWrongStateIgnored(provider);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "types": ["node"]
   },
   "include": ["extensions/**/*.ts"]


### PR DESCRIPTION
## Description

Align the OAuth scope and CLI-proxy metadata contract with the pinned official Grok Build transport:

- Fresh xAI OAuth logins request the frozen eight-scope contract, including `conversations:read` and `conversations:write`.
- Existing refresh tokens remain refreshable without scope renegotiation; users can re-login when they need the newly added grants.
- OAuth Responses streaming and direct helpers send truthful `pi-xai-oauth` package identity/version plus the required proxy auth, client-mode, request, conversation, model, and session headers.
- Explicit API-key routing remains free of proxy-only metadata, and endpoint selection remains credential-aware rather than model-aware.
- Exact outgoing request-shape tests cover standard Grok, Grok Build, and Composer paths, including caller-header spoof resistance.

Closes #65

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [x] Documentation update

## How Has This Been Tested?

- [x] LSP diagnostics on final TypeScript source (no errors; test script has only pre-existing CommonJS/jiti hints)
- [x] `npm test`
- [x] `npm run typecheck` with locked TypeScript 7.0.2
- [x] `git diff --check`
- [x] `npm pack --dry-run --json` (36 expected files; package metadata/runtime changes present; no scaffold, subagent, credential, environment, or session artifacts)
- [x] Independent protocol/security, regression/runtime, and scope/docs review fan-out; accepted client-mode and Authorization-spoof findings fixed and revalidated
- [x] Safe live OAuth Responses smoke with `XAI_API_KEY` unset and image generation never invoked

Live OAuth smoke:

- Grok 4.5: `OAUTH_PROXY_OK`
- Grok Build: `OAUTH_PROXY_OK` after one transient upstream HTTP 503 was automatically retried
- Composer 2.5 Fast: `OAUTH_PROXY_OK`

An initial Grok 4.5 text-mode smoke exceeded the 180-second harness timeout without output; the structured JSON-mode rerun completed successfully and settled with `OAUTH_PROXY_OK`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented the code where the protocol mapping is not obvious
- [x] I have made corresponding documentation changes
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] New and existing tests pass locally

## Residual risks

- Refreshing an older credential intentionally preserves its original grant; it does not add the new conversation scopes. The README explains how to perform a fresh login and decline reused `~/.grok/auth.json` credentials when those grants are needed.
- Live availability can still be affected by transient upstream proxy failures, as seen in the recovered Grok Build 503.

## Screenshots

Not applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth authorization scopes and every OAuth Responses request header path; mistakes could break login, refresh compatibility, or proxy acceptance, though routing and API-key paths are largely unchanged and coverage is strong.
> 
> **Overview**
> Aligns fresh xAI OAuth grants and every OAuth Responses call with the official Grok Build CLI-proxy contract, without changing credential-aware endpoint routing from PR #70.
> 
> **OAuth:** Fresh browser logins now request the eight-scope grant (including `conversations:read` / `conversations:write`); token refresh stays unchanged and does not renegotiate scopes. README documents re-login when users need the new grants.
> 
> **Proxy metadata:** OAuth Responses traffic no longer limits Grok-style headers to Build/Composer. All OAuth models get the full proxy set—package-derived `pi-xai-oauth` identity/version, auth and client-mode headers, and per-request conversation, request, session, and model override IDs. Client mode is `interactive` vs `headless` from pi argv and TTY state. Explicit API-key Responses paths still omit proxy-only headers.
> 
> **Transport hardening:** Streaming and direct helpers strip caller `Authorization` and merge required proxy headers last so spoofed metadata cannot override the real bearer or attribution. Direct Responses mint coherent UUID session metadata instead of reusing `previous_response_id`.
> 
> **Tests & docs:** `verify-extension.js` asserts exact outgoing shapes, scope order, legacy refresh bodies, client-mode resolution, and spoof resistance. `tsconfig` enables `resolveJsonModule` for `package.json` client version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67683514b196b7023dcc7090b38905d511f038d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->