### PR TITLE
Harden OAuth state binding and OIDC validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.pi-subagents/
 .DS_Store
 *.log
 dist/

--- a/.npmignore
+++ b/.npmignore
@@ -8,6 +8,7 @@ node_modules/
 .idea/
 .vscode/
 .omp/
+.pi-subagents/
 .scaffold/
 *.pem
 *.key

--- a/.scaffold/constraints.md
+++ b/.scaffold/constraints.md
@@ -1,28 +1,24 @@
 # Constraints & Safety Rules
 
 ## Hard Boundaries (MUST NOT)
-- Never commit API keys or OAuth tokens
-- Never modify files outside this package without explicit delegation
-- Never skip TypeScript type checking before edits
-- Never use global state — prefer external .scaffold/ files
-- Never ignore errors from subagent calls or tool failures
+- Never commit, print, log, or include in errors API keys, OAuth codes, access/refresh/ID tokens, PKCE verifiers, state, nonce, or token response bodies.
+- Never delete, revoke, overwrite, or migrate user credentials without explicit user approval.
+- Never modify core pi-coding-agent internals or unrelated extensions/tools.
+- Never implement issue #66's device-code selection/polling feature as part of issue #67.
+- Never accept raw authorization codes or callbacks with missing/mismatched state.
+- Never trust discovery, endpoints, JWT algorithms, or signing keys solely because a hostname ends in `x.ai`.
 
 ## Required Practices (MUST)
-- Always start on a feature branch
-- Always read AGENTS.md before starting work
-- Use parallel subagents for research + planning when possible
-- Update progress.md after every significant step
-- Run `git status` and confirm branch before any edit
-- Prefer vertical feature organization in new code
+- Work on `feature/issue-67-oauth-state-oidc` from current merged `main`.
+- Keep PKCE S256, state, nonce, redirect URI, discovery metadata, and callback code bound to one in-memory login transaction.
+- Validate the exact first-party OIDC issuer/endpoints and retained ID-token signature, signing key, issuer, audience, expiry, and nonce before returning fresh credentials.
+- Fail closed without reflecting sensitive upstream token bodies.
+- Preserve existing Grok CLI credential reuse and refresh compatibility.
+- Update `.scaffold/progress.md` after significant steps.
+- Run LSP diagnostics, `npm test`, `npm run typecheck`, `git diff --check`, and npm package inspection before delivery.
+- Use independent read-only security/correctness/test review before finalizing; keep one writer in the active worktree.
 
-## Tool Usage Rules
-- Subagent: Prefer PARALLEL mode for independent tasks
-- Always specify `cwd` when working in specific directories
-- Use `reviewer` agent before merging or finalizing large changes
-
-## Performance & Context Rules
-- Keep context under 40% of window when possible
-- Externalize plans and progress to reduce token usage
-- Use scout for fast recon before deep dives
-
-Update this file whenever new constraints are discovered.
+## Live-flow Safety
+- Only attempt interactive OAuth when this pane can safely present the browser URL and receive user interaction.
+- Do not print stored credentials or inspect credential contents during live validation.
+- Do not revoke existing grants or remove credential files.

--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -1,34 +1,35 @@
 # Shared Agent Context
 
 **Project:** pi-xai-oauth
-**Branch:** feature/issue-65-proxy-headers
+**Branch:** feature/issue-67-oauth-state-oidc
 **Date:** 2026-07-16
 
 ## Issue
-GitHub issue #65 reports that fresh OAuth scopes and CLI-proxy request metadata lag the official Grok Build client. PR #70 already made Responses routing credential-aware; this issue changes the protocol metadata sent after routing, not endpoint selection.
+Issue #67 reports that token-shaped manual input is marked `trustedManualCode` and exchanged without OAuth state, while fresh-login ID tokens are stored without signature or claim validation. The fix must bind every authorization completion to its in-memory transaction and validate retained OIDC identity material.
 
-## Pinned Official Contract
-- Fresh personal OAuth grants request, in order: `openid profile email offline_access grok-cli:access api:access conversations:read conversations:write`.
-- Refresh exchanges send the existing refresh token and client ID without a new scope parameter.
-- Authenticated CLI-proxy requests require package/client version, `X-XAI-Token-Auth: xai-grok-cli`, `x-authenticateresponse: authenticate-response`, and client mode.
-- Official sampling transport also emits conversation, request, model override, and session identifiers per request.
-- Client mode is `headless` for pi print/explicit non-TUI mode and `interactive` otherwise.
+## First-party and normative contract
+- OIDC trust root: `https://auth.x.ai/.well-known/openid-configuration`.
+- Exact issuer: `https://auth.x.ai`.
+- Exact authorization endpoint: `https://auth.x.ai/oauth2/authorize`.
+- Exact token endpoint: `https://auth.x.ai/oauth2/token`.
+- Exact JWKS endpoint: `https://auth.x.ai/.well-known/jwks.json`.
+- Current ID-token algorithm/key shape: ES256 with public EC P-256 signing JWKs selected by `kid`.
+- Current PKCE method: S256.
+- OIDC Core requires fresh code-flow ID-token validation for exact issuer, client audience, expiry, nonce, and issuer signing key before tokens are accepted.
+- xAI's generic RFC 8414 metadata currently differs from its OIDC metadata; this OIDC client must not merge or fall back between them.
 
-## Implementation
-- `extensions/xai/constants.ts` derives client name/version from module-relative `package.json` and carries the eight-scope fresh-login string.
-- `extensions/xai/models.ts` builds the complete OAuth proxy header set for all OAuth models and keeps API-key requests header-free.
-- `extensions/xai/responses.ts` applies stable stream session IDs (with UUID fallback), fresh request IDs, and coherent direct-call conversation/session UUIDs. Required metadata wins over caller headers.
-- Build/Composer capability checks remain limited to payload/tool/shim compatibility; `routing.ts` remains unchanged.
-- `scripts/verify-extension.js` asserts exact actual-fetch request shapes, scope order, legacy refresh forms, client modes, spoof resistance, and API-key absence.
+## Scope decisions
+- Raw authorization codes are rejected because they carry no state. Users must paste the complete redirect URL containing matching `code` and `state`.
+- Device authorization is not implemented here; issue #66 owns method selection, device endpoint requests, polling, expiry, cancellation, and remote/headless UX.
+- Existing `~/.grok/auth.json` reuse and refresh remain compatible. Existing credentials are not deleted, revoked, or retroactively treated as fresh OIDC responses.
+- Fresh login requires and validates an ID token before credentials are returned. Refresh responses do not retain a new ID token unless a future design supplies the original validated identity context required by OIDC refresh rules.
+- Token endpoint response bodies, authorization codes, tokens, verifiers, state, and nonce must never be logged or included in errors.
 
-## User Migration
-Older credentials may continue refreshing and working, but refresh does not add `conversations:read` or `conversations:write`. To obtain the expanded grant, run `/login xai-auth` and answer `n` if prompted to reuse `~/.grok/auth.json`, forcing a fresh browser authorization.
+## Test strategy
+Use generated ES256/P-256 test keys and local JWT fixtures. Exercise HTTP and pasted callbacks, token-request capture, cancellation/listener cleanup, discovery/JWKS policy, signature/key failures, issuer/audience/nonce/expiry failures, refresh fallback/unvalidated-ID-token discard, and exact valid ID-token retention. No test uses production keys or credentials.
 
-## Validation State
-- LSP diagnostics, locked TypeScript 7.0.2 typecheck, `npm test`, and `git diff --check` pass.
-- Package inspection includes the changed runtime files and package metadata and excludes scaffold, subagent, credential, and session artifacts.
-- Live OAuth smoke with `XAI_API_KEY` unset returned `OAUTH_PROXY_OK` for Grok 4.5, Grok Build, and Composer. Grok Build retried one transient upstream 503 before succeeding.
-- Independent review found and fixed client-mode parsing and authorization-spoof gaps; focused regression coverage passes.
-
-## Delivery
-The reviewed implementation is committed on `feature/issue-65-proxy-headers`, pushed to `origin`, and open against `main` as PR #71: https://github.com/BlockedPath/pi-xai-oauth/pull/71. The PR is intentionally unmerged; no paid image generation was invoked.
+## Validation state
+- LSP diagnostics, `npm test`, strict-unhandled focused verification, `npm run typecheck`, and `git diff --check` pass.
+- Dry-run package inspection includes `extensions/xai/oidc.ts` and excludes scaffold, subagent, credential, key, and local artifacts.
+- Two independent review rounds completed; accepted findings were fixed and the final security review reported no blockers.
+- Live interactive OAuth was not attempted because browser/TUI interaction is not safely available through this tool pane. Existing credentials were not read, removed, rewritten, or revoked.

--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -33,3 +33,6 @@ Use generated ES256/P-256 test keys and local JWT fixtures. Exercise HTTP and pa
 - Dry-run package inspection includes `extensions/xai/oidc.ts` and excludes scaffold, subagent, credential, key, and local artifacts.
 - Two independent review rounds completed; accepted findings were fixed and the final security review reported no blockers.
 - Live interactive OAuth was not attempted because browser/TUI interaction is not safely available through this tool pane. Existing credentials were not read, removed, rewritten, or revoked.
+
+## Delivery
+The reviewed implementation was committed as `3721691`, pushed on `feature/issue-67-oauth-state-oidc`, and opened against `main` as unmerged PR #72: https://github.com/BlockedPath/pi-xai-oauth/pull/72

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -31,6 +31,6 @@ Remove the unbound raw authorization-code fallback and make fresh xAI browser OA
 - [x] Live OAuth was not attempted because this tool pane cannot safely hand browser/TUI interaction to the user; existing credentials were not read, removed, rewritten, or revoked.
 
 ## Delivery
-- [ ] Commit reviewed implementation.
-- [ ] Push `feature/issue-67-oauth-state-oidc`.
-- [ ] Open a PR against `main` without merging it.
+- [x] Committed the reviewed implementation as `3721691`.
+- [x] Pushed `feature/issue-67-oauth-state-oidc`.
+- [x] Opened PR #72 against `main` without merging it: https://github.com/BlockedPath/pi-xai-oauth/pull/72

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,40 +1,36 @@
-# Implementation Plan: Issue #65 OAuth scopes and proxy metadata
+# Implementation Plan: Issue #67 OAuth state and OIDC validation
 
-**Branch:** feature/issue-65-proxy-headers
+**Branch:** feature/issue-67-oauth-state-oidc
 **Date:** 2026-07-16
 
 ## Goal
-Align fresh xAI OAuth grants and every OAuth Responses request with the pinned official Grok Build scope and CLI-proxy metadata contracts without changing credential-aware endpoint routing.
+Remove the unbound raw authorization-code fallback and make fresh xAI browser OAuth completion fail closed on transaction state plus validated first-party OIDC identity metadata.
 
 ## Implementation
-- [x] Request the frozen eight-scope OAuth contract for fresh browser logins.
-- [x] Preserve legacy refresh behavior without scope renegotiation.
-- [x] Derive the truthful `pi-xai-oauth` client identifier and version from package metadata.
-- [x] Add required auth-response and interactive/headless client-mode headers to every OAuth proxy request.
-- [x] Add request, conversation, session, and model headers for streaming and direct Responses calls.
-- [x] Keep required proxy metadata authoritative over caller-supplied headers.
-- [x] Keep API-key Responses free of OAuth proxy-only metadata.
-- [x] Add exact outgoing-request, OAuth-scope, refresh-body, spoof-protection, and client-mode regression coverage.
-- [x] Document refresh compatibility and the fresh re-login path for new scopes.
+- [x] Remove `trustedManualCode` and reject raw-code-only manual input with a safe migration message.
+- [x] Require the expected state on every HTTP or pasted callback before token exchange.
+- [x] Pin and validate xAI OIDC issuer, authorization endpoint, token endpoint, JWKS endpoint, ES256, and S256 metadata.
+- [x] Validate fresh-login ID tokens before retaining credentials: compact JWS shape, ES256 signature, matching P-256 signing key, issuer, audience/authorized party, expiry, required claims, and nonce.
+- [x] Preserve existing Grok CLI credential reuse and refresh compatibility without retaining unvalidated refresh ID tokens.
+- [x] Stop reflecting authorization/token endpoint response data in errors.
+- [x] Add focused wrong/missing-state, raw-code migration, code-substitution, cancellation/cleanup, discovery/JWKS, ID-token failure, and valid-completion tests.
+- [x] Update README, CHANGELOG, AGENTS.md, and scaffold security guidance.
+
+## Non-goals
+- Do not implement device authorization; full device-code UX, polling, and cancellation remain tracked by issue #66.
+- Do not revoke, delete, migrate, or rewrite existing user credentials.
+- Do not change model routing, scopes, tools, payloads, or xAI API behavior outside issue #67.
 
 ## Validation Contract
-- [x] Focused extension verification passes.
+- [x] LSP diagnostics pass for changed TypeScript files.
+- [x] `npm test` passes.
 - [x] `npm run typecheck` passes.
-- [x] Full `npm test` passes.
-- [x] `git diff --check` passes after documentation/scaffold updates.
-- [x] Parent-owned LSP diagnostics pass on the final TypeScript source (the persistent server cache was cross-checked with fresh exact-source copies).
-- [x] `npm pack --dry-run --json` contains package metadata and changed runtime files while excluding scaffold, subagent, credential, and session artifacts.
-- [x] Parent-owned safe live OAuth smoke returned `OAUTH_PROXY_OK` for Grok 4.5, Grok Build, and Composer; no image generation was invoked.
-- [x] Independent focused review/fix passes completed; client-mode parsing and authorization-spoof findings were fixed and revalidated.
-
-## Scope Decisions
-- Endpoint selection remains credential-aware in `extensions/xai/routing.ts`; model checks do not select transport.
-- Grok Build/Composer payload and local tool compatibility remain model-specific and unchanged.
-- Existing refresh tokens continue using their original grant; only a fresh login can add newly requested scopes.
-- Direct Responses calls mint their own coherent conversation/session UUID instead of treating `previous_response_id` as a session identifier.
-- The OAuth-only provider does not add API-key fallback and never logs or exposes bearer tokens.
+- [x] `git diff --check` passes.
+- [x] `npm pack --dry-run --json` contains intended runtime/docs files and no local artifacts or credentials.
+- [x] Independent security, correctness, and test reviews complete; accepted fixes are applied and revalidated.
+- [x] Live OAuth was not attempted because this tool pane cannot safely hand browser/TUI interaction to the user; existing credentials were not read, removed, rewritten, or revoked.
 
 ## Delivery
-- [x] Committed and pushed `feature/issue-65-proxy-headers`.
-- [x] Opened PR #71 against `main`: https://github.com/BlockedPath/pi-xai-oauth/pull/71
-- [x] Left the PR unmerged for external review.
+- [ ] Commit reviewed implementation.
+- [ ] Push `feature/issue-67-oauth-state-oidc`.
+- [ ] Open a PR against `main` without merging it.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,42 +1,35 @@
 # Execution Progress
 
-**Project:** pi-xai-oauth Issue #65 OAuth scopes and proxy metadata
-**Branch:** feature/issue-65-proxy-headers
+**Project:** pi-xai-oauth Issue #67 OAuth state and OIDC validation
+**Branch:** feature/issue-67-oauth-state-oidc
 **Started:** 2026-07-16
 
 ## Research and Baseline
-- [x] Started from current `main` after merged PR #70.
-- [x] Read issue #65, provider/OAuth/routing/Responses code, tests, setup, and package documentation.
-- [x] Read pinned official Grok Build scope, proxy middleware, sampling-header, and client-mode sources at commit `b189869b7755d2b482969acf6c92da3ecfeffd36`.
-- [x] Confirmed baseline `npm test` and `npm run typecheck` pass.
+- [x] Started from clean current `main` after merged PRs #70 and #71.
+- [x] Created `feature/issue-67-oauth-state-oidc` before editing.
+- [x] Read AGENTS.md, issues #67 and #66, provider entrypoint, setup, all OAuth discovery/login/callback/token/reuse code, and current OAuth tests.
+- [x] Read current pi provider/OAuth APIs, types, interactive manual-input behavior, extension docs, and provider examples.
+- [x] Read authoritative OIDC Core/Discovery, OAuth metadata/PKCE/security guidance, and live first-party xAI OIDC discovery/JWKS behavior.
+- [x] Confirmed xAI OIDC metadata currently pins issuer `https://auth.x.ai`, `/oauth2/authorize`, `/oauth2/token`, `/.well-known/jwks.json`, ES256, and S256.
+- [x] Confirmed baseline LSP diagnostics, `npm test`, and `npm run typecheck` pass.
 
 ## Implementation
-- [x] Added `conversations:read` and `conversations:write` to fresh OAuth authorization requests in official order.
-- [x] Preserved legacy refresh forms with no scope renegotiation.
-- [x] Replaced the stale Grok CLI version with package-derived `pi-xai-oauth` identity/version.
-- [x] Added complete auth, client-mode, conversation, request, model, and session metadata for every OAuth Responses proxy request.
-- [x] Kept explicit API-key Responses free of proxy-only metadata.
-- [x] Added stable stream IDs, UUID fallback, coherent direct-call IDs, and caller-spoof protection.
-- [x] Kept endpoint routing independent from model compatibility checks.
-- [x] Added exact actual-request and OAuth regression coverage.
-- [x] Updated README re-login guidance, Unreleased changelog, and scaffold state.
+- [x] Removed `trustedManualCode`; raw-code-only input now fails with full-redirect-URL migration guidance and issue #66 remains separate.
+- [x] Required matching state for HTTP and pasted callbacks before any authorization-code exchange.
+- [x] Added exact first-party issuer/authorization/token/JWKS policy plus ES256/S256 discovery validation.
+- [x] Added generated-key ES256 ID-token verification for signing key, signature, issuer, audience/authorized party, expiry, issued-at, subject, and nonce before credential retention.
+- [x] Preserved Grok CLI credential reuse and refresh responses without retaining unvalidated refresh ID tokens.
+- [x] Removed token response body reflection from errors.
+- [x] Added focused state, raw-code, code-substitution, discovery/JWKS, claims, unknown-key, bad-signature, valid-completion, and redaction tests.
+- [x] Updated README, CHANGELOG, AGENTS.md, and scaffold security guidance.
 
 ## Validation
-- [x] Focused `node scripts/verify-extension.js` passes after implementation and review fixes.
-- [x] Locked TypeScript 7.0.2 `npm run typecheck` passes.
-- [x] Full `npm test` passes.
-- [x] Parent-owned LSP diagnostics pass on final TypeScript source; fresh exact-source copies bypassed a stale persistent-server buffer after the locked dependency reinstall.
-- [x] `git diff --check` passes after final edits.
-- [x] npm package inspection includes package metadata and runtime files and excludes scaffold, subagent, credential, and session artifacts.
-- [x] Safe live OAuth smoke with `XAI_API_KEY` unset returned `OAUTH_PROXY_OK` for Grok 4.5, Grok Build, and Composer; Grok Build recovered from one transient upstream 503.
-- [x] Independent focused review/fix passes completed; fixed truthful pi mode resolution and case-insensitive Authorization spoofing.
-- [x] No paid image generation was invoked.
+- [x] Changed-file LSP diagnostics pass for `oauth.ts`, `oidc.ts`, and `constants.ts`.
+- [x] `npm test`, strict-unhandled focused verification, and `npm run typecheck` pass.
+- [x] `git diff --check` and npm dry-run package assertions pass; `oidc.ts` is included and scaffold/subagent/credential/key artifacts are excluded.
+- [x] Independent security/correctness/test review completed. Accepted fixes added cancellation propagation, callback-listener cleanup, authorization-error redaction, raw-code retry guidance, optional JWK-hint compatibility, exact valid-token retention checks, refresh fallback/discard checks, and broader negative coverage.
+- [x] Final re-review found no source/package blockers; the requested callback-wait cancellation regression was added and passes.
+- [x] Live OAuth was not attempted because this tool pane cannot safely transfer browser/TUI interaction to the user. Existing credentials were never read, removed, rewritten, or revoked.
 
 ## Delivery
-- [x] Committed the reviewed implementation as `d01cb5e`.
-- [x] Pushed `feature/issue-65-proxy-headers` to `origin`.
-- [x] Opened PR #71 against `main`: https://github.com/BlockedPath/pi-xai-oauth/pull/71
-- [x] Left the PR unmerged.
-
-## Next
-- [ ] Await external PR review; preserve issue #65 scope when addressing feedback.
+- [ ] Commit, push, and open an unmerged PR against `main`.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -29,6 +29,7 @@
 - [x] `git diff --check` and npm dry-run package assertions pass; `oidc.ts` is included and scaffold/subagent/credential/key artifacts are excluded.
 - [x] Independent security/correctness/test review completed. Accepted fixes added cancellation propagation, callback-listener cleanup, authorization-error redaction, raw-code retry guidance, optional JWK-hint compatibility, exact valid-token retention checks, refresh fallback/discard checks, and broader negative coverage.
 - [x] Final re-review found no source/package blockers; the requested callback-wait cancellation regression was added and passes.
+- [x] Post-PR Codex feedback was rechecked and addressed: multi-audience ID tokens now require client membership plus this client as `azp`; positive and missing-`azp` regressions pass.
 - [x] Live OAuth was not attempted because this tool pane cannot safely transfer browser/TUI interaction to the user. Existing credentials were never read, removed, rewritten, or revoked.
 
 ## Delivery

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -32,4 +32,7 @@
 - [x] Live OAuth was not attempted because this tool pane cannot safely transfer browser/TUI interaction to the user. Existing credentials were never read, removed, rewritten, or revoked.
 
 ## Delivery
-- [ ] Commit, push, and open an unmerged PR against `main`.
+- [x] Committed the reviewed implementation as `3721691`.
+- [x] Pushed `feature/issue-67-oauth-state-oidc` to `origin`.
+- [x] Opened PR #72 against `main`: https://github.com/BlockedPath/pi-xai-oauth/pull/72
+- [x] Left the PR unmerged for external review.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,24 +5,30 @@
 ## Project Overview
 pi-xai-oauth is a pi-package that registers the xAI OAuth provider ("xai-auth") and Grok models (including grok-4.5 and grok-4.3 with reasoning) for the pi coding agent framework.
 
-Core flow: `bin/setup.js` → `pi install` → provider registration in `extensions/xai-oauth.ts` → OAuth PKCE login in `extensions/xai/oauth.ts` → streaming via xAI API helpers in `extensions/xai/responses.ts`.
+Core flow: `bin/setup.js` → `pi install` → provider registration in `extensions/xai-oauth.ts` → OAuth PKCE transaction in `extensions/xai/oauth.ts` → pinned OIDC/JWKS validation in `extensions/xai/oidc.ts` → streaming via xAI API helpers in `extensions/xai/responses.ts`.
 
 ## Key Commands (Exact, Copy-Paste Ready)
 - Install / setup: `node bin/setup.js` or `npm run setup` (if added)
 - Install as pi extension: `pi install npm:pi-xai-oauth`
 - Run TypeScript: `npx tsc --noEmit` (validate)
-- Git: Always work on feature branches. Current branch for this work: `feature/issue-63-auth-aware-routing`
+- Git: Always work on feature branches. Current branch for this work: `feature/issue-67-oauth-state-oidc`
 
 ## Architecture & Boundaries (MUST / MUST NOT)
 **MUST:**
 - Register providers via `pi.registerProvider("xai-auth", { ... })`
-- Use PKCE OAuth flow with local callback server
+- Use PKCE S256 OAuth flow with local callback server
+- Require matching state for every HTTP or pasted authorization callback before token exchange
+- Validate retained fresh-login ID tokens against pinned first-party discovery/JWKS, ES256, issuer, audience, expiry, and nonce
 - Support reasoning levels: none / low / medium / high
-- Reuse `~/.grok/auth.json` when possible
+- Reuse `~/.grok/auth.json` when possible without deleting or revoking it
 - Keep models list in sync with xAI releases
 
 **MUST NOT:**
 - Hardcode API keys (use OAuth only)
+- Accept raw authorization codes or callbacks with missing/mismatched state
+- Trust arbitrary `*.x.ai` discovery, token, or JWKS endpoints
+- Log or reflect authorization codes, tokens, PKCE verifiers, state, nonce, or token response bodies
+- Delete or revoke existing user credentials during validation
 - Modify core pi-coding-agent internals
 - Touch unrelated extensions or skills
 - Skip error handling on OAuth refresh
@@ -37,7 +43,8 @@ pi-xai-oauth/
 │   └── xai/              # Focused implementation modules
 │       ├── constants.ts  # URLs, defaults, OAuth constants
 │       ├── models.ts     # Model catalog + model compatibility helpers
-│       ├── oauth.ts      # OAuth discovery/login/refresh/callback helpers
+│       ├── oauth.ts      # OAuth login/refresh/callback transaction helpers
+│       ├── oidc.ts       # Pinned discovery/JWKS + ID-token validation
 │       ├── auth.ts       # Credential reuse + token resolution helpers
 │       ├── payload.ts    # Responses payload normalization
 │       ├── responses.ts  # xAI request/stream helpers
@@ -66,7 +73,8 @@ Start any task by reading:
 - Prefer async/await for OAuth and API calls
 - Add JSDoc for all exported functions
 - Keep OAuth callback server minimal and secure
-- Never log sensitive tokens
+- Treat raw-code/device-code migration as separate from issue #66's full device authorization implementation
+- Never log OAuth codes, tokens, token response bodies, verifiers, state, or nonce
 
 ## Safety Gates
 - Before any file edit: run `git status` and confirm on correct branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 
 ### Fixed
 
+- Removed the unbound raw authorization-code fallback; pasted completions now require the matching OAuth state and raw-code users receive safe full-redirect-URL migration guidance while device authorization remains tracked separately.
+- Pinned xAI OIDC discovery and JWKS policy and validated fresh-login ID-token ES256 signatures, signing keys, issuer, audience, expiry, and nonce before retaining credentials.
+- Stopped reflecting xAI token endpoint response bodies in authentication errors.
 - Routed normal streaming and separate Responses helpers for every `xai-auth` model through the official Grok CLI session-token proxy, matching the intended OAuth/session-token transport contract for Responses traffic.
 - Preserved the official direct `api.x.ai` Images endpoint for OAuth-backed image generation while keeping a future explicit API-key Responses route on the public API.
 - Added the complete CLI-proxy authentication, client-mode, request, conversation, session, and model metadata to every OAuth Responses request, with required values protected from caller overrides.

--- a/README.md
+++ b/README.md
@@ -91,12 +91,13 @@ See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and
 2. It builds an xAI OAuth authorize URL with PKCE challenge
 3. **Your default browser opens automatically** to the xAI login page
 4. After you approve, xAI redirects to the local callback server
-5. The authorization code is exchanged for access + refresh tokens
-6. Tokens are persisted and refreshed automatically
-7. All OAuth-backed Responses traffic—normal streaming and separate Responses helpers—uses xAI's session-token proxy (`https://cli-chat-proxy.grok.com/v1`) rather than the public Responses endpoint on `https://api.x.ai/v1`
-8. Proxy requests identify this client as `pi-xai-oauth` at the installed package version and include xAI's required auth, client-mode, request, conversation, session, and model metadata
+5. pi verifies that the callback state matches the in-memory login attempt before exchanging the authorization code
+6. The returned ID token is verified against xAI's pinned OIDC issuer and first-party JWKS for ES256 signature, signing key, audience, expiry, and nonce
+7. Only then are access + refresh credentials persisted and refreshed automatically
+8. All OAuth-backed Responses traffic—normal streaming and separate Responses helpers—uses xAI's session-token proxy (`https://cli-chat-proxy.grok.com/v1`) rather than the public Responses endpoint on `https://api.x.ai/v1`
+9. Proxy requests identify this client as `pi-xai-oauth` at the installed package version and include xAI's required auth, client-mode, request, conversation, session, and model metadata
 
-If localhost callbacks are blocked (VPN, Docker, remote dev), the TUI shows a text field where you can paste the redirect URL manually.
+If localhost callbacks are blocked (VPN, Docker, remote dev), the TUI shows a text field where you can paste the **complete redirect URL** manually. The URL must contain the matching OAuth `state`; raw authorization codes are not accepted.
 
 ---
 
@@ -181,7 +182,9 @@ Fresh logins request xAI's current eight-scope Grok client grant, including `con
 
 > **Need the new conversation scopes?** Run `/login xai-auth` for a fresh authorization grant. If pi finds `~/.grok/auth.json` and asks whether to reuse it, answer **`n`** so the browser login runs; reusing or refreshing an older credential will not add scopes. You do not need to re-login merely to keep using an older credential that already works for your requests.
 >
-> **Choosing a different browser/profile?** The instructions in the TUI explain how. You can copy the shown URL, open your preferred browser manually, and paste it there.
+> **Choosing a different browser/profile?** The instructions in the TUI explain how. You can copy the shown authorization URL and open it manually in your preferred browser.
+>
+> **Remote/headless login:** If the browser cannot reach pi's loopback listener, paste the complete failed redirect URL from the browser address bar into pi. Do not paste only the authorization code: code-only input has no OAuth state and is rejected. A full device-code alternative remains separately tracked in [issue #66](https://github.com/BlockedPath/pi-xai-oauth/issues/66).
 
 ### Re-authenticating
 
@@ -471,9 +474,11 @@ pi runs `open <url>` on macOS / `xdg-open` on Linux to launch your default brows
 If localhost is blocked (VPN, Docker, remote SSH, WSL):
 
 1. After authorizing in the browser, the page will show an error (can't reach localhost).
-2. **Copy the full URL** from the browser's address bar.
+2. **Copy the complete URL** from the browser's address bar. It must include both `code` and the matching `state` query parameter.
 3. **Paste it into the TUI's input field** that says "Paste redirect URL below."
-4. pi parses the authorization code from the URL and completes the login.
+4. pi verifies the state, exchanges the bound code with PKCE, validates the returned OIDC ID token, and then completes login.
+
+Raw authorization-code-only input is intentionally rejected because it cannot prove which browser login attempt produced the code. If you already pasted a raw code, run `/login xai-auth` again before pasting the complete redirect URL. If your environment cannot preserve that URL, use the loopback flow from a reachable browser for now; standardized device-code support is tracked separately in [issue #66](https://github.com/BlockedPath/pi-xai-oauth/issues/66).
 
 ### "Cannot find provider xai-auth"
 
@@ -691,7 +696,8 @@ pi-xai-oauth/
 │       ├── auth.ts           # Grok CLI credential reuse + token resolution
 │       ├── constants.ts      # URLs, OAuth constants, defaults
 │       ├── models.ts         # Model catalog + model-specific compatibility helpers
-│       ├── oauth.ts          # OAuth discovery/login/refresh/callback helpers
+│       ├── oauth.ts          # OAuth login/refresh/callback transaction helpers
+│       ├── oidc.ts           # Pinned discovery/JWKS + ID-token validation
 │       ├── payload.ts        # xAI Responses payload normalization
 │       ├── responses.ts      # xAI request + streaming helpers
 │       ├── routing.ts        # Credential-aware Responses and Images endpoints

--- a/extensions/xai/constants.ts
+++ b/extensions/xai/constants.ts
@@ -2,6 +2,11 @@ import packageMetadata from "../../package.json";
 
 export const XAI_OAUTH_ISSUER = "https://auth.x.ai";
 export const XAI_OAUTH_DISCOVERY_URL = `${XAI_OAUTH_ISSUER}/.well-known/openid-configuration`;
+export const XAI_OAUTH_AUTHORIZATION_URL = `${XAI_OAUTH_ISSUER}/oauth2/authorize`;
+export const XAI_OAUTH_TOKEN_URL = `${XAI_OAUTH_ISSUER}/oauth2/token`;
+export const XAI_OAUTH_JWKS_URL = `${XAI_OAUTH_ISSUER}/.well-known/jwks.json`;
+export const XAI_OAUTH_ID_TOKEN_ALGORITHM = "ES256";
+export const XAI_OAUTH_PKCE_METHOD = "S256";
 export const XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
 export const XAI_OAUTH_SCOPE =
   "openid profile email offline_access grok-cli:access api:access conversations:read conversations:write";

--- a/extensions/xai/oauth.ts
+++ b/extensions/xai/oauth.ts
@@ -3,18 +3,14 @@ import { createHash, randomBytes, randomUUID } from "crypto";
 import { createServer, type Server } from "http";
 import {
   XAI_OAUTH_CLIENT_ID,
-  XAI_OAUTH_DISCOVERY_URL,
   XAI_OAUTH_REDIRECT_HOST,
   XAI_OAUTH_REDIRECT_PATH,
   XAI_OAUTH_REDIRECT_PORT,
   XAI_OAUTH_REFRESH_SKEW_MS,
   XAI_OAUTH_SCOPE,
+  XAI_OAUTH_TOKEN_URL,
 } from "./constants";
-
-type XaiDiscovery = {
-  authorization_endpoint: string;
-  token_endpoint: string;
-};
+import { discoverXaiOidc, validateXaiIdToken, type XaiOidcDiscovery } from "./oidc";
 
 type XaiTokenPayload = {
   access_token?: string;
@@ -28,9 +24,15 @@ type CallbackResult = {
   code?: string;
   state?: string;
   error?: string;
-  error_description?: string;
-  trustedManualCode?: boolean;
 };
+
+type ManualCallbackInput =
+  | { kind: "callback"; result: CallbackResult }
+  | { kind: "raw-code" }
+  | { kind: "invalid" };
+
+const RAW_CODE_MIGRATION_MESSAGE =
+  "Raw xAI authorization codes are no longer accepted because they do not include the OAuth state that binds the code to this login. Run /login xai-auth again, then paste the complete redirect URL containing both code and state. Device-code login for remote/headless environments is tracked separately in issue #66.";
 
 type XaiOAuthOptions = {
   getExistingCredentials: () => OAuthCredentials | null;
@@ -40,38 +42,26 @@ function messageFromError(error: unknown): string {
   return error instanceof Error ? error.message : "Unknown error";
 }
 
+function assertLoginNotCancelled(signal?: AbortSignal): void {
+  if (signal?.aborted) throw new Error("xAI OAuth login was cancelled");
+}
+
+async function runAbortableLoginStep<T>(signal: AbortSignal | undefined, operation: () => Promise<T>): Promise<T> {
+  assertLoginNotCancelled(signal);
+  try {
+    const result = await operation();
+    assertLoginNotCancelled(signal);
+    return result;
+  } catch (error) {
+    if (signal?.aborted) throw new Error("xAI OAuth login was cancelled");
+    throw error;
+  }
+}
+
 function pkcePair(): { verifier: string; challenge: string } {
   const verifier = randomBytes(32).toString("base64url");
   const challenge = createHash("sha256").update(verifier).digest("base64url");
   return { verifier, challenge };
-}
-
-function validateXaiEndpoint(url: string): string {
-  const parsed = new URL(url);
-  const host = parsed.hostname.toLowerCase();
-  if (parsed.protocol !== "https:" || (host !== "x.ai" && !host.endsWith(".x.ai"))) {
-    throw new Error(`xAI OAuth discovery returned an unexpected endpoint: ${url}`);
-  }
-  return url;
-}
-
-async function xaiDiscovery(): Promise<XaiDiscovery> {
-  const response = await fetch(XAI_OAUTH_DISCOVERY_URL, {
-    headers: { Accept: "application/json" },
-  });
-  if (!response.ok) {
-    throw new Error(`xAI OAuth discovery failed: ${response.status} ${await response.text()}`);
-  }
-
-  const data = (await response.json()) as Partial<XaiDiscovery>;
-  if (!data.authorization_endpoint || !data.token_endpoint) {
-    throw new Error("xAI OAuth discovery response did not include authorization/token endpoints");
-  }
-
-  return {
-    authorization_endpoint: validateXaiEndpoint(data.authorization_endpoint),
-    token_endpoint: validateXaiEndpoint(data.token_endpoint),
-  };
 }
 
 function callbackCorsOrigin(origin: string | undefined): string | undefined {
@@ -79,28 +69,41 @@ function callbackCorsOrigin(origin: string | undefined): string | undefined {
 }
 
 /** Refresh xAI OAuth credentials using their refresh token. */
-export async function refreshXaiCredentials(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+export async function refreshXaiCredentials(
+  credentials: OAuthCredentials,
+  signal?: AbortSignal,
+): Promise<OAuthCredentials> {
   if (!credentials.refresh) {
     throw new Error("xAI credentials are expired and do not include a refresh token");
   }
 
   const tokenEndpoint =
     typeof credentials.tokenEndpoint === "string" && credentials.tokenEndpoint
-      ? validateXaiEndpoint(credentials.tokenEndpoint)
-      : (await xaiDiscovery()).token_endpoint;
-  const data = await exchangeXaiToken(tokenEndpoint, {
-    grant_type: "refresh_token",
-    refresh_token: credentials.refresh,
-    client_id: XAI_OAUTH_CLIENT_ID,
-  });
+      ? credentials.tokenEndpoint
+      : (await discoverXaiOidc(signal)).token_endpoint;
+  if (tokenEndpoint !== XAI_OAUTH_TOKEN_URL) {
+    throw new Error("xAI credentials reference an untrusted token endpoint; run /login xai-auth again");
+  }
+  const data = await exchangeXaiToken(
+    tokenEndpoint,
+    {
+      grant_type: "refresh_token",
+      refresh_token: credentials.refresh,
+      client_id: XAI_OAUTH_CLIENT_ID,
+    },
+    signal,
+  );
 
   return credentialsFromTokenPayload(data, tokenEndpoint, credentials.refresh);
 }
 
 /** Return credentials as-is when fresh, otherwise refresh them. */
-export async function ensureFreshXaiCredentials(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+export async function ensureFreshXaiCredentials(
+  credentials: OAuthCredentials,
+  signal?: AbortSignal,
+): Promise<OAuthCredentials> {
   if (!credentials.expires || credentials.expires > Date.now()) return credentials;
-  return refreshXaiCredentials(credentials);
+  return refreshXaiCredentials(credentials, signal);
 }
 
 async function startCallbackServer(expectedState: string): Promise<{
@@ -144,7 +147,6 @@ async function startCallbackServer(expectedState: string): Promise<{
         code: url.searchParams.get("code") || undefined,
         state: url.searchParams.get("state") || undefined,
         error: url.searchParams.get("error") || undefined,
-        error_description: url.searchParams.get("error_description") || undefined,
       };
       if (result.state !== expectedState) {
         writeCors();
@@ -204,6 +206,10 @@ async function startCallbackServer(expectedState: string): Promise<{
       let timer: NodeJS.Timeout | undefined;
       let abortHandler: (() => void) | undefined;
       const timeout = new Promise<CallbackResult>((_, reject) => {
+        if (signal?.aborted) {
+          reject(new Error("xAI OAuth login was cancelled"));
+          return;
+        }
         timer = setTimeout(() => reject(new Error("Timed out waiting for xAI OAuth callback")), 180_000);
         abortHandler = () => {
           if (timer) clearTimeout(timer);
@@ -223,7 +229,13 @@ async function startCallbackServer(expectedState: string): Promise<{
   };
 }
 
-function buildAuthorizeUrl(discovery: XaiDiscovery, redirectUri: string, challenge: string, state: string, nonce: string): string {
+function buildAuthorizeUrl(
+  discovery: XaiOidcDiscovery,
+  redirectUri: string,
+  challenge: string,
+  state: string,
+  nonce: string,
+): string {
   // Match the official Grok CLI authorize URL. Extra query params such as
   // `plan=generic` can change xAI's routing/branding and send users toward
   // the API-console SSO surface instead of the Grok OAuth consent surface.
@@ -240,30 +252,37 @@ function buildAuthorizeUrl(discovery: XaiDiscovery, redirectUri: string, challen
   return `${discovery.authorization_endpoint}?${params.toString()}`;
 }
 
-function parseCallbackInput(input: string): CallbackResult | undefined {
+function parseCallbackInput(input: string): ManualCallbackInput {
   const value = input.trim();
-  if (!value) return undefined;
-
-  // xAI may show only the authorization code when localhost redirect fails,
-  // especially when pi runs in WSL and the browser runs on Windows.
-  if (/^[A-Za-z0-9_-]{20,}$/.test(value)) return { code: value, trustedManualCode: true };
+  if (!value) return { kind: "invalid" };
+  if (/^[A-Za-z0-9_-]{20,}$/.test(value)) return { kind: "raw-code" };
 
   try {
     const url = value.startsWith("http")
       ? new URL(value)
       : new URL(`http://${XAI_OAUTH_REDIRECT_HOST}${XAI_OAUTH_REDIRECT_PATH}?${value.replace(/^\?/, "")}`);
     return {
-      code: url.searchParams.get("code") || undefined,
-      state: url.searchParams.get("state") || undefined,
-      error: url.searchParams.get("error") || undefined,
-      error_description: url.searchParams.get("error_description") || undefined,
+      kind: "callback",
+      result: {
+        code: url.searchParams.get("code") || undefined,
+        state: url.searchParams.get("state") || undefined,
+        error: url.searchParams.get("error") || undefined,
+      },
     };
   } catch {
-    return undefined;
+    return { kind: "invalid" };
   }
 }
 
-async function exchangeXaiToken(tokenEndpoint: string, body: Record<string, string>): Promise<XaiTokenPayload> {
+async function exchangeXaiToken(
+  tokenEndpoint: string,
+  body: Record<string, string>,
+  signal?: AbortSignal,
+): Promise<XaiTokenPayload> {
+  if (tokenEndpoint !== XAI_OAUTH_TOKEN_URL) {
+    throw new Error("Refusing to send xAI credentials to an untrusted token endpoint");
+  }
+
   const response = await fetch(tokenEndpoint, {
     method: "POST",
     headers: {
@@ -271,30 +290,49 @@ async function exchangeXaiToken(tokenEndpoint: string, body: Record<string, stri
       "Content-Type": "application/x-www-form-urlencoded",
     },
     body: new URLSearchParams(body).toString(),
+    redirect: "error",
+    signal,
   });
   if (!response.ok) {
-    throw new Error(`xAI token request failed: ${response.status} ${await response.text()}`);
+    throw new Error(`xAI token request failed with status ${response.status}`);
   }
-  return (await response.json()) as XaiTokenPayload;
+  try {
+    const payload = (await response.json()) as unknown;
+    if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
+      throw new Error("invalid payload");
+    }
+    return payload as XaiTokenPayload;
+  } catch {
+    throw new Error("xAI token request returned invalid JSON");
+  }
 }
 
-function credentialsFromTokenPayload(data: XaiTokenPayload, tokenEndpoint: string, fallbackRefresh = ""): OAuthCredentials {
-  if (!data.access_token) {
+function credentialsFromTokenPayload(
+  data: XaiTokenPayload,
+  tokenEndpoint: string,
+  fallbackRefresh = "",
+  validatedIdToken?: string,
+): OAuthCredentials {
+  if (typeof data.access_token !== "string" || !data.access_token) {
     throw new Error("xAI token response did not include an access token");
   }
 
-  const refresh = data.refresh_token || fallbackRefresh;
+  const refresh = typeof data.refresh_token === "string" && data.refresh_token ? data.refresh_token : fallbackRefresh;
   if (!refresh) {
     throw new Error("xAI token response did not include a refresh token");
   }
+  const expiresIn =
+    typeof data.expires_in === "number" && Number.isFinite(data.expires_in) && data.expires_in > 0
+      ? data.expires_in
+      : 3600;
 
   return {
     refresh,
     access: data.access_token,
-    expires: Date.now() + (data.expires_in || 3600) * 1000 - XAI_OAUTH_REFRESH_SKEW_MS,
+    expires: Date.now() + expiresIn * 1000 - XAI_OAUTH_REFRESH_SKEW_MS,
     tokenEndpoint,
-    idToken: data.id_token || "",
-    tokenType: data.token_type || "Bearer",
+    ...(validatedIdToken ? { idToken: validatedIdToken } : {}),
+    tokenType: typeof data.token_type === "string" && data.token_type ? data.token_type : "Bearer",
   };
 }
 
@@ -305,6 +343,7 @@ export function createXaiOAuth({ getExistingCredentials }: XaiOAuthOptions) {
     name: "xAI (Grok)",
 
     async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+      assertLoginNotCancelled(callbacks.signal);
       const existingCredentials = getExistingCredentials();
       if (existingCredentials) {
         const useExisting = await callbacks.onPrompt({
@@ -312,7 +351,9 @@ export function createXaiOAuth({ getExistingCredentials }: XaiOAuthOptions) {
         });
         if (useExisting.toLowerCase().startsWith("y")) {
           try {
-            return await ensureFreshXaiCredentials(existingCredentials);
+            return await runAbortableLoginStep(callbacks.signal, () =>
+              ensureFreshXaiCredentials(existingCredentials, callbacks.signal),
+            );
           } catch (error) {
             callbacks.onProgress?.(
               `Existing Grok CLI credentials could not be refreshed (${messageFromError(error)}). Starting a fresh xAI OAuth login...`,
@@ -322,66 +363,100 @@ export function createXaiOAuth({ getExistingCredentials }: XaiOAuthOptions) {
       }
 
       callbacks.onProgress?.("Starting xAI SuperGrok OAuth login...");
-      const discovery = await xaiDiscovery();
+      const discovery = await runAbortableLoginStep(callbacks.signal, () => discoverXaiOidc(callbacks.signal));
       const { verifier, challenge } = pkcePair();
       const state = randomUUID().replace(/-/g, "");
       const nonce = randomUUID().replace(/-/g, "");
       const callbackServer = await startCallbackServer(state);
-      const authorizeUrl = buildAuthorizeUrl(discovery, callbackServer.redirectUri, challenge, state, nonce);
+      let callback: CallbackResult;
+      try {
+        const authorizeUrl = buildAuthorizeUrl(discovery, callbackServer.redirectUri, challenge, state, nonce);
 
-      // Trigger automatic browser open via pi's onAuth handler.
-      // pi's login dialog runs `open <url>` on macOS / `xdg-open` on Linux,
-      // AND when usesCallbackServer:true it also shows a built-in manual input
-      // field that resolves via onManualCodeInput. We race both paths below.
-      callbacks.onAuth?.({
-        url: authorizeUrl,
-        instructions:
-          "If the automatic open uses the wrong browser/profile, copy the URL and paste it into the field below (or open it manually in your preferred browser).",
-      });
-
-      callbacks.onProgress?.(`Waiting for xAI OAuth callback on ${callbackServer.redirectUri}...`);
-
-      // Race the local callback server against pi's built-in manual input
-      // (shown automatically when usesCallbackServer: true). If the HTTP
-      // callback fires first (browser reaches localhost), the manual input
-      // is simply a no-op since resolveCallback already ran.
-      const manualCodePromise = callbacks.onManualCodeInput?.();
-      if (manualCodePromise) {
-        manualCodePromise.then((input: string) => {
-          if (input) {
-            const manual = parseCallbackInput(input);
-            if (manual?.trustedManualCode || manual?.state === state || manual?.error) {
-              callbackServer.resolveCallback(manual);
-            } else if (manual) {
-              callbacks.onProgress?.("Ignored pasted xAI callback because the OAuth state did not match. Try the login again if needed.");
-            }
-          }
-        }).catch(() => {
-          // Cancellation is handled by callbacks.signal / the login dialog.
+        // Trigger automatic browser open via pi's onAuth handler.
+        // pi's login dialog runs `open <url>` on macOS / `xdg-open` on Linux,
+        // AND when usesCallbackServer:true it also shows a built-in manual input
+        // field that resolves via onManualCodeInput. We race both paths below.
+        callbacks.onAuth?.({
+          url: authorizeUrl,
+          instructions:
+            "If the automatic open uses the wrong browser/profile, copy the authorization URL and open it manually. If the redirect cannot reach pi, paste the complete redirect URL (including code and state) below; raw codes are not accepted.",
         });
-      }
 
-      const callback = await callbackServer.waitForCallback(callbacks.signal);
-      if (callback.error) {
-        throw new Error(`xAI authorization failed: ${callback.error_description || callback.error}`);
+        callbacks.onProgress?.(`Waiting for xAI OAuth callback on ${callbackServer.redirectUri}...`);
+
+        // Race the local callback server against pi's built-in manual input
+        // (shown automatically when usesCallbackServer: true). If the HTTP
+        // callback fires first (browser reaches localhost), the manual input
+        // is simply a no-op since resolveCallback already ran.
+        const manualCodePromise = callbacks.onManualCodeInput?.();
+        if (manualCodePromise) {
+          manualCodePromise
+            .then((input: string) => {
+              if (!input) return;
+              const manual = parseCallbackInput(input);
+              if (manual.kind === "raw-code") {
+                callbacks.onProgress?.(RAW_CODE_MIGRATION_MESSAGE);
+                callbackServer.resolveCallback({ error: "raw_code_not_supported", state });
+                return;
+              }
+              if (manual.kind === "invalid") {
+                callbacks.onProgress?.("Ignored pasted xAI OAuth input because it was not a complete redirect URL.");
+                return;
+              }
+              if (manual.result.state !== state) {
+                callbacks.onProgress?.(
+                  "Ignored pasted xAI callback because it was missing the matching OAuth state. Paste the complete redirect URL from this login attempt.",
+                );
+                return;
+              }
+              callbackServer.resolveCallback(manual.result);
+            })
+            .catch(() => {
+              // Cancellation is handled by callbacks.signal / the login dialog.
+            });
+        }
+
+        callback = await callbackServer.waitForCallback(callbacks.signal);
+      } finally {
+        callbackServer.close();
       }
-      if (!callback.trustedManualCode && callback.state !== state) {
+      if (callback.error === "raw_code_not_supported") {
+        throw new Error(RAW_CODE_MIGRATION_MESSAGE);
+      }
+      if (callback.state !== state) {
         throw new Error("xAI authorization failed: state mismatch");
+      }
+      if (callback.error) {
+        throw new Error("xAI authorization failed");
       }
       if (!callback.code) {
         throw new Error("xAI authorization failed: no authorization code returned");
       }
 
+      assertLoginNotCancelled(callbacks.signal);
       callbacks.onProgress?.("Exchanging xAI authorization code...");
-      const data = await exchangeXaiToken(discovery.token_endpoint, {
-        grant_type: "authorization_code",
-        code: callback.code,
-        redirect_uri: callbackServer.redirectUri,
-        client_id: XAI_OAUTH_CLIENT_ID,
-        code_verifier: verifier,
-      });
+      const data = await runAbortableLoginStep(callbacks.signal, () =>
+        exchangeXaiToken(
+          discovery.token_endpoint,
+          {
+            grant_type: "authorization_code",
+            code: callback.code!,
+            redirect_uri: callbackServer.redirectUri,
+            client_id: XAI_OAUTH_CLIENT_ID,
+            code_verifier: verifier,
+          },
+          callbacks.signal,
+        ),
+      );
+      if (typeof data.id_token !== "string" || !data.id_token) {
+        throw new Error("xAI token response did not include an ID token");
+      }
+      await runAbortableLoginStep(callbacks.signal, () =>
+        validateXaiIdToken(data.id_token!, discovery, nonce, callbacks.signal),
+      );
+      assertLoginNotCancelled(callbacks.signal);
 
-      return credentialsFromTokenPayload(data, discovery.token_endpoint);
+      return credentialsFromTokenPayload(data, discovery.token_endpoint, "", data.id_token);
     },
 
     async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {

--- a/extensions/xai/oidc.ts
+++ b/extensions/xai/oidc.ts
@@ -1,0 +1,321 @@
+import { createPublicKey, verify as verifySignature, webcrypto } from "crypto";
+import {
+  XAI_OAUTH_AUTHORIZATION_URL,
+  XAI_OAUTH_CLIENT_ID,
+  XAI_OAUTH_DISCOVERY_URL,
+  XAI_OAUTH_ID_TOKEN_ALGORITHM,
+  XAI_OAUTH_ISSUER,
+  XAI_OAUTH_JWKS_URL,
+  XAI_OAUTH_PKCE_METHOD,
+  XAI_OAUTH_TOKEN_URL,
+} from "./constants";
+
+const ID_TOKEN_CLOCK_SKEW_SECONDS = 60;
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+export type XaiOidcDiscovery = {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  jwks_uri: string;
+  id_token_signing_alg_values_supported: string[];
+  code_challenge_methods_supported: string[];
+};
+
+type XaiIdTokenHeader = {
+  alg?: unknown;
+  kid?: unknown;
+  crit?: unknown;
+  jku?: unknown;
+  jwk?: unknown;
+  x5u?: unknown;
+};
+
+type XaiIdTokenClaims = {
+  iss?: unknown;
+  sub?: unknown;
+  aud?: unknown;
+  azp?: unknown;
+  exp?: unknown;
+  iat?: unknown;
+  nonce?: unknown;
+};
+
+type XaiJwk = {
+  kty?: unknown;
+  crv?: unknown;
+  use?: unknown;
+  alg?: unknown;
+  kid?: unknown;
+  x?: unknown;
+  y?: unknown;
+  d?: unknown;
+  key_ops?: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function readJsonResponse(response: Response, label: string): Promise<unknown> {
+  const contentType = response.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
+  if (contentType !== "application/json") {
+    throw new Error(`${label} did not return application/json`);
+  }
+
+  try {
+    return await response.json();
+  } catch {
+    throw new Error(`${label} returned invalid JSON`);
+  }
+}
+
+function requirePinnedMetadataValue(
+  metadata: Record<string, unknown>,
+  field: string,
+  expected: string,
+  label: string,
+): string {
+  if (metadata[field] !== expected) {
+    throw new Error(`xAI OIDC discovery ${label} did not match the pinned first-party value`);
+  }
+  return expected;
+}
+
+/** Validate xAI OIDC metadata against the package's pinned first-party policy. */
+export function validateXaiDiscovery(metadata: unknown): XaiOidcDiscovery {
+  if (!isRecord(metadata)) {
+    throw new Error("xAI OIDC discovery returned an invalid document");
+  }
+
+  const issuer = requirePinnedMetadataValue(metadata, "issuer", XAI_OAUTH_ISSUER, "issuer");
+  const authorizationEndpoint = requirePinnedMetadataValue(
+    metadata,
+    "authorization_endpoint",
+    XAI_OAUTH_AUTHORIZATION_URL,
+    "authorization endpoint",
+  );
+  const tokenEndpoint = requirePinnedMetadataValue(metadata, "token_endpoint", XAI_OAUTH_TOKEN_URL, "token endpoint");
+  const jwksUri = requirePinnedMetadataValue(metadata, "jwks_uri", XAI_OAUTH_JWKS_URL, "JWKS endpoint");
+
+  const signingAlgorithms = metadata.id_token_signing_alg_values_supported;
+  if (!Array.isArray(signingAlgorithms) || !signingAlgorithms.includes(XAI_OAUTH_ID_TOKEN_ALGORITHM)) {
+    throw new Error(`xAI OIDC discovery did not advertise ${XAI_OAUTH_ID_TOKEN_ALGORITHM} ID-token signing`);
+  }
+
+  const pkceMethods = metadata.code_challenge_methods_supported;
+  if (!Array.isArray(pkceMethods) || !pkceMethods.includes(XAI_OAUTH_PKCE_METHOD)) {
+    throw new Error(`xAI OIDC discovery did not advertise ${XAI_OAUTH_PKCE_METHOD} PKCE`);
+  }
+
+  return {
+    issuer,
+    authorization_endpoint: authorizationEndpoint,
+    token_endpoint: tokenEndpoint,
+    jwks_uri: jwksUri,
+    id_token_signing_alg_values_supported: [XAI_OAUTH_ID_TOKEN_ALGORITHM],
+    code_challenge_methods_supported: [XAI_OAUTH_PKCE_METHOD],
+  };
+}
+
+/** Fetch and validate xAI's pinned OpenID Provider metadata. */
+export async function discoverXaiOidc(signal?: AbortSignal): Promise<XaiOidcDiscovery> {
+  const response = await fetch(XAI_OAUTH_DISCOVERY_URL, {
+    headers: { Accept: "application/json" },
+    redirect: "error",
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error(`xAI OIDC discovery failed with status ${response.status}`);
+  }
+  return validateXaiDiscovery(await readJsonResponse(response, "xAI OIDC discovery"));
+}
+
+function decodeJwtJson(segment: string, label: string): Record<string, unknown> {
+  if (!BASE64URL_PATTERN.test(segment)) {
+    throw new Error(`xAI ID token ${label} was not valid base64url`);
+  }
+
+  try {
+    const decoded = JSON.parse(Buffer.from(segment, "base64url").toString("utf8")) as unknown;
+    if (!isRecord(decoded)) throw new Error("not an object");
+    return decoded;
+  } catch {
+    throw new Error(`xAI ID token ${label} was not valid JSON`);
+  }
+}
+
+function decodeBase64UrlBytes(value: unknown, label: string): Buffer {
+  if (typeof value !== "string" || !BASE64URL_PATTERN.test(value)) {
+    throw new Error(`xAI JWKS ${label} was invalid`);
+  }
+  return Buffer.from(value, "base64url");
+}
+
+async function fetchXaiJwks(discovery: XaiOidcDiscovery, signal?: AbortSignal): Promise<XaiJwk[]> {
+  if (discovery.jwks_uri !== XAI_OAUTH_JWKS_URL || discovery.issuer !== XAI_OAUTH_ISSUER) {
+    throw new Error("xAI JWKS request was not bound to the pinned issuer");
+  }
+
+  const response = await fetch(XAI_OAUTH_JWKS_URL, {
+    headers: { Accept: "application/json" },
+    redirect: "error",
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error(`xAI JWKS request failed with status ${response.status}`);
+  }
+
+  const document = await readJsonResponse(response, "xAI JWKS");
+  if (
+    !isRecord(document) ||
+    !Array.isArray(document.keys) ||
+    document.keys.length === 0 ||
+    document.keys.length > 100 ||
+    !document.keys.every(isRecord)
+  ) {
+    throw new Error("xAI JWKS returned an invalid key set");
+  }
+  return document.keys;
+}
+
+function selectSigningKey(keys: XaiJwk[], kid: string): XaiJwk {
+  const matches = keys.filter((key) => key.kid === kid);
+  if (matches.length !== 1) {
+    throw new Error(matches.length === 0 ? "xAI ID token used an unknown signing key" : "xAI JWKS contained an ambiguous signing key");
+  }
+
+  const key = matches[0];
+  if (
+    key.kty !== "EC" ||
+    key.crv !== "P-256" ||
+    (key.use !== undefined && key.use !== "sig") ||
+    (key.alg !== undefined && key.alg !== XAI_OAUTH_ID_TOKEN_ALGORITHM) ||
+    key.d !== undefined ||
+    (key.key_ops !== undefined && (!Array.isArray(key.key_ops) || !key.key_ops.includes("verify")))
+  ) {
+    throw new Error("xAI ID token signing key did not match the required ES256 public-key policy");
+  }
+
+  if (decodeBase64UrlBytes(key.x, "x coordinate").length !== 32 || decodeBase64UrlBytes(key.y, "y coordinate").length !== 32) {
+    throw new Error("xAI ID token signing key had invalid P-256 coordinates");
+  }
+  return key;
+}
+
+function validateIdTokenClaims(claims: XaiIdTokenClaims, expectedNonce: string, nowSeconds: number): void {
+  if (claims.iss !== XAI_OAUTH_ISSUER) {
+    throw new Error("xAI ID token issuer did not match the pinned issuer");
+  }
+
+  if (
+    typeof claims.sub !== "string" ||
+    claims.sub.length === 0 ||
+    claims.sub.length > 255 ||
+    !/^[\x20-\x7e]+$/.test(claims.sub)
+  ) {
+    throw new Error("xAI ID token subject was invalid");
+  }
+
+  const audiences = typeof claims.aud === "string" ? [claims.aud] : claims.aud;
+  if (
+    !Array.isArray(audiences) ||
+    audiences.length === 0 ||
+    audiences.some((audience) => audience !== XAI_OAUTH_CLIENT_ID)
+  ) {
+    throw new Error("xAI ID token audience did not match this OAuth client");
+  }
+  if (claims.azp !== undefined && claims.azp !== XAI_OAUTH_CLIENT_ID) {
+    throw new Error("xAI ID token authorized party did not match this OAuth client");
+  }
+
+  if (typeof claims.exp !== "number" || !Number.isFinite(claims.exp)) {
+    throw new Error("xAI ID token expiry was invalid");
+  }
+  if (nowSeconds >= claims.exp + ID_TOKEN_CLOCK_SKEW_SECONDS) {
+    throw new Error("xAI ID token has expired");
+  }
+  if (typeof claims.iat !== "number" || !Number.isFinite(claims.iat)) {
+    throw new Error("xAI ID token issued-at time was invalid");
+  }
+  if (claims.iat > nowSeconds + ID_TOKEN_CLOCK_SKEW_SECONDS) {
+    throw new Error("xAI ID token was issued in the future");
+  }
+  if (claims.nonce !== expectedNonce) {
+    throw new Error("xAI ID token nonce did not match this login attempt");
+  }
+}
+
+/** Validate and verify a fresh-login xAI ID token before it is retained. */
+export async function validateXaiIdToken(
+  idToken: string,
+  discovery: XaiOidcDiscovery,
+  expectedNonce: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (!idToken || !expectedNonce) {
+    throw new Error("xAI token response did not include a verifiable ID token");
+  }
+  if (
+    discovery.issuer !== XAI_OAUTH_ISSUER ||
+    discovery.jwks_uri !== XAI_OAUTH_JWKS_URL ||
+    discovery.id_token_signing_alg_values_supported.length !== 1 ||
+    discovery.id_token_signing_alg_values_supported[0] !== XAI_OAUTH_ID_TOKEN_ALGORITHM
+  ) {
+    throw new Error("xAI ID token validation was not bound to trusted discovery metadata");
+  }
+
+  const segments = idToken.split(".");
+  if (segments.length !== 3 || segments.some((segment) => !segment)) {
+    throw new Error("xAI ID token was not a compact signed JWT");
+  }
+
+  const [encodedHeader, encodedClaims, encodedSignature] = segments;
+  const header = decodeJwtJson(encodedHeader, "header") as XaiIdTokenHeader;
+  const claims = decodeJwtJson(encodedClaims, "claims") as XaiIdTokenClaims;
+  if (header.alg !== XAI_OAUTH_ID_TOKEN_ALGORITHM) {
+    throw new Error(`xAI ID token did not use ${XAI_OAUTH_ID_TOKEN_ALGORITHM}`);
+  }
+  if (typeof header.kid !== "string" || !header.kid) {
+    throw new Error("xAI ID token did not identify a signing key");
+  }
+  if (header.crit !== undefined || header.jku !== undefined || header.jwk !== undefined || header.x5u !== undefined) {
+    throw new Error("xAI ID token used unsupported JOSE header parameters");
+  }
+
+  if (!BASE64URL_PATTERN.test(encodedSignature)) {
+    throw new Error("xAI ID token signature was not valid base64url");
+  }
+  const signature = Buffer.from(encodedSignature, "base64url");
+  if (signature.length !== 64) {
+    throw new Error("xAI ID token signature had an invalid ES256 length");
+  }
+
+  const signingKey = selectSigningKey(await fetchXaiJwks(discovery, signal), header.kid);
+  let publicKey;
+  try {
+    publicKey = createPublicKey({
+      key: {
+        kty: "EC",
+        crv: "P-256",
+        x: signingKey.x as string,
+        y: signingKey.y as string,
+      } as webcrypto.JsonWebKey,
+      format: "jwk",
+    });
+  } catch {
+    throw new Error("xAI ID token signing key could not be imported");
+  }
+
+  const validSignature = verifySignature(
+    "sha256",
+    Buffer.from(`${encodedHeader}.${encodedClaims}`, "ascii"),
+    { key: publicKey, dsaEncoding: "ieee-p1363" },
+    signature,
+  );
+  if (!validSignature) {
+    throw new Error("xAI ID token signature was invalid");
+  }
+
+  validateIdTokenClaims(claims, expectedNonce, Math.floor(Date.now() / 1000));
+}

--- a/extensions/xai/oidc.ts
+++ b/extensions/xai/oidc.ts
@@ -221,11 +221,15 @@ function validateIdTokenClaims(claims: XaiIdTokenClaims, expectedNonce: string, 
   if (
     !Array.isArray(audiences) ||
     audiences.length === 0 ||
-    audiences.some((audience) => audience !== XAI_OAUTH_CLIENT_ID)
+    audiences.some((audience) => typeof audience !== "string") ||
+    !audiences.includes(XAI_OAUTH_CLIENT_ID)
   ) {
     throw new Error("xAI ID token audience did not match this OAuth client");
   }
-  if (claims.azp !== undefined && claims.azp !== XAI_OAUTH_CLIENT_ID) {
+  if (
+    (audiences.length > 1 && claims.azp !== XAI_OAUTH_CLIENT_ID) ||
+    (claims.azp !== undefined && claims.azp !== XAI_OAUTH_CLIENT_ID)
+  ) {
     throw new Error("xAI ID token authorized party did not match this OAuth client");
   }
 

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -1607,6 +1607,19 @@ async function verifyOAuthOidcValidation(provider) {
   );
   await expectOidcLoginFailure(
     provider,
+    "multi-audience-missing-authorized-party",
+    {
+      tokenOptions: {
+        claims: {
+          aud: ["b1a00492-073a-47ea-816f-4c329264a828", "another-valid-audience"],
+          azp: undefined,
+        },
+      },
+    },
+    /authorized party did not match/,
+  );
+  await expectOidcLoginFailure(
+    provider,
     "wrong-nonce",
     { tokenOptions: { claims: { nonce: "wrong-nonce" } } },
     /nonce did not match/,
@@ -1691,6 +1704,30 @@ async function verifyOAuthOidcValidation(provider) {
     { tokenResponse: {} },
     /did not include an ID token/,
   );
+}
+
+async function verifyOAuthMultiAudience(provider) {
+  let expectedIdToken;
+  const credentials = await provider.oauth.login({
+    onPrompt: async () => "n",
+    onProgress: () => {},
+    onAuth(auth) {
+      const authUrl = new URL(auth.url);
+      expectedIdToken = queueValidOAuthToken("multi-audience", authUrl, {
+        claims: {
+          aud: ["b1a00492-073a-47ea-816f-4c329264a828", "another-valid-audience"],
+          azp: "b1a00492-073a-47ea-816f-4c329264a828",
+        },
+      });
+      setTimeout(async () => {
+        const callbackUrl = new URL(authUrl.searchParams.get("redirect_uri"));
+        callbackUrl.searchParams.set("code", "multi-audience");
+        callbackUrl.searchParams.set("state", authUrl.searchParams.get("state"));
+        await originalFetch(callbackUrl);
+      }, 0);
+    },
+  });
+  assert.strictEqual(credentials.idToken, expectedIdToken, "multi-audience token should require and accept this client as azp");
 }
 
 async function verifyOAuthOptionalJwkHints(provider) {
@@ -1940,6 +1977,7 @@ async function main() {
     await verifyOAuthManualMissingStateIgnored(provider);
     await verifyOAuthDiscoveryPolicy(provider);
     await verifyOAuthOidcValidation(provider);
+    await verifyOAuthMultiAudience(provider);
     await verifyOAuthOptionalJwkHints(provider);
     await verifyOAuthAuthorizationErrorRedaction(provider);
     await verifyOAuthTokenErrorRedaction(provider);

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const assert = require("assert");
+const crypto = require("crypto");
 const path = require("path");
 const fs = require("fs/promises");
 const { createJiti } = require("jiti");
@@ -20,6 +21,21 @@ const { resolveXaiRoute } = jiti(path.join(repoRoot, "extensions", "xai", "routi
 const { XAI_NETWORK_TOOL_NAMES } = jiti(path.join(repoRoot, "extensions", "xai", "tools", "model-scope.ts"));
 const originalFetch = global.fetch;
 const requests = [];
+const oauthTokenResponses = new Map();
+const { privateKey: oidcPrivateKey, publicKey: oidcPublicKey } = crypto.generateKeyPairSync("ec", {
+  namedCurve: "prime256v1",
+});
+const TEST_OIDC_KID = "test-xai-es256-key";
+const TEST_OIDC_PUBLIC_JWK = {
+  ...oidcPublicKey.export({ format: "jwk" }),
+  use: "sig",
+  alg: "ES256",
+  kid: TEST_OIDC_KID,
+};
+let nextDiscoveryDocument;
+let nextJwksDocument;
+let nextRefreshTokenResponse;
+let abortNextOAuthFetch;
 let nextXaiResponse;
 
 const TEST_XAI_MODEL = {
@@ -78,6 +94,53 @@ function jsonResponse(body, init = {}) {
   });
 }
 
+function validOidcDiscovery(overrides = {}) {
+  return {
+    issuer: "https://auth.x.ai",
+    authorization_endpoint: "https://auth.x.ai/oauth2/authorize",
+    token_endpoint: "https://auth.x.ai/oauth2/token",
+    jwks_uri: "https://auth.x.ai/.well-known/jwks.json",
+    id_token_signing_alg_values_supported: ["ES256"],
+    code_challenge_methods_supported: ["S256"],
+    ...overrides,
+  };
+}
+
+function signTestIdToken({ nonce, claims = {}, header = {}, key = oidcPrivateKey } = {}) {
+  const now = Math.floor(Date.now() / 1000);
+  const encodedHeader = Buffer.from(JSON.stringify({ alg: "ES256", kid: TEST_OIDC_KID, typ: "JWT", ...header })).toString("base64url");
+  const encodedClaims = Buffer.from(JSON.stringify({
+    iss: "https://auth.x.ai",
+    sub: "test-user",
+    aud: "b1a00492-073a-47ea-816f-4c329264a828",
+    exp: now + 300,
+    iat: now,
+    nonce,
+    ...claims,
+  })).toString("base64url");
+  const signingInput = `${encodedHeader}.${encodedClaims}`;
+  const signature = crypto.sign("sha256", Buffer.from(signingInput, "ascii"), {
+    key,
+    dsaEncoding: "ieee-p1363",
+  });
+  return `${signingInput}.${signature.toString("base64url")}`;
+}
+
+function queueOAuthTokenResponse(code, response) {
+  oauthTokenResponses.set(code, response);
+}
+
+function queueValidOAuthToken(code, authUrl, options = {}) {
+  const idToken = signTestIdToken({
+    nonce: authUrl.searchParams.get("nonce"),
+    claims: options.claims,
+    header: options.header,
+    key: options.key,
+  });
+  queueOAuthTokenResponse(code, { ...options.token, id_token: idToken });
+  return idToken;
+}
+
 function installFetchMock() {
   global.fetch = async (url, init = {}) => {
     const href = String(url);
@@ -85,21 +148,49 @@ function installFetchMock() {
       return originalFetch(url, init);
     }
 
+    if (abortNextOAuthFetch?.url === href) {
+      const pendingAbort = abortNextOAuthFetch;
+      abortNextOAuthFetch = undefined;
+      assert.strictEqual(init.signal, pendingAbort.controller.signal, `${href} should receive the login abort signal`);
+      pendingAbort.controller.abort();
+      throw new DOMException("The operation was aborted", "AbortError");
+    }
+
     if (href === "https://auth.x.ai/.well-known/openid-configuration") {
-      return jsonResponse({
-        authorization_endpoint: "https://auth.x.ai/oauth2/authorize",
-        token_endpoint: "https://auth.x.ai/oauth2/token",
-      });
+      assert.equal(init.redirect, "error", "OIDC discovery must not follow redirects away from the pinned URL");
+      const document = nextDiscoveryDocument ?? validOidcDiscovery();
+      nextDiscoveryDocument = undefined;
+      return jsonResponse(document);
+    }
+
+    if (href === "https://auth.x.ai/.well-known/jwks.json") {
+      assert.equal(init.redirect, "error", "JWKS fetch must not follow redirects away from the pinned URL");
+      const document = nextJwksDocument ?? { keys: [TEST_OIDC_PUBLIC_JWK] };
+      nextJwksDocument = undefined;
+      return jsonResponse(document);
     }
 
     if (href === "https://auth.x.ai/oauth2/token") {
+      assert.equal(init.redirect, "error", "token requests must not follow redirects away from the pinned endpoint");
       const params = new URLSearchParams(String(init.body || ""));
-      requests.push({ url: href, method: init.method, body: Object.fromEntries(params) });
+      const body = Object.fromEntries(params);
+      requests.push({ url: href, method: init.method, body });
+      const code = params.get("code");
+      const queued = code ? oauthTokenResponses.get(code) : nextRefreshTokenResponse;
+      if (code) {
+        oauthTokenResponses.delete(code);
+      } else {
+        nextRefreshTokenResponse = undefined;
+      }
+      if (queued?.status) {
+        return jsonResponse(queued.body ?? {}, { status: queued.status });
+      }
       return jsonResponse({
-        access_token: `access-${params.get("code") || "refresh"}`,
+        access_token: `access-${code || "refresh"}`,
         refresh_token: "refresh-token",
         expires_in: 3600,
         token_type: "Bearer",
+        ...(queued || {}),
       });
     }
 
@@ -1216,7 +1307,9 @@ function verifyXaiClientModeResolution() {
 }
 
 async function verifyOAuthCallbackState(provider) {
+  const before = requests.length;
   let authUrl;
+  let expectedIdToken;
   const login = provider.oauth.login({
     onPrompt: async () => "n",
     onProgress: () => {},
@@ -1224,7 +1317,13 @@ async function verifyOAuthCallbackState(provider) {
       authUrl = new URL(auth.url);
       const redirectUri = authUrl.searchParams.get("redirect_uri");
       const expectedState = authUrl.searchParams.get("state");
+      expectedIdToken = queueValidOAuthToken("good-code", authUrl);
       setTimeout(async () => {
+        const missing = new URL(redirectUri);
+        missing.searchParams.set("code", "missing-state-code");
+        const missingResponse = await originalFetch(missing);
+        assert.equal(missingResponse.status, 400, "missing OAuth state should be rejected without resolving login");
+
         const bad = new URL(redirectUri);
         bad.searchParams.set("code", "bad-code");
         bad.searchParams.set("state", "wrong-state");
@@ -1241,16 +1340,23 @@ async function verifyOAuthCallbackState(provider) {
 
   const credentials = await login;
   assert.equal(credentials.access, "access-good-code", "login should ignore the bad callback and exchange the good code");
+  assert.strictEqual(credentials.idToken, expectedIdToken, "valid completion should retain the exact verified ID token");
   assert.ok(authUrl, "login should provide an authorization URL");
   assert.deepStrictEqual(
     authUrl.searchParams.get("scope")?.split(" "),
     XAI_OAUTH_SCOPES,
     "fresh xAI login should request the frozen eight-scope contract in order",
   );
+  const exchanges = requests.slice(before).filter((entry) => entry.body?.grant_type === "authorization_code");
+  assert.deepStrictEqual(exchanges.map((entry) => entry.body.code), ["good-code"], "wrong-state code substitution must not reach token exchange");
 }
 
 async function verifyLegacyOAuthRefresh(provider) {
   const before = requests.length;
+  nextRefreshTokenResponse = {
+    refresh_token: undefined,
+    id_token: "unvalidated-refresh-id-token-must-not-be-retained",
+  };
   const credentials = await provider.oauth.refreshToken({
     access: "legacy-access-token",
     refresh: "legacy-refresh-token",
@@ -1270,36 +1376,51 @@ async function verifyLegacyOAuthRefresh(provider) {
   });
   assert.equal(Object.hasOwn(refreshRequest.body, "scope"), false, "refresh must not renegotiate fresh-login scopes");
   assert.equal(credentials.access, "access-refresh");
+  assert.equal(credentials.refresh, "legacy-refresh-token", "refresh should preserve the previous token when rotation omits one");
+  assert.equal(Object.hasOwn(credentials, "idToken"), false, "refresh must not retain an unvalidated ID token");
+
+  await assert.rejects(
+    provider.oauth.refreshToken({
+      access: "legacy-access-token",
+      refresh: "legacy-refresh-token",
+      expires: Date.now() - 1,
+      tokenEndpoint: "https://evil.x.ai/oauth2/token",
+    }),
+    /untrusted token endpoint/,
+  );
 }
 
-async function verifyOAuthManualRawCode(provider) {
+async function verifyOAuthManualRawCodeRejected(provider) {
   const rawCode = "bMmOusw8w9arz1aNEuDCY02jhiOs22O5j-92yEKTzMCbPShyToONJWSc2KITti2CgoM0clOeFMUosJm76y_2MA";
-  const controller = new AbortController();
-  const abortTimer = setTimeout(() => controller.abort(), 500);
+  const before = requests.length;
+  const progress = [];
   let authUrl;
 
-  try {
-    const credentials = await provider.oauth.login({
+  await assert.rejects(
+    provider.oauth.login({
       onPrompt: async () => "n",
-      onProgress: () => {},
+      onProgress(message) {
+        progress.push(message);
+      },
       onAuth(auth) {
         authUrl = new URL(auth.url);
       },
       onManualCodeInput: async () => rawCode,
-      signal: controller.signal,
-    });
+    }),
+    /Raw xAI authorization codes are no longer accepted.*complete redirect URL.*issue #66/s,
+  );
 
-    assert.equal(credentials.access, `access-${rawCode}`, "raw pasted xAI authorization code should be accepted and exchanged");
-    assert.ok(authUrl, "login should provide an authorization URL before accepting manual code");
-  } finally {
-    clearTimeout(abortTimer);
-  }
+  assert.ok(authUrl, "login should provide an authorization URL before rejecting raw code");
+  assert.ok(progress.some((message) => /complete redirect URL/.test(message)), "raw-code users should receive safe migration guidance");
+  const exchanges = requests.slice(before).filter((entry) => entry.body?.grant_type === "authorization_code");
+  assert.equal(exchanges.length, 0, "raw authorization code must never reach token exchange");
 }
 
 async function verifyOAuthManualCallbackUrlState(provider) {
   const controller = new AbortController();
   const abortTimer = setTimeout(() => controller.abort(), 500);
   let callbackUrl;
+  let expectedIdToken;
 
   try {
     const credentials = await provider.oauth.login({
@@ -1310,18 +1431,21 @@ async function verifyOAuthManualCallbackUrlState(provider) {
         callbackUrl = new URL(authUrl.searchParams.get("redirect_uri"));
         callbackUrl.searchParams.set("code", "manual-url-code");
         callbackUrl.searchParams.set("state", authUrl.searchParams.get("state"));
+        expectedIdToken = queueValidOAuthToken("manual-url-code", authUrl);
       },
       onManualCodeInput: async () => callbackUrl.toString(),
       signal: controller.signal,
     });
 
     assert.equal(credentials.access, "access-manual-url-code", "manual callback URL with matching state should be exchanged");
+    assert.strictEqual(credentials.idToken, expectedIdToken, "manual completion should retain the exact verified ID token");
   } finally {
     clearTimeout(abortTimer);
   }
 }
 
 async function verifyOAuthManualWrongStateIgnored(provider) {
+  const before = requests.length;
   const progress = [];
   const controller = new AbortController();
   const abortTimer = setTimeout(() => controller.abort(), 5_000);
@@ -1337,6 +1461,7 @@ async function verifyOAuthManualWrongStateIgnored(provider) {
         authUrl = new URL(auth.url);
         const redirectUri = authUrl.searchParams.get("redirect_uri");
         const expectedState = authUrl.searchParams.get("state");
+        queueValidOAuthToken("manual-wrong-state-fallback-good", authUrl);
         setTimeout(async () => {
           const good = new URL(redirectUri);
           good.searchParams.set("code", "manual-wrong-state-fallback-good");
@@ -1349,11 +1474,412 @@ async function verifyOAuthManualWrongStateIgnored(provider) {
     });
 
     assert.equal(credentials.access, "access-manual-wrong-state-fallback-good", "manual callback query with wrong state should be ignored");
-    assert.ok(progress.some((message) => /OAuth state did not match/.test(message)), "wrong-state manual callback should log that it was ignored");
+    assert.ok(progress.some((message) => /matching OAuth state/.test(message)), "wrong-state manual callback should report that it was ignored");
     assert.ok(authUrl, "login should provide an authorization URL");
+    const exchanges = requests.slice(before).filter((entry) => entry.body?.grant_type === "authorization_code");
+    assert.deepStrictEqual(
+      exchanges.map((entry) => entry.body.code),
+      ["manual-wrong-state-fallback-good"],
+      "wrong-state pasted code must not be substituted into token exchange",
+    );
   } finally {
     clearTimeout(abortTimer);
   }
+}
+
+async function verifyOAuthManualMissingStateIgnored(provider) {
+  const before = requests.length;
+  const progress = [];
+  const controller = new AbortController();
+  const abortTimer = setTimeout(() => controller.abort(), 5_000);
+
+  try {
+    const credentials = await provider.oauth.login({
+      onPrompt: async () => "n",
+      onProgress(message) {
+        progress.push(message);
+      },
+      onAuth(auth) {
+        const authUrl = new URL(auth.url);
+        const redirectUri = authUrl.searchParams.get("redirect_uri");
+        queueValidOAuthToken("manual-missing-state-fallback-good", authUrl);
+        setTimeout(async () => {
+          const good = new URL(redirectUri);
+          good.searchParams.set("code", "manual-missing-state-fallback-good");
+          good.searchParams.set("state", authUrl.searchParams.get("state"));
+          await originalFetch(good);
+        }, 10);
+      },
+      onManualCodeInput: async () => "code=manual-missing-state-code",
+      signal: controller.signal,
+    });
+
+    assert.equal(credentials.access, "access-manual-missing-state-fallback-good");
+    assert.ok(progress.some((message) => /missing the matching OAuth state/.test(message)), "missing-state manual callback should be ignored clearly");
+    const exchanges = requests.slice(before).filter((entry) => entry.body?.grant_type === "authorization_code");
+    assert.deepStrictEqual(
+      exchanges.map((entry) => entry.body.code),
+      ["manual-missing-state-fallback-good"],
+      "missing-state pasted code must not reach token exchange",
+    );
+  } finally {
+    clearTimeout(abortTimer);
+  }
+}
+
+async function verifyOAuthDiscoveryPolicy(provider) {
+  const cases = [
+    ["issuer", { issuer: "https://auth.x.ai/" }, /issuer did not match/],
+    ["authorization endpoint", { authorization_endpoint: "https://accounts.x.ai/oauth2/authorize" }, /authorization endpoint did not match/],
+    ["token endpoint", { token_endpoint: "https://evil.x.ai/oauth2/token" }, /token endpoint did not match/],
+    ["JWKS endpoint", { jwks_uri: "https://evil.x.ai/.well-known/jwks.json" }, /JWKS endpoint did not match/],
+    ["ID-token algorithm", { id_token_signing_alg_values_supported: ["RS256"] }, /ES256 ID-token signing/],
+    ["PKCE method", { code_challenge_methods_supported: ["plain"] }, /S256 PKCE/],
+  ];
+
+  for (const [label, override, pattern] of cases) {
+    nextDiscoveryDocument = validOidcDiscovery(override);
+    let openedBrowser = false;
+    await assert.rejects(
+      provider.oauth.login({
+        onPrompt: async () => "n",
+        onProgress: () => {},
+        onAuth() {
+          openedBrowser = true;
+        },
+      }),
+      pattern,
+      `${label} discovery policy should fail closed`,
+    );
+    assert.equal(openedBrowser, false, `${label} discovery failure must happen before browser authorization`);
+  }
+}
+
+async function expectOidcLoginFailure(provider, name, options, expectedError) {
+  const code = `oidc-${name}`;
+  const before = requests.length;
+  await assert.rejects(
+    provider.oauth.login({
+      onPrompt: async () => "n",
+      onProgress: () => {},
+      onAuth(auth) {
+        const authUrl = new URL(auth.url);
+        if (options.jwks) nextJwksDocument = options.jwks;
+        if (options.tokenResponse) {
+          queueOAuthTokenResponse(code, options.tokenResponse);
+        } else {
+          queueValidOAuthToken(code, authUrl, options.tokenOptions);
+        }
+        setTimeout(async () => {
+          const callbackUrl = new URL(authUrl.searchParams.get("redirect_uri"));
+          callbackUrl.searchParams.set("code", code);
+          callbackUrl.searchParams.set("state", authUrl.searchParams.get("state"));
+          await originalFetch(callbackUrl);
+        }, 0);
+      },
+    }),
+    expectedError,
+    `${name} ID token should be rejected`,
+  );
+  const exchanges = requests.slice(before).filter((entry) => entry.body?.grant_type === "authorization_code");
+  assert.deepStrictEqual(exchanges.map((entry) => entry.body.code), [code], `${name} should fail only after its bound code exchange`);
+}
+
+async function verifyOAuthOidcValidation(provider) {
+  const now = Math.floor(Date.now() / 1000);
+  await expectOidcLoginFailure(
+    provider,
+    "wrong-issuer",
+    { tokenOptions: { claims: { iss: "https://accounts.x.ai" } } },
+    /issuer did not match/,
+  );
+  await expectOidcLoginFailure(
+    provider,
+    "wrong-audience",
+    { tokenOptions: { claims: { aud: "another-client" } } },
+    /audience did not match/,
+  );
+  await expectOidcLoginFailure(
+    provider,
+    "wrong-authorized-party",
+    { tokenOptions: { claims: { azp: "another-client" } } },
+    /authorized party did not match/,
+  );
+  await expectOidcLoginFailure(
+    provider,
+    "wrong-nonce",
+    { tokenOptions: { claims: { nonce: "wrong-nonce" } } },
+    /nonce did not match/,
+  );
+  await expectOidcLoginFailure(
+    provider,
+    "expired",
+    { tokenOptions: { claims: { exp: now - 120 } } },
+    /has expired/,
+  );
+  await expectOidcLoginFailure(
+    provider,
+    "missing-subject",
+    { tokenOptions: { claims: { sub: undefined } } },
+    /subject was invalid/,
+  );
+  await expectOidcLoginFailure(
+    provider,
+    "missing-expiry",
+    { tokenOptions: { claims: { exp: undefined } } },
+    /expiry was invalid/,
+  );
+  await expectOidcLoginFailure(
+    provider,
+    "future-issued-at",
+    { tokenOptions: { claims: { iat: now + 120 } } },
+    /issued in the future/,
+  );
+  await expectOidcLoginFailure(
+    provider,
+    "missing-nonce",
+    { tokenOptions: { claims: { nonce: undefined } } },
+    /nonce did not match/,
+  );
+  await expectOidcLoginFailure(
+    provider,
+    "wrong-algorithm",
+    { tokenOptions: { header: { alg: "RS256" } } },
+    /did not use ES256/,
+  );
+  await expectOidcLoginFailure(
+    provider,
+    "unknown-key",
+    { tokenOptions: { header: { kid: "unknown-key" } } },
+    /unknown signing key/,
+  );
+
+  const { privateKey: wrongPrivateKey } = crypto.generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+  await expectOidcLoginFailure(
+    provider,
+    "bad-signature",
+    { tokenOptions: { key: wrongPrivateKey } },
+    /signature was invalid/,
+  );
+  await expectOidcLoginFailure(
+    provider,
+    "wrong-jwks-use",
+    { jwks: { keys: [{ ...TEST_OIDC_PUBLIC_JWK, use: "enc" }] } },
+    /public-key policy/,
+  );
+  await expectOidcLoginFailure(
+    provider,
+    "wrong-jwks-curve",
+    { jwks: { keys: [{ ...TEST_OIDC_PUBLIC_JWK, crv: "P-384" }] } },
+    /public-key policy/,
+  );
+  await expectOidcLoginFailure(
+    provider,
+    "duplicate-signing-key",
+    { jwks: { keys: [TEST_OIDC_PUBLIC_JWK, { ...TEST_OIDC_PUBLIC_JWK }] } },
+    /ambiguous signing key/,
+  );
+  await expectOidcLoginFailure(
+    provider,
+    "malformed-id-token",
+    { tokenResponse: { id_token: "not-a-compact-jwt" } },
+    /compact signed JWT/,
+  );
+  await expectOidcLoginFailure(
+    provider,
+    "missing-id-token",
+    { tokenResponse: {} },
+    /did not include an ID token/,
+  );
+}
+
+async function verifyOAuthOptionalJwkHints(provider) {
+  const { use: _use, alg: _alg, ...keyWithoutOptionalHints } = TEST_OIDC_PUBLIC_JWK;
+  let expectedIdToken;
+  const credentials = await provider.oauth.login({
+    onPrompt: async () => "n",
+    onProgress: () => {},
+    onAuth(auth) {
+      const authUrl = new URL(auth.url);
+      expectedIdToken = queueValidOAuthToken("optional-jwk-hints", authUrl);
+      nextJwksDocument = { keys: [keyWithoutOptionalHints] };
+      setTimeout(async () => {
+        const callbackUrl = new URL(authUrl.searchParams.get("redirect_uri"));
+        callbackUrl.searchParams.set("code", "optional-jwk-hints");
+        callbackUrl.searchParams.set("state", authUrl.searchParams.get("state"));
+        await originalFetch(callbackUrl);
+      }, 0);
+    },
+  });
+  assert.strictEqual(credentials.idToken, expectedIdToken, "optional JWK alg/use hints may be omitted when key and signature are valid");
+}
+
+async function verifyOAuthAuthorizationErrorRedaction(provider) {
+  const sentinel = "AUTHORIZATION_ERROR_MUST_NOT_LEAK_\u001b[31m";
+  const before = requests.length;
+  await assert.rejects(
+    provider.oauth.login({
+      onPrompt: async () => "n",
+      onProgress: () => {},
+      onAuth(auth) {
+        const authUrl = new URL(auth.url);
+        setTimeout(async () => {
+          const callbackUrl = new URL(authUrl.searchParams.get("redirect_uri"));
+          callbackUrl.searchParams.set("error", sentinel);
+          callbackUrl.searchParams.set("state", authUrl.searchParams.get("state"));
+          await originalFetch(callbackUrl);
+        }, 0);
+      },
+    }),
+    (error) => {
+      assert.equal(error.message, "xAI authorization failed");
+      assert.doesNotMatch(error.message, /AUTHORIZATION_ERROR_MUST_NOT_LEAK/);
+      return true;
+    },
+  );
+  assert.equal(
+    requests.slice(before).filter((entry) => entry.body?.grant_type === "authorization_code").length,
+    0,
+    "authorization errors must not trigger token exchange",
+  );
+}
+
+async function verifyOAuthTokenErrorRedaction(provider) {
+  const sentinel = "TOKEN_RESPONSE_BODY_MUST_NOT_LEAK";
+  await assert.rejects(
+    provider.oauth.login({
+      onPrompt: async () => "n",
+      onProgress: () => {},
+      onAuth(auth) {
+        const authUrl = new URL(auth.url);
+        queueOAuthTokenResponse("redacted-error", {
+          status: 400,
+          body: { error: "invalid_grant", error_description: sentinel },
+        });
+        setTimeout(async () => {
+          const callbackUrl = new URL(authUrl.searchParams.get("redirect_uri"));
+          callbackUrl.searchParams.set("code", "redacted-error");
+          callbackUrl.searchParams.set("state", authUrl.searchParams.get("state"));
+          await originalFetch(callbackUrl);
+        }, 0);
+      },
+    }),
+    (error) => {
+      assert.match(error.message, /status 400/);
+      assert.doesNotMatch(error.message, new RegExp(sentinel));
+      return true;
+    },
+  );
+}
+
+async function verifyOAuthCancellationAndCleanup(provider) {
+  const preAborted = new AbortController();
+  preAborted.abort();
+  let preAbortedBrowserOpened = false;
+  await assert.rejects(
+    provider.oauth.login({
+      onPrompt: async () => "n",
+      onProgress: () => {},
+      onAuth() {
+        preAbortedBrowserOpened = true;
+      },
+      signal: preAborted.signal,
+    }),
+    /cancelled/,
+  );
+  assert.equal(preAbortedBrowserOpened, false, "pre-aborted login must stop before discovery/browser authorization");
+
+  const discoveryAbort = new AbortController();
+  abortNextOAuthFetch = {
+    url: "https://auth.x.ai/.well-known/openid-configuration",
+    controller: discoveryAbort,
+  };
+  await assert.rejects(
+    provider.oauth.login({
+      onPrompt: async () => "n",
+      onProgress: () => {},
+      onAuth() {
+        throw new Error("browser should not open after discovery cancellation");
+      },
+      signal: discoveryAbort.signal,
+    }),
+    /cancelled/,
+  );
+
+  const callbackWaitAbort = new AbortController();
+  let waitingRedirectUri;
+  await assert.rejects(
+    provider.oauth.login({
+      onPrompt: async () => "n",
+      onProgress: () => {},
+      onAuth(auth) {
+        waitingRedirectUri = new URL(auth.url).searchParams.get("redirect_uri");
+        queueMicrotask(() => callbackWaitAbort.abort());
+      },
+      signal: callbackWaitAbort.signal,
+    }),
+    /cancelled/,
+  );
+  assert.ok(waitingRedirectUri, "callback-wait cancellation test should capture the listener URL");
+  await assert.rejects(originalFetch(waitingRedirectUri), "callback listener must close when login is cancelled while waiting");
+
+  const tokenAbort = new AbortController();
+  await assert.rejects(
+    provider.oauth.login({
+      onPrompt: async () => "n",
+      onProgress: () => {},
+      onAuth(auth) {
+        const authUrl = new URL(auth.url);
+        queueValidOAuthToken("cancel-token", authUrl);
+        abortNextOAuthFetch = { url: "https://auth.x.ai/oauth2/token", controller: tokenAbort };
+        setTimeout(async () => {
+          const callbackUrl = new URL(authUrl.searchParams.get("redirect_uri"));
+          callbackUrl.searchParams.set("code", "cancel-token");
+          callbackUrl.searchParams.set("state", authUrl.searchParams.get("state"));
+          await originalFetch(callbackUrl);
+        }, 0);
+      },
+      signal: tokenAbort.signal,
+    }),
+    /cancelled/,
+  );
+  oauthTokenResponses.delete("cancel-token");
+
+  const jwksAbort = new AbortController();
+  await assert.rejects(
+    provider.oauth.login({
+      onPrompt: async () => "n",
+      onProgress: () => {},
+      onAuth(auth) {
+        const authUrl = new URL(auth.url);
+        queueValidOAuthToken("cancel-jwks", authUrl);
+        abortNextOAuthFetch = { url: "https://auth.x.ai/.well-known/jwks.json", controller: jwksAbort };
+        setTimeout(async () => {
+          const callbackUrl = new URL(authUrl.searchParams.get("redirect_uri"));
+          callbackUrl.searchParams.set("code", "cancel-jwks");
+          callbackUrl.searchParams.set("state", authUrl.searchParams.get("state"));
+          await originalFetch(callbackUrl);
+        }, 0);
+      },
+      signal: jwksAbort.signal,
+    }),
+    /cancelled/,
+  );
+
+  let leakedRedirectUri;
+  await assert.rejects(
+    provider.oauth.login({
+      onPrompt: async () => "n",
+      onProgress: () => {},
+      onAuth(auth) {
+        leakedRedirectUri = new URL(auth.url).searchParams.get("redirect_uri");
+        throw new Error("simulated pi UI callback failure");
+      },
+    }),
+    /simulated pi UI callback failure/,
+  );
+  assert.ok(leakedRedirectUri, "cleanup test should capture the callback listener URL");
+  await assert.rejects(originalFetch(leakedRedirectUri), "callback listener must close when a pi UI callback throws");
 }
 
 async function main() {
@@ -1408,9 +1934,16 @@ async function main() {
 
     await verifyOAuthCallbackState(provider);
     await verifyLegacyOAuthRefresh(provider);
-    await verifyOAuthManualRawCode(provider);
+    await verifyOAuthManualRawCodeRejected(provider);
     await verifyOAuthManualCallbackUrlState(provider);
     await verifyOAuthManualWrongStateIgnored(provider);
+    await verifyOAuthManualMissingStateIgnored(provider);
+    await verifyOAuthDiscoveryPolicy(provider);
+    await verifyOAuthOidcValidation(provider);
+    await verifyOAuthOptionalJwkHints(provider);
+    await verifyOAuthAuthorizationErrorRedaction(provider);
+    await verifyOAuthTokenErrorRedaction(provider);
+    await verifyOAuthCancellationAndCleanup(provider);
 
     await firstLoad.commands.get("xai-tools").handler(
       "enable xai_generate_text",


### PR DESCRIPTION
## Description

Fixes #67.

This removes the unbound `trustedManualCode` path and requires every HTTP or pasted OAuth callback to carry the matching in-memory state before an authorization code can reach token exchange. Raw-code-only input now fails with safe guidance to rerun login and paste the complete redirect URL; the full device-code feature remains scoped to #66.

Fresh browser login now:

- pins the xAI OIDC issuer, authorization endpoint, token endpoint, JWKS endpoint, ES256 signing policy, and S256 PKCE support
- refuses discovery, JWKS, and token redirects
- requires a fresh-login ID token and validates its compact JWS form, ES256/P-256 signing key and signature, issuer, audience/authorized party, expiry, issued-at time, subject, and nonce before credentials are returned
- propagates cancellation through discovery, callback waiting, token exchange, and JWKS retrieval
- closes the callback listener on cancellation and pi UI callback failures
- avoids reflecting authorization error values or token response bodies

Existing Grok CLI credential reuse and refresh remain non-destructive. Refresh preserves a previous refresh token if rotation omits one and does not retain an unvalidated refresh-response ID token.

## Type of change

- [x] Bug fix (security hardening)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## How Has This Been Tested?

- [x] `npm test`
- [x] `npm run typecheck`
- [x] changed-file LSP diagnostics
- [x] `git diff --check`
- [x] `node --unhandled-rejections=strict scripts/verify-extension.js`
- [x] `npm pack --dry-run --json` with required/excluded file assertions

Focused generated-key tests cover wrong/missing state, raw-code rejection/migration, code substitution, pinned discovery/JWKS policy, wrong issuer/audience/authorized party/nonce, expired/malformed tokens, missing claims, unknown/ambiguous/wrong-use/wrong-curve signing keys, wrong algorithm, bad signature, valid exact token retention, refresh fallback/discard behavior, authorization/token error redaction, cancellation at each network phase, and callback-listener cleanup.

No interactive production OAuth login was attempted because safe browser/TUI user interaction was not available through the tool pane. Existing credentials were not read, removed, rewritten, or revoked. Live unauthenticated xAI discovery and JWKS documents were inspected read-only and matched the pinned policy.

## Checklist

- [x] Code follows project style and strict TypeScript
- [x] Self-review completed
- [x] Independent security/correctness/test reviews completed and accepted fixes applied
- [x] Documentation and agent/scaffold security guidance updated
- [x] No new diagnostics or warnings
- [x] Focused regression tests added
- [x] Existing and new tests pass locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication state binding, token endpoint trust, and ID-token validation on the login path; mistakes could break login or weaken CSRF/OIDC checks, though behavior is heavily regression-tested.
> 
> **Overview**
> **Hardens xAI browser OAuth** by removing the unbound `trustedManualCode` path and requiring matching in-memory `state` on every HTTP or pasted callback before any authorization code is exchanged. Raw-code-only manual input now fails with migration guidance toward the full redirect URL (device-code remains out of scope).
> 
> **Adds `extensions/xai/oidc.ts`** to pin first-party OIDC discovery (issuer, authorize/token/JWKS URLs, ES256, S256 PKCE), refuse redirects on discovery/JWKS/token calls, and verify fresh-login ID tokens (JWKS ES256/P-256 signature plus issuer, audience/`azp`, expiry, and nonce) before credentials are returned. Token and authorization errors no longer echo upstream response bodies; login/refresh propagate `AbortSignal` and close the callback listener on cancel or failure.
> 
> **Refresh/reuse stays compatible**: untrusted stored token endpoints are rejected, refresh keeps the prior refresh token when rotation omits one, and unvalidated refresh ID tokens are not retained. Docs, changelog, agent/scaffold guidance, and `verify-extension.js` regressions cover state/substitution, discovery policy, OIDC failures, redaction, and cancellation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ca163b99a866d6928e3875785b012163d419a53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->