### PR TITLE
Fetch and cache the authenticated OAuth model catalog

### DIFF
--- a/.scaffold/constraints.md
+++ b/.scaffold/constraints.md
@@ -1,24 +1,23 @@
 # Constraints & Safety Rules
 
 ## Hard Boundaries (MUST NOT)
-- Never commit, print, log, or include in errors API keys, OAuth codes, access/refresh/ID tokens, PKCE verifiers, state, nonce, or token response bodies.
-- Never delete, revoke, overwrite, or migrate user credentials without explicit user approval.
-- Never modify core pi-coding-agent internals or unrelated extensions/tools.
-- Never implement issue #66's device-code selection/polling feature as part of issue #67.
-- Never accept raw authorization codes or callbacks with missing/mismatched state.
-- Never trust discovery, endpoints, JWT algorithms, or signing keys solely because a hostname ends in `x.ai`.
+- Never commit, cache, print, log, hash for identity, or include in errors API keys, OAuth codes, access/refresh/ID tokens, PKCE verifiers, state, nonce, or token response bodies.
+- Never cache the raw `/models-v2` payload; persist normalized non-secret model definitions only.
+- Never expose known API-key-only models (including `grok-build-0.1`) or entries carrying API-key/env-key/auth-scheme indicators to OAuth users.
+- Never trust catalog-provided endpoints or arbitrary API backends; OAuth models stay on the pinned credential-aware CLI proxy Responses route.
+- Never weaken issue #63 routing, issue #65 scopes/headers, issue #67 OAuth/OIDC state validation, existing compatibility shims, or paid-tool opt-in.
+- Never delete, revoke, overwrite, or migrate user credentials.
 
 ## Required Practices (MUST)
-- Work on `feature/issue-67-oauth-state-oidc` from current merged `main`.
-- Keep PKCE S256, state, nonce, redirect URI, discovery metadata, and callback code bound to one in-memory login transaction.
-- Validate the exact first-party OIDC issuer/endpoints and retained ID-token signature, signing key, issuer, audience, expiry, and nonce before returning fresh credentials.
-- Fail closed without reflecting sensitive upstream token bodies.
-- Preserve existing Grok CLI credential reuse and refresh compatibility.
+- Work on `feature/issue-64-oauth-model-catalog` from merged PRs #70/#71/#72.
+- Treat a successful authenticated catalog as exact entitlement state: additions appear and removals disappear; never merge old entries into a successful refresh.
+- Use bounded startup networking, redirect refusal, defensive JSON limits, atomic cache replacement, and last-known-good writes only after full normalization succeeds.
+- Distinguish authentication/permanent failures from transient network/server failures; do not use stale entitlement cache after 401/403.
+- Preserve a documented small curated fallback and model-specific metadata for known models.
 - Update `.scaffold/progress.md` after significant steps.
-- Run LSP diagnostics, `npm test`, `npm run typecheck`, `git diff --check`, and npm package inspection before delivery.
-- Use independent read-only security/correctness/test review before finalizing; keep one writer in the active worktree.
+- Run LSP diagnostics, tests, typecheck, diff check, package inspection, safe GET-only live smoke, and independent review before delivery.
 
 ## Live-flow Safety
-- Only attempt interactive OAuth when this pane can safely present the browser URL and receive user interaction.
-- Do not print stored credentials or inspect credential contents during live validation.
-- Do not revoke existing grants or remove credential files.
+- Live validation may only GET the official pinned `/models-v2` endpoint with an existing OAuth credential loaded in-process.
+- Never print request headers, credential files, token values, response identity fields, or response bodies on failure.
+- Never invoke Responses, search, image generation, or any other paid tool during the catalog smoke.

--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -27,4 +27,7 @@ Issue #64 requires authenticated OAuth-visible `/models-v2` discovery, exact ent
 Keep OAuth-session Responses routing on `cli-chat-proxy.grok.com`, API-key routing direct and explicit, Images direct, issue #65 proxy metadata/scopes intact, issue #67 state/OIDC hardening intact, and current model-specific payload/reasoning/tool compatibility intact.
 
 ## Validation evidence
-Baseline `npm test` and `npm run typecheck` pass. Safe authenticated GET-only smoke returned HTTP 200 with two OAuth-visible Responses entries and no paid API/tool invocation.
+Final LSP diagnostics, `npm test`, `npm run typecheck`, `git diff --check`, and 43-file npm dry-run package inspection pass. Safe authenticated GET-only smoke through the implemented selector returned two OAuth-visible Responses entries and invoked no paid API/tool. Independent correctness, security/privacy, cache, tests, docs, and package reviews completed; accepted concurrency/cancellation/cache fixes were applied and the final focused review reported `CLEAN`.
+
+## Delivery
+Reviewed implementation commit `70436d2` was pushed on `feature/issue-64-oauth-model-catalog`; unmerged PR #73 targets `main`: https://github.com/BlockedPath/pi-xai-oauth/pull/73

--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -1,38 +1,30 @@
 # Shared Agent Context
 
 **Project:** pi-xai-oauth
-**Branch:** feature/issue-67-oauth-state-oidc
+**Branch:** feature/issue-64-oauth-model-catalog
 **Date:** 2026-07-16
 
-## Issue
-Issue #67 reports that token-shaped manual input is marked `trustedManualCode` and exchanged without OAuth state, while fresh-login ID tokens are stored without signature or claim validation. The fix must bind every authorization completion to its in-memory transaction and validate retained OIDC identity material.
+## Issue contract
+Issue #64 requires authenticated OAuth-visible `/models-v2` discovery, exact entitlement/removal filtering, defensive metadata normalization, explicit refresh/cache/fallback behavior, lifecycle integration, fixture tests, documentation, safe live smoke, and delivery as an unmerged PR.
 
-## First-party and normative contract
-- OIDC trust root: `https://auth.x.ai/.well-known/openid-configuration`.
-- Exact issuer: `https://auth.x.ai`.
-- Exact authorization endpoint: `https://auth.x.ai/oauth2/authorize`.
-- Exact token endpoint: `https://auth.x.ai/oauth2/token`.
-- Exact JWKS endpoint: `https://auth.x.ai/.well-known/jwks.json`.
-- Current ID-token algorithm/key shape: ES256 with public EC P-256 signing JWKs selected by `kid`.
-- Current PKCE method: S256.
-- OIDC Core requires fresh code-flow ID-token validation for exact issuer, client audience, expiry, nonce, and issuer signing key before tokens are accepted.
-- xAI's generic RFC 8414 metadata currently differs from its OIDC metadata; this OIDC client must not merge or fall back between them.
+## Authoritative behavior
+- Official session users fetch `{cli proxy base}/models-v2` with bearer auth, `X-XAI-Token-Auth: xai-grok-cli`, client version, and client mode; official idle refresh uses a 5-second bound and skips BYOK.
+- Official parsing accepts `model`/`modelId`/`id`, name, `apiBackend`, context-window variants, max-completion variants, reasoning capability/default/options, hidden flags, and `_meta` fallbacks.
+- Official catalog guidance says `grok-build-0.1` is API-key-only and excluded from OAuth catalogs.
+- pi awaits async extension factories before startup/session events/provider flush, making that the correct dynamic-model hook. Provider re-registration after startup is immediate. `/reload` recreates the extension runtime.
 
-## Scope decisions
-- Raw authorization codes are rejected because they carry no state. Users must paste the complete redirect URL containing matching `code` and `state`.
-- Device authorization is not implemented here; issue #66 owns method selection, device endpoint requests, polling, expiry, cancellation, and remote/headless UX.
-- Existing `~/.grok/auth.json` reuse and refresh remain compatible. Existing credentials are not deleted, revoked, or retroactively treated as fresh OIDC responses.
-- Fresh login requires and validates an ID token before credentials are returned. Refresh responses do not retain a new ID token unless a future design supplies the original validated identity context required by OIDC refresh rules.
-- Token endpoint response bodies, authorization codes, tokens, verifiers, state, and nonce must never be logged or included in errors.
+## Planned policy
+- Cache path: pi agent cache directory, `cache/pi-xai-oauth/models-v2.json`.
+- Fresh TTL: 15 minutes (startup uses cache without network).
+- Stale refresh: one redirect-refusing authenticated GET bounded to the official client's 5 seconds.
+- Stale-if-transient: normalized LKG up to 7 days for network/timeout/429/5xx/invalid-success failures.
+- Auth/permanent failure or unusable/no cache: the documented `grok-4.5`-only curated fallback; 401/403 never reuse stale entitlements.
+- Successful login always forces refresh, forbids stale reuse on every failure, invalidates the old account cache if refresh fails, and immediately re-registers models.
+- Expired pi-owned credentials are never refreshed in the extension factory; normal-session startup resolves them through pi's lock-protected model registry before catalog refresh.
+- Successful remote refresh replaces rather than merges, so account-specific additions/removals take effect.
 
-## Test strategy
-Use generated ES256/P-256 test keys and local JWT fixtures. Exercise HTTP and pasted callbacks, token-request capture, cancellation/listener cleanup, discovery/JWKS policy, signature/key failures, issuer/audience/nonce/expiry failures, refresh fallback/unvalidated-ID-token discard, and exact valid ID-token retention. No test uses production keys or credentials.
+## Preservation boundaries
+Keep OAuth-session Responses routing on `cli-chat-proxy.grok.com`, API-key routing direct and explicit, Images direct, issue #65 proxy metadata/scopes intact, issue #67 state/OIDC hardening intact, and current model-specific payload/reasoning/tool compatibility intact.
 
-## Validation state
-- LSP diagnostics, `npm test`, strict-unhandled focused verification, `npm run typecheck`, and `git diff --check` pass.
-- Dry-run package inspection includes `extensions/xai/oidc.ts` and excludes scaffold, subagent, credential, key, and local artifacts.
-- Two independent review rounds completed; accepted findings were fixed and the final security review reported no blockers.
-- Live interactive OAuth was not attempted because browser/TUI interaction is not safely available through this tool pane. Existing credentials were not read, removed, rewritten, or revoked.
-
-## Delivery
-The reviewed implementation was committed as `3721691`, pushed on `feature/issue-67-oauth-state-oidc`, and opened against `main` as unmerged PR #72: https://github.com/BlockedPath/pi-xai-oauth/pull/72
+## Validation evidence
+Baseline `npm test` and `npm run typecheck` pass. Safe authenticated GET-only smoke returned HTTP 200 with two OAuth-visible Responses entries and no paid API/tool invocation.

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -32,6 +32,6 @@ Replace the release-bound OAuth model advertisement with an authenticated, entit
 - [x] Independent correctness, security, cache, and test reviews complete; accepted fixes are applied and revalidated.
 
 ## Delivery
-- [ ] Commit reviewed work.
-- [ ] Push `feature/issue-64-oauth-model-catalog`.
-- [ ] Open an unmerged PR against `main` that closes #64.
+- [x] Committed reviewed implementation as `70436d2`.
+- [x] Pushed `feature/issue-64-oauth-model-catalog`.
+- [x] Opened unmerged PR #73 against `main`, closing #64: https://github.com/BlockedPath/pi-xai-oauth/pull/73

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,36 +1,37 @@
-# Implementation Plan: Issue #67 OAuth state and OIDC validation
+# Implementation Plan: Issue #64 authenticated OAuth model catalog
 
-**Branch:** feature/issue-67-oauth-state-oidc
+**Branch:** feature/issue-64-oauth-model-catalog
 **Date:** 2026-07-16
 
 ## Goal
-Remove the unbound raw authorization-code fallback and make fresh xAI browser OAuth completion fail closed on transaction state plus validated first-party OIDC identity metadata.
+Replace the release-bound OAuth model advertisement with an authenticated, entitlement-aware `/models-v2` catalog while preserving a small safe fallback, bounded startup, existing routing/header/OIDC behavior, and model-specific compatibility.
 
 ## Implementation
-- [x] Remove `trustedManualCode` and reject raw-code-only manual input with a safe migration message.
-- [x] Require the expected state on every HTTP or pasted callback before token exchange.
-- [x] Pin and validate xAI OIDC issuer, authorization endpoint, token endpoint, JWKS endpoint, ES256, and S256 metadata.
-- [x] Validate fresh-login ID tokens before retaining credentials: compact JWS shape, ES256 signature, matching P-256 signing key, issuer, audience/authorized party, expiry, required claims, and nonce.
-- [x] Preserve existing Grok CLI credential reuse and refresh compatibility without retaining unvalidated refresh ID tokens.
-- [x] Stop reflecting authorization/token endpoint response data in errors.
-- [x] Add focused wrong/missing-state, raw-code migration, code-substitution, cancellation/cleanup, discovery/JWKS, ID-token failure, and valid-completion tests.
-- [x] Update README, CHANGELOG, AGENTS.md, and scaffold security guidance.
+- [x] Add a focused catalog module with defensive `/models-v2` normalization, pinned Responses-backend handling, hidden/API-key-only rejection, and exact replacement semantics for additions/removals.
+- [x] Add an atomic token-free last-known-good cache under pi's user cache directory.
+- [x] Use a 15-minute fresh TTL, an official-aligned bounded 5-second stale refresh, a 7-day stale-if-transient window, durable invalidation for auth/permanent failures, and forced no-stale refresh after successful login.
+- [x] Make the extension factory async so the selected catalog is registered before startup and `--list-models`; re-register immediately after login so `/model` sees new entitlements without `/reload`.
+- [x] Defer expired pi-owned token refresh to `session_start` through the bound model registry/credential lock.
+- [x] Keep direct helper metadata synchronized with the active catalog while preserving Grok 4.5, Build, Composer, 4.20, routing, headers/scopes, payload, and OIDC compatibility logic.
+- [x] Add fixture-based tests for additions, removals, malformed entries, duplicate/API-key-only/unsupported-backend filtering, reasoning metadata, fresh/stale cache, auth/network failures, and fallback choice.
+- [x] Update README, CHANGELOG, AGENTS.md, and scaffold state with refresh/login/reload/model-selection and cache policy.
 
 ## Non-goals
-- Do not implement device authorization; full device-code UX, polling, and cancellation remain tracked by issue #66.
-- Do not revoke, delete, migrate, or rewrite existing user credentials.
-- Do not change model routing, scopes, tools, payloads, or xAI API behavior outside issue #67.
+- Do not add API-key auth or expose API-key-only models.
+- Do not alter issue #63 credential-aware Responses/Images routing, issue #65 scopes/proxy headers, issue #67 OAuth state/OIDC validation, or issue #66 device login.
+- Do not call paid generation/search/image tools during validation.
+- Do not persist or log access/refresh/ID tokens or raw catalog payloads.
 
 ## Validation Contract
-- [x] LSP diagnostics pass for changed TypeScript files.
+- [x] Changed-file LSP diagnostics pass.
 - [x] `npm test` passes.
 - [x] `npm run typecheck` passes.
 - [x] `git diff --check` passes.
-- [x] `npm pack --dry-run --json` contains intended runtime/docs files and no local artifacts or credentials.
-- [x] Independent security, correctness, and test reviews complete; accepted fixes are applied and revalidated.
-- [x] Live OAuth was not attempted because this tool pane cannot safely hand browser/TUI interaction to the user; existing credentials were not read, removed, rewritten, or revoked.
+- [x] `npm pack --dry-run --json` contains required runtime/fixtures/docs and excludes credentials/cache/scaffold/subagent artifacts.
+- [x] Safe authenticated GET-only `/models-v2` smoke succeeds when credentials are available without printing credentials.
+- [x] Independent correctness, security, cache, and test reviews complete; accepted fixes are applied and revalidated.
 
 ## Delivery
-- [x] Committed the reviewed implementation as `3721691`.
-- [x] Pushed `feature/issue-67-oauth-state-oidc`.
-- [x] Opened PR #72 against `main` without merging it: https://github.com/BlockedPath/pi-xai-oauth/pull/72
+- [ ] Commit reviewed work.
+- [ ] Push `feature/issue-64-oauth-model-catalog`.
+- [ ] Open an unmerged PR against `main` that closes #64.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -46,5 +46,10 @@
 
 - [x] Final focused race-condition re-review reproduced the prior commit-window issue, accepted the queued conditional rollback fix, reran the deterministic probe, and reported `CLEAN`.
 
+## Delivery
+- [x] Committed the reviewed implementation as `70436d2`.
+- [x] Pushed `feature/issue-64-oauth-model-catalog` to `origin`.
+- [x] Opened PR #73 against `main` without merging: https://github.com/BlockedPath/pi-xai-oauth/pull/73
+
 ## Next
-Commit, push, and open an unmerged PR.
+Leave PR #73 unmerged for external review.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,39 +1,50 @@
 # Execution Progress
 
-**Project:** pi-xai-oauth Issue #67 OAuth state and OIDC validation
-**Branch:** feature/issue-67-oauth-state-oidc
+**Project:** pi-xai-oauth Issue #64 authenticated OAuth model catalog
+**Branch:** feature/issue-64-oauth-model-catalog
 **Started:** 2026-07-16
 
 ## Research and Baseline
-- [x] Started from clean current `main` after merged PRs #70 and #71.
-- [x] Created `feature/issue-67-oauth-state-oidc` before editing.
-- [x] Read AGENTS.md, issues #67 and #66, provider entrypoint, setup, all OAuth discovery/login/callback/token/reuse code, and current OAuth tests.
-- [x] Read current pi provider/OAuth APIs, types, interactive manual-input behavior, extension docs, and provider examples.
-- [x] Read authoritative OIDC Core/Discovery, OAuth metadata/PKCE/security guidance, and live first-party xAI OIDC discovery/JWKS behavior.
-- [x] Confirmed xAI OIDC metadata currently pins issuer `https://auth.x.ai`, `/oauth2/authorize`, `/oauth2/token`, `/.well-known/jwks.json`, ES256, and S256.
-- [x] Confirmed baseline LSP diagnostics, `npm test`, and `npm run typecheck` pass.
+- [x] Updated clean `main` through merged PRs #70/#71/#72 and created the requested feature branch before editing.
+- [x] Read AGENTS.md, complete issue #64 (no comments), PR #70/#71/#72 summaries, provider/setup/model/auth/routing/OAuth/OIDC/payload/Responses/tool code, current tests, README, changelog, and scaffold state.
+- [x] Read pi's complete custom-provider, models, providers, SDK/model-registry, and extensions docs plus complete custom-provider/OAuth/model selection/reload examples.
+- [x] Read the pinned official Grok Build `/models-v2` refresh/parser and API-key-only catalog sources at commit `b189869...`.
+- [x] Confirmed baseline changed-file diagnostics, `npm test`, and `npm run typecheck` pass (test script retains only pre-existing CommonJS/jiti hints).
+- [x] Performed a safe GET-only authenticated live `/models-v2` smoke: HTTP 200, two OAuth-visible Responses models, no token/header/body logging and no paid tool invocation.
+
+## Current Findings
+- The live authenticated catalog currently exposes `grok-4.5` and `grok-composer-2.5-fast` for this account; the response supplies backend/context/reasoning metadata but currently omits max-completion tokens.
+- pi requires dynamic model discovery in an async extension factory so models exist at startup and `--list-models`; post-start `registerProvider` calls apply immediately.
+- Successful login can force-refresh and immediately re-register the provider; `/reload` reruns the async factory and respects the explicit cache TTL.
+- The cache must store normalized model definitions only and must not reuse stale entitlements after 401/403.
 
 ## Implementation
-- [x] Removed `trustedManualCode`; raw-code-only input now fails with full-redirect-URL migration guidance and issue #66 remains separate.
-- [x] Required matching state for HTTP and pasted callbacks before any authorization-code exchange.
-- [x] Added exact first-party issuer/authorization/token/JWKS policy plus ES256/S256 discovery validation.
-- [x] Added generated-key ES256 ID-token verification for signing key, signature, issuer, audience/authorized party, expiry, issued-at, subject, and nonce before credential retention.
-- [x] Preserved Grok CLI credential reuse and refresh responses without retaining unvalidated refresh ID tokens.
-- [x] Removed token response body reflection from errors.
-- [x] Added focused state, raw-code, code-substitution, discovery/JWKS, claims, unknown-key, bad-signature, valid-completion, and redaction tests.
-- [x] Updated README, CHANGELOG, AGENTS.md, and scaffold security guidance.
+- [x] Completed independent research and planning review; accepted forced-login no-stale behavior, durable invalidation, exact empty-catalog replacement, a 5-second official-aligned bound, and lock-safe expired-token handling.
+- [x] Added defensive normalization for official aliases, Responses-only routing, hidden/API-key-only/malformed filtering, known metadata enrichment, conservative unknown defaults, reasoning capability, and supplied levels.
+- [x] Added an atomic 0600 token-free normalized cache with 15-minute freshness, 7-day stale-if-transient behavior, and auth/permanent/forced-failure tombstones.
+- [x] Made provider startup async, added exact unregister/register replacement, forced post-login refresh, deferred lock-protected session refresh, and removed-active-model fail-safe handling.
+- [x] Added fixture-based catalog/cache/failure tests and updated the extension harness for async load and login/empty-catalog replacement.
+- [x] Updated README, CHANGELOG, AGENTS.md, and scaffold policy documentation.
+
+## Review Fixes
+- [x] Completed four independent correctness, security/privacy, cache/normalization, and regression/docs/package reviews.
+- [x] Prevented cross-account refresh coalescing and aborts superseded requests so an older completion cannot overwrite provider state or cache.
+- [x] Bypassed fresh cache after logout/no credentials and when the credential file changed after the cache; preserved lock-refresh intent across fresh cache and retryable lookup failures.
+- [x] Added caller-cancellation handling that leaves cache/provider state untouched.
+- [x] Added pre-input model reconciliation plus transport/direct-helper entitlement guards; additional helpers default to the active entitled model.
+- [x] Fixed `none` reasoning mapping, capability-without-level defaults, known-output/context clamping, mixed malformed filtering, cache-write invalidation, and permissive cache permissions.
+- [x] Added overlap, removed-model, no-replacement, logout/fresh-cache, credential-change, cancellation, oversized-response, permissions, reasoning, and limit regressions.
+- [x] Documented pi's empty-catalog + disk-defined `xai-auth` model limitation; transport remains fail-closed before network.
 
 ## Validation
-- [x] Changed-file LSP diagnostics pass for `oauth.ts`, `oidc.ts`, and `constants.ts`.
-- [x] `npm test`, strict-unhandled focused verification, and `npm run typecheck` pass.
-- [x] `git diff --check` and npm dry-run package assertions pass; `oidc.ts` is included and scaffold/subagent/credential/key artifacts are excluded.
-- [x] Independent security/correctness/test review completed. Accepted fixes added cancellation propagation, callback-listener cleanup, authorization-error redaction, raw-code retry guidance, optional JWK-hint compatibility, exact valid-token retention checks, refresh fallback/discard checks, and broader negative coverage.
-- [x] Final re-review found no source/package blockers; the requested callback-wait cancellation regression was added and passes.
-- [x] Post-PR Codex feedback was rechecked and addressed: multi-audience ID tokens now require client membership plus this client as `azp`; positive and missing-`azp` regressions pass.
-- [x] Live OAuth was not attempted because this tool pane cannot safely transfer browser/TUI interaction to the user. Existing credentials were never read, removed, rewritten, or revoked.
+- [x] Changed TypeScript files have zero LSP errors/warnings; JS verifiers retain only pre-existing CommonJS/jiti hints.
+- [x] `npm test` passes (`verify-catalog`, `verify-extension`, `verify-setup`).
+- [x] `npm run typecheck` passes.
+- [x] `git diff --check` passes.
+- [x] `npm pack --dry-run --json` includes 43 intended files including `catalog.ts` and fixtures; no scaffold, subagent, credential, session, or cache artifacts.
+- [x] Safe live authenticated GET-only smoke through the implemented selector succeeded with source `remote`, two models, and no paid tool invocation or credential/header logging.
 
-## Delivery
-- [x] Committed the reviewed implementation as `3721691`.
-- [x] Pushed `feature/issue-67-oauth-state-oidc` to `origin`.
-- [x] Opened PR #72 against `main`: https://github.com/BlockedPath/pi-xai-oauth/pull/72
-- [x] Left the PR unmerged for external review.
+- [x] Final focused race-condition re-review reproduced the prior commit-window issue, accepted the queued conditional rollback fix, reran the deterministic probe, and reported `CLEAN`.
+
+## Next
+Commit, push, and open an unmerged PR.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -55,6 +55,7 @@
 - [x] A second PR recheck found five additional Cursor findings; fixed failed-commit stale-cache refusal, expired-pi/fresh-Grok startup fallback, non-abort login fallback application, login/deferred refresh priority, and runtime-entitlement event gating.
 - [x] Added expired-pi/fresh-Grok, Grok-backed deferred-intent, disk-defined-unentitled, invalidation-sidecar, and credential-lookup/login-priority regressions; re-ran focused validation.
 - [x] Independent fault-injection/concurrency re-review verified all second-round fixes and reported `CLEAN — no blockers found`.
+- [x] A third PR recheck found one reasoning-denial issue; explicit `supportsReasoningEffort: false` now overrides known reasoning metadata and ignores supplied effort levels, with a focused regression.
 
 ## Delivery
 - [x] Committed the reviewed implementation as `70436d2`.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -46,6 +46,13 @@
 
 - [x] Final focused race-condition re-review reproduced the prior commit-window issue, accepted the queued conditional rollback fix, reran the deterministic probe, and reported `CLEAN`.
 
+## Post-PR Recheck
+- [x] Re-read PR #73 status, automated reviews, inline comments, and checks after the user requested another check.
+- [x] Accepted and fixed active-catalog credential lookup when Grok 4.5 is absent, empty/malformed reasoning-level defaults, lock-refreshed deferred entitlement validation, case-insensitive runtime reasoning lookup, and transient retry retention/backoff.
+- [x] Added focused regressions for Composer-only credential lookup, empty/malformed reasoning lists, mixed-case runtime IDs, fresh-cache deferred refresh, and retryable transient failures.
+- [x] Re-ran focused catalog/extension tests, full `npm test`, typecheck, diff check, package inspection, and LSP diagnostics successfully.
+- [x] Independent post-feedback review caught and fixed a superseded retry-deadline race; focused re-review reported `CLEAN`.
+
 ## Delivery
 - [x] Committed the reviewed implementation as `70436d2`.
 - [x] Pushed `feature/issue-64-oauth-model-catalog` to `origin`.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -52,6 +52,9 @@
 - [x] Added focused regressions for Composer-only credential lookup, empty/malformed reasoning lists, mixed-case runtime IDs, fresh-cache deferred refresh, and retryable transient failures.
 - [x] Re-ran focused catalog/extension tests, full `npm test`, typecheck, diff check, package inspection, and LSP diagnostics successfully.
 - [x] Independent post-feedback review caught and fixed a superseded retry-deadline race; focused re-review reported `CLEAN`.
+- [x] A second PR recheck found five additional Cursor findings; fixed failed-commit stale-cache refusal, expired-pi/fresh-Grok startup fallback, non-abort login fallback application, login/deferred refresh priority, and runtime-entitlement event gating.
+- [x] Added expired-pi/fresh-Grok, Grok-backed deferred-intent, disk-defined-unentitled, invalidation-sidecar, and credential-lookup/login-priority regressions; re-ran focused validation.
+- [x] Independent fault-injection/concurrency re-review verified all second-round fixes and reported `CLEAN — no blockers found`.
 
 ## Delivery
 - [x] Committed the reviewed implementation as `70436d2`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,15 +3,15 @@
 > **For AI coding agents only.** Keep this file machine-readable and concise. Human-facing docs live in README.md.
 
 ## Project Overview
-pi-xai-oauth is a pi-package that registers the xAI OAuth provider ("xai-auth") and Grok models (including grok-4.5 and grok-4.3 with reasoning) for the pi coding agent framework.
+pi-xai-oauth is a pi-package that registers the xAI OAuth provider (`xai-auth`) and the authenticated account's OAuth-visible Grok model catalog for the pi coding agent framework, with Grok 4.5 as the curated offline fallback.
 
-Core flow: `bin/setup.js` → `pi install` → provider registration in `extensions/xai-oauth.ts` → OAuth PKCE transaction in `extensions/xai/oauth.ts` → pinned OIDC/JWKS validation in `extensions/xai/oidc.ts` → streaming via xAI API helpers in `extensions/xai/responses.ts`.
+Core flow: `bin/setup.js` → `pi install` → bounded catalog selection in `extensions/xai/catalog.ts` → provider registration in `extensions/xai-oauth.ts` → OAuth PKCE transaction in `extensions/xai/oauth.ts` → pinned OIDC/JWKS validation in `extensions/xai/oidc.ts` → streaming via xAI API helpers in `extensions/xai/responses.ts`.
 
 ## Key Commands (Exact, Copy-Paste Ready)
 - Install / setup: `node bin/setup.js` or `npm run setup` (if added)
 - Install as pi extension: `pi install npm:pi-xai-oauth`
 - Run TypeScript: `npx tsc --noEmit` (validate)
-- Git: Always work on feature branches. Current branch for this work: `feature/issue-67-oauth-state-oidc`
+- Git: Always work on feature branches. Current branch for this work: `feature/issue-64-oauth-model-catalog`
 
 ## Architecture & Boundaries (MUST / MUST NOT)
 **MUST:**
@@ -21,13 +21,18 @@ Core flow: `bin/setup.js` → `pi install` → provider registration in `extensi
 - Validate retained fresh-login ID tokens against pinned first-party discovery/JWKS, ES256, issuer, audience, expiry, and nonce
 - Support reasoning levels: none / low / medium / high
 - Reuse `~/.grok/auth.json` when possible without deleting or revoking it
-- Keep models list in sync with xAI releases
+- Fetch OAuth-visible models only from the pinned authenticated CLI proxy `/models-v2` endpoint
+- Treat successful catalog responses as exact entitlement state; additions appear and removals disappear
+- Keep the normalized token-free catalog cache atomic and apply the documented TTL/stale/fallback policy
+- Preserve known model metadata and compatibility behavior without advertising models absent from the authenticated catalog
 
 **MUST NOT:**
 - Hardcode API keys (use OAuth only)
 - Accept raw authorization codes or callbacks with missing/mismatched state
 - Trust arbitrary `*.x.ai` discovery, token, or JWKS endpoints
-- Log or reflect authorization codes, tokens, PKCE verifiers, state, nonce, or token response bodies
+- Log or reflect authorization codes, tokens, PKCE verifiers, state, nonce, token response bodies, or authenticated request headers
+- Cache raw `/models-v2` responses, credentials, identity fields, endpoint URLs, or known API-key-only models
+- Trust catalog-provided endpoints or route non-Responses models through the OAuth provider
 - Delete or revoke existing user credentials during validation
 - Modify core pi-coding-agent internals
 - Touch unrelated extensions or skills
@@ -41,8 +46,9 @@ pi-xai-oauth/
 ├── extensions/
 │   ├── xai-oauth.ts      # Thin entrypoint: provider registration + tool orchestration
 │   └── xai/              # Focused implementation modules
-│       ├── constants.ts  # URLs, defaults, OAuth constants
-│       ├── models.ts     # Model catalog + model compatibility helpers
+│       ├── catalog.ts    # Authenticated catalog normalization + atomic token-free cache
+│       ├── constants.ts  # URLs, defaults, OAuth/catalog constants
+│       ├── models.ts     # Curated fallback/known metadata + compatibility helpers
 │       ├── oauth.ts      # OAuth login/refresh/callback transaction helpers
 │       ├── oidc.ts       # Pinned discovery/JWKS + ID-token validation
 │       ├── auth.ts       # Credential reuse + token resolution helpers
@@ -74,7 +80,9 @@ Start any task by reading:
 - Add JSDoc for all exported functions
 - Keep OAuth callback server minimal and secure
 - Treat raw-code/device-code migration as separate from issue #66's full device authorization implementation
-- Never log OAuth codes, tokens, token response bodies, verifiers, state, or nonce
+- Never log OAuth codes, tokens, token response bodies, verifiers, state, nonce, catalog request headers, or raw authenticated catalog bodies
+- Reject malformed, hidden, unsupported-backend, secret-bearing, and known API-key-only catalog entries
+- Keep startup catalog network behavior bounded and use pi's credential lock for expired stored-token refresh
 
 ## Safety Gates
 - Before any file edit: run `git status` and confirm on correct branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,20 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 
 ## Unreleased
 
+### Added
+
+- Added authenticated OAuth-visible model discovery from the official CLI proxy `/models-v2` endpoint.
+- Added defensive model normalization plus an atomic, token-free last-known-good cache with a 15-minute fresh TTL, a 5-second bounded refresh, and a 7-day stale-if-transient window.
+- Added fixture-based coverage for catalog additions, removals, empty entitlements, malformed entries, API-key-only filtering, cache freshness, auth/network failures, and curated fallback selection.
+
 ### Changed
 
 - Centralized xAI endpoint selection around explicit OAuth-session versus API-key credential provenance instead of model IDs.
 - Kept Grok Build and Composer payload, header, and tool compatibility separate from transport routing.
 - Updated fresh OAuth logins to request xAI's current eight-scope Grok client grant, including conversation read/write access, while leaving existing refresh grants compatible.
 - Derived the proxy client identifier and version from this package's own metadata instead of impersonating a stale Grok CLI release.
+- Made the authenticated account catalog authoritative for OAuth model additions and removals; known static metadata now enriches returned IDs without advertising unreturned models.
+- Made successful login force-refresh and immediately replace the model catalog, while `/reload` follows the documented cache TTL.
 
 ### Fixed
 
@@ -21,6 +29,8 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 - Routed normal streaming and separate Responses helpers for every `xai-auth` model through the official Grok CLI session-token proxy, matching the intended OAuth/session-token transport contract for Responses traffic.
 - Preserved the official direct `api.x.ai` Images endpoint for OAuth-backed image generation while keeping a future explicit API-key Responses route on the public API.
 - Added the complete CLI-proxy authentication, client-mode, request, conversation, session, and model metadata to every OAuth Responses request, with required values protected from caller overrides.
+- Filtered hidden, malformed, unsupported-backend, secret-bearing, and known API-key-only entries such as `grok-build-0.1` from the OAuth provider catalog.
+- Invalidated stale entitlement data after authentication/permanent failures and prevented a forced post-login refresh from reusing another account's stale cache.
 
 ## 1.3.5 - 2026-07-15
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pi --model grok-4.5:high "Review this architecture for failure modes"
 pi --model grok-4.5:low "Quick status check"   # fast mode
 ```
 
-This package adds **Grok 4.5** (default), **Grok 4.3**, **Grok Build**, and **Composer 2.5** as fully-integrated xAI OAuth models in pi, with proper OAuth login, automatic token refresh, and a suite of custom tools (`xai_generate_text`, `xai_web_search`, `xai_x_search`, etc.).
+This package adds xAI's **account-specific OAuth model catalog** to pi, with **Grok 4.5** as the offline fallback/default, proper OAuth login, automatic token refresh, and a suite of custom tools (`xai_generate_text`, `xai_web_search`, `xai_x_search`, etc.). Models such as Grok Build, Composer, Grok 4.3, and Grok 4.20 appear only when xAI returns them for the authenticated account.
 
 > **Latest release:** `pi-xai-oauth` **1.3.5** keeps the highlighted `/xai-tools` row in place after toggling, so multiple tools can be configured without repeatedly navigating from the top. Version 1.3.4 made every network-backed xAI helper an explicit, session-scoped opt-in through `/xai-tools`, including paid image generation, and made disabled tools fail before OAuth credential lookup or network access. Existing npm installs should run `pi update npm:pi-xai-oauth`; local checkout installs should keep only one copy with `pi remove npm:pi-xai-oauth && pi install .`.
 >
@@ -73,9 +73,11 @@ See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and
 - **Reuses existing credentials** — auto-detects `~/.grok/auth.json` from the official Grok CLI
 - **Grok 4.5 flagship (default)** — xAI's newest model for coding, agentic tasks, and knowledge work; 500K context, text+image input, high reasoning by default
 - **Grok 4.5 fast mode** — same model with `low` reasoning effort (`/think low` or `grok-4.5:low`); not a separate model ID
-- **Long-context option** — Grok 4.3 still available with a full 1M context window
-- **Coding models** — Grok Build and Composer 2.5 Fast are available from the same `xai-auth` provider
-- **Reasoning support** — configurable thinking levels: `low` / `medium` / `high`
+- **Long-context metadata when entitled** — known Grok 4.3 behavior is preserved when xAI returns it, with authenticated limits taking precedence
+- **Authenticated model catalog** — fetches the OAuth-visible `/models-v2` list from the official CLI proxy, so additions and removals track the signed-in account
+- **Coding models when entitled** — Grok Build, Composer, and other models appear only when xAI includes them in the account catalog
+- **Reasoning support** — parses supplied reasoning capability and thinking levels while preserving known model compatibility
+- **Bounded last-known-good cache** — avoids routine startup delay and falls back safely when discovery is offline or unavailable
 - **Custom xAI tools** — generate text, web search, X/Twitter search, multi-agent research, code analysis
 - **Credential-aware Responses routing** — OAuth/session traffic uses the official `https://cli-chat-proxy.grok.com/v1` endpoint for every Grok model; the public `api.x.ai` Responses endpoint is reserved for a future explicit API-key path
 
@@ -94,8 +96,9 @@ See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and
 5. pi verifies that the callback state matches the in-memory login attempt before exchanging the authorization code
 6. The returned ID token is verified against xAI's pinned OIDC issuer and first-party JWKS for ES256 signature, signing key, audience, expiry, and nonce
 7. Only then are access + refresh credentials persisted and refreshed automatically
-8. All OAuth-backed Responses traffic—normal streaming and separate Responses helpers—uses xAI's session-token proxy (`https://cli-chat-proxy.grok.com/v1`) rather than the public Responses endpoint on `https://api.x.ai/v1`
-9. Proxy requests identify this client as `pi-xai-oauth` at the installed package version and include xAI's required auth, client-mode, request, conversation, session, and model metadata
+8. The extension performs a bounded authenticated `GET https://cli-chat-proxy.grok.com/v1/models-v2`, normalizes the OAuth-visible entries, filters unsafe/API-key-only entries, and immediately replaces the provider catalog
+9. All OAuth-backed Responses traffic—normal streaming and separate Responses helpers—uses xAI's session-token proxy (`https://cli-chat-proxy.grok.com/v1`) rather than the public Responses endpoint on `https://api.x.ai/v1`
+10. Proxy requests identify this client as `pi-xai-oauth` at the installed package version and include xAI's required auth, client-mode, request, conversation, session, and model metadata
 
 If localhost callbacks are blocked (VPN, Docker, remote dev), the TUI shows a text field where you can paste the **complete redirect URL** manually. The URL must contain the matching OAuth `state`; raw authorization codes are not accepted.
 
@@ -220,17 +223,21 @@ pi --model grok-4.5 "Write a poem about Rust"
 
 ### Switching Models
 
+`/model` shows the current authenticated account's xAI catalog. A successful refresh is authoritative: newly returned models appear, removed models disappear, hidden entries are omitted, and known API-key-only models such as `grok-build-0.1` are never advertised through `xai-auth`.
+
+Common catalog entries include:
+
 | Model ID | Description |
 |----------|-------------|
-| `grok-4.5` | **Default.** xAI flagship for coding, agentic tasks, and knowledge work; reasoning low (**fast**) / medium / high (default), 500K context, text+image. |
-| `grok-4.3` | Full reasoning, 1M context. |
-| `grok-build` | Grok Build coding model with Cursor/Grok CLI tool compatibility, 512K context. |
-| `grok-composer-2.5-fast` | Composer 2.5 Fast coding model with Cursor/Grok CLI tool compatibility, 200K context. |
-| `grok-4.20-0309-reasoning` | Grok 4.20 with automatic reasoning, 2M context. |
-| `grok-4.20-0309-non-reasoning` | Grok 4.20 fast responses, 2M context. |
-| `grok-4.20-multi-agent-0309` | Grok 4.20 multi-agent research model, 2M context. |
+| `grok-4.5` | **Default and curated offline fallback.** xAI flagship; reasoning low (**fast**) / medium / high (default), 500K context, text+image. |
+| `grok-4.3` | When entitled: full reasoning, with limits taken from the authenticated catalog. |
+| `grok-build` | When entitled: Grok Build coding model with Cursor/Grok CLI tool compatibility. |
+| `grok-composer-2.5-fast` | When entitled: Composer coding model with Cursor/Grok CLI tool compatibility. |
+| `grok-4.20-0309-reasoning` | When entitled: Grok 4.20 with automatic reasoning. |
+| `grok-4.20-0309-non-reasoning` | When entitled: Grok 4.20 non-reasoning variant. |
+| `grok-4.20-multi-agent-0309` | When entitled: Grok 4.20 multi-agent research model. |
 
-From the pi TUI:
+The exact list is account-specific and can change independently of package releases. From the pi TUI:
 
 ```
 /model grok-4.5
@@ -251,9 +258,27 @@ pi --model grok-composer-2.5-fast "Refactor this module"
 pi --model grok-4.20-0309-non-reasoning "Quick answer"
 ```
 
+### Catalog refresh and cache policy
+
+The normalized, token-free last-known-good catalog is stored at:
+
+```text
+~/.pi/agent/cache/pi-xai-oauth/models-v2.json
+```
+
+- **Fresh for 15 minutes:** with a usable OAuth credential (or an expired stored credential awaiting pi's lock-protected refresh), startup and `/reload` use the cache immediately and do not make a catalog request. Logged-out startup uses the curated fallback instead of exposing the previous account's cache.
+- **Stale refresh:** after 15 minutes, startup performs one authenticated GET bounded to 5 seconds.
+- **Transient fallback:** network errors, timeouts, HTTP 408/429/5xx, or a malformed successful response may reuse a validated cache no older than 7 days.
+- **Auth/permanent failure:** HTTP 401/403 or other permanent 4xx responses invalidate cached entitlements and use the curated `grok-4.5` fallback.
+- **Login:** every successful `/login xai-auth` forces a refresh with the newly returned credential, never reuses stale data, and updates `/model` immediately. If that refresh fails, login still succeeds and the curated fallback is used.
+- **`/reload`:** recreates the extension and follows the same 15-minute policy; it is not an unconditional network refresh.
+- **Selection:** if a refresh removes the active xAI model, the next turn switches to an entitled xAI replacement when available; otherwise it aborts before sending an unentitled request.
+
+The cache stores only normalized model definitions and timestamps. It never stores access/refresh/ID tokens, auth headers, raw endpoint responses, or account identity fields. Startup does not expose a previous account's fresh cache when no credential exists, and a credential-file modification newer than the cache forces discovery. A token-free cache still cannot distinguish an external account replacement that deliberately preserves the credential file's timestamp; in-product login always bypasses and replaces the cache.
+
 ### Reasoning / Thinking Levels
 
-Grok 4.5 and Grok 4.3 support configurable thinking levels via pi's `/think` command or `model:effort` syntax. There is **no separate `grok-4.5-fast` model** — on Grok 4.5, “fast mode” is **`reasoning_effort: "low"`** on the same model ID.
+Grok 4.5, and Grok 4.3 when returned with reasoning support, expose configurable thinking levels via pi's `/think` command or `model:effort` syntax. There is **no separate `grok-4.5-fast` model** — on Grok 4.5, “fast mode” is **`reasoning_effort: "low"`** on the same model ID.
 
 ```
 /think high
@@ -275,7 +300,7 @@ pi --model grok-4.5:low "What's the weather?"   # fast / latency-sensitive
 | **`medium`** | Balanced thinking vs latency | Analysis and longer-context work |
 | **`low`** (**fast mode**) | Some reasoning, still fast | Latency-sensitive agents and simple tool calling |
 
-`grok-4.5` defaults to **high** when no effort is specified; reasoning **cannot be disabled** (`/think off` is not supported for this model). Because `xai-auth` is OAuth-only, Grok 4.5, Grok 4.3, every Grok 4.20 variant, Grok Build, and Composer all send Responses traffic through xAI's Grok CLI session endpoint using the same X account OAuth token. Grok Build and Composer still receive their model-specific compatibility payloads, headers, and local tool shims. `grok-composer-2.5-fast` does not accept configurable reasoning effort. `grok-4.20-0309-reasoning` reasons automatically and does not accept a configurable effort parameter. `grok-4.20-multi-agent-0309` uses `medium` for 4 agents and `high` for 16 agents.
+`grok-4.5` defaults to **high** when no effort is specified; reasoning **cannot be disabled** (`/think off` is not supported for this model). Every model actually returned and selected through the OAuth-only `xai-auth` catalog sends Responses traffic through xAI's Grok CLI session endpoint using the same X account OAuth token. When returned, Grok Build and Composer still receive their model-specific compatibility payloads, headers, and local tool shims. `grok-composer-2.5-fast` does not accept configurable reasoning effort. `grok-4.20-0309-reasoning` reasons automatically and does not accept a configurable effort parameter. `grok-4.20-multi-agent-0309` uses `medium` for 4 agents and `high` for 16 agents.
 
 ### Grok 4.5 source notes
 
@@ -457,6 +482,7 @@ Opt-in research using the active xAI model plus native web and X search tools. E
 | Set default model | `/model grok-4.5` (in TUI) |
 | Set thinking level | `/think high` (in TUI) |
 | Manage outbound xAI tools | `/xai-tools` (in TUI) |
+| Recreate extension/catalog state | `/reload` (respects the 15-minute cache TTL) |
 
 ---
 
@@ -531,6 +557,14 @@ This re-runs the full OAuth flow and replaces your stored tokens.
 The paid `xai_generate_image` helper is a deliberate transport exception: the official Grok Build client sends both OAuth and BYOK Imagine requests directly to the public Images endpoint. This does not change normal chat or Responses-helper routing.
 
 If you have the official Grok CLI installed and authenticated (`~/.grok/auth.json`), this package detects and reuses those credentials automatically.
+
+### "Why is a model missing or still cached?"
+
+The xAI model list is entitlement-aware. If a model is missing, the authenticated `/models-v2` response did not include a usable OAuth Responses entry, or discovery fell back to the curated offline catalog. Run `/login xai-auth` to force an account-bound refresh. `/reload` reloads the extension but intentionally reuses a cache younger than 15 minutes; after the TTL it performs a bounded refresh.
+
+A one-shot `pi --list-models` cannot refresh an already-expired stored OAuth token before the model registry is bound. In that case it uses fresh cache or the curated fallback; starting a normal session lets pi refresh the credential under its credential-store lock and then refresh the catalog.
+
+Do not add custom `xai-auth` entries to `~/.pi/agent/models.json`; that provider ID is owned by this extension. Pi can re-merge user-defined entries when an authenticated catalog is empty. The extension's input and transport guards still refuse any model absent from the active OAuth entitlement snapshot before an xAI request is sent, but such custom entries may remain visible in `/model` because pi exposes no extension API for removing disk-defined models from an otherwise empty provider.
 
 ### "What model am I using?"
 
@@ -693,9 +727,10 @@ pi-xai-oauth/
 ├── extensions/
 │   ├── xai-oauth.ts          # Thin provider/tools entrypoint
 │   └── xai/                  # Domain modules: OAuth, auth, models, payloads, tools
-│       ├── auth.ts           # Grok CLI credential reuse + token resolution
-│       ├── constants.ts      # URLs, OAuth constants, defaults
-│       ├── models.ts         # Model catalog + model-specific compatibility helpers
+│       ├── auth.ts           # Pi/Grok credential reuse + token resolution
+│       ├── catalog.ts        # Authenticated /models-v2 normalization + atomic LKG cache
+│       ├── constants.ts      # URLs, OAuth constants, catalog bounds, defaults
+│       ├── models.ts         # Curated fallback/known metadata + compatibility helpers
 │       ├── oauth.ts          # OAuth login/refresh/callback transaction helpers
 │       ├── oidc.ts           # Pinned discovery/JWKS + ID-token validation
 │       ├── payload.ts        # xAI Responses payload normalization

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ The normalized, token-free last-known-good catalog is stored at:
 - **`/reload`:** recreates the extension and follows the same 15-minute policy; it is not an unconditional network refresh.
 - **Selection:** if a refresh removes the active xAI model, the next turn switches to an entitled xAI replacement when available; otherwise it aborts before sending an unentitled request.
 
-The cache stores only normalized model definitions and timestamps. It never stores access/refresh/ID tokens, auth headers, raw endpoint responses, or account identity fields. Startup does not expose a previous account's fresh cache when no credential exists, and a credential-file modification newer than the cache forces discovery. A token-free cache still cannot distinguish an external account replacement that deliberately preserves the credential file's timestamp; in-product login always bypasses and replaces the cache.
+The cache stores only normalized model definitions and timestamps. It never stores access/refresh/ID tokens, auth headers, raw endpoint responses, or account identity fields. Startup does not expose a previous account's fresh cache when no credential exists, and a credential-file modification newer than the cache forces discovery. If an exceptional filesystem error prevents replacing or deleting an old cache, a token-free `.invalidated` sidecar suppresses it until a later successful atomic write. A token-free cache still cannot distinguish an external account replacement that deliberately preserves the credential file's timestamp; in-product login always bypasses and replaces the cache.
 
 ### Reasoning / Thinking Levels
 
@@ -562,7 +562,7 @@ If you have the official Grok CLI installed and authenticated (`~/.grok/auth.jso
 
 The xAI model list is entitlement-aware. If a model is missing, the authenticated `/models-v2` response did not include a usable OAuth Responses entry, or discovery fell back to the curated offline catalog. Run `/login xai-auth` to force an account-bound refresh. `/reload` reloads the extension but intentionally reuses a cache younger than 15 minutes; after the TTL it performs a bounded refresh.
 
-A one-shot `pi --list-models` cannot refresh an already-expired stored OAuth token before the model registry is bound. In that case it uses fresh cache or the curated fallback; starting a normal session lets pi refresh the credential under its credential-store lock and then refresh the catalog.
+A one-shot `pi --list-models` cannot refresh an already-expired pi-stored OAuth token before the model registry is bound. It can still use a fresh official Grok CLI bearer when available; otherwise it uses fresh cache or the curated fallback. Starting a normal session lets pi refresh its stored credential under the credential-store lock and then revalidate the catalog.
 
 Do not add custom `xai-auth` entries to `~/.pi/agent/models.json`; that provider ID is owned by this extension. Pi can re-merge user-defined entries when an authenticated catalog is empty. The extension's input and transport guards still refuse any model absent from the active OAuth entitlement snapshot before an xAI request is sent, but such custom entries may remain visible in `/model` because pi exposes no extension API for removing disk-defined models from an otherwise empty provider.
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ The normalized, token-free last-known-good catalog is stored at:
 
 - **Fresh for 15 minutes:** with a usable OAuth credential (or an expired stored credential awaiting pi's lock-protected refresh), startup and `/reload` use the cache immediately and do not make a catalog request. Logged-out startup uses the curated fallback instead of exposing the previous account's cache.
 - **Stale refresh:** after 15 minutes, startup performs one authenticated GET bounded to 5 seconds.
-- **Transient fallback:** network errors, timeouts, HTTP 408/429/5xx, or a malformed successful response may reuse a validated cache no older than 7 days.
+- **Transient fallback:** network errors, timeouts, HTTP 408/429/5xx, or a malformed successful response may reuse a validated cache no older than 7 days. A forced/deferred refresh never reuses stale account data; it uses the curated fallback and remains retryable with a one-minute in-session backoff.
 - **Auth/permanent failure:** HTTP 401/403 or other permanent 4xx responses invalidate cached entitlements and use the curated `grok-4.5` fallback.
 - **Login:** every successful `/login xai-auth` forces a refresh with the newly returned credential, never reuses stale data, and updates `/model` immediately. If that refresh fails, login still succeeds and the curated fallback is used.
 - **`/reload`:** recreates the extension and follows the same 15-minute policy; it is not an unconditional network refresh.

--- a/bin/setup.js
+++ b/bin/setup.js
@@ -30,7 +30,7 @@ function color(text, c) {
 
 function printHeader() {
   console.log(`\n${color("🚀  pi-xai-oauth", "cyan")} — ${color("xAI Grok + OAuth for pi", "bold")}\n`);
-  console.log("   One-command setup for Grok 4.5, Grok Build, and Composer 2.5 with clean OAuth login.\n");
+  console.log("   One-command setup for Grok 4.5 plus your account's OAuth-visible xAI model catalog.\n");
 }
 
 function checkPi() {
@@ -212,7 +212,7 @@ function printNextSteps(nonInteractive = false) {
     console.log(`   ${color("2.", "bold")} Start chatting with Grok 4.5 (already set as default)`);
     console.log(`      ${color("pi", "cyan")}\n`);
   } else {
-    console.log("Grok 4.5, Grok 4.3, Grok Build, Composer 2.5 + xAI OAuth are now configured and ready.\n");
+    console.log("Grok 4.5 plus your account's OAuth-visible xAI models are now configured and ready.\n");
   }
 
   console.log("You now have access to powerful reasoning, coding models, and long context!\n");

--- a/extensions/xai-oauth.ts
+++ b/extensions/xai-oauth.ts
@@ -14,6 +14,7 @@ export default async function (pi: ExtensionAPI) {
   const oauthResponsesRoute = resolveXaiRoute("oauth-session", "responses");
   let currentModels: readonly XaiCatalogModel[] = CURATED_FALLBACK_MODELS;
   let needsSessionRefresh = false;
+  let deferredRetryAfter = 0;
   let refreshGeneration = 0;
   let refreshAbortController: AbortController | undefined;
   let oauth: ReturnType<typeof createXaiOAuth>;
@@ -76,7 +77,10 @@ export default async function (pi: ExtensionAPI) {
         forceRefresh: true,
         signal: callbacks.signal,
       });
-      if (isCurrent) applyCatalog(selection, true);
+      if (isCurrent) {
+        applyCatalog(selection, true);
+        if (selection.needsAuthenticatedRefresh) deferredRetryAfter = Date.now() + 60_000;
+      }
       callbacks.onProgress?.(
         selection.source === "remote"
           ? `Refreshed ${selection.models.length} OAuth-visible xAI model${selection.models.length === 1 ? "" : "s"}.`
@@ -94,11 +98,14 @@ export default async function (pi: ExtensionAPI) {
   applyCatalog(startupSelection, false);
 
   const refreshDeferredCatalog = async (ctx: any) => {
-    if (!needsSessionRefresh) return;
+    if (!needsSessionRefresh || Date.now() < deferredRetryAfter) return;
     const lookupModel =
       ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, DEFAULT_XAI_MODEL) ||
       currentModels.map((model) => ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, model.id)).find(Boolean);
-    if (!lookupModel || typeof ctx?.modelRegistry?.getApiKeyAndHeaders !== "function") return;
+    if (!lookupModel || typeof ctx?.modelRegistry?.getApiKeyAndHeaders !== "function") {
+      deferredRetryAfter = Date.now() + 5_000;
+      return;
+    }
     const auth = await ctx.modelRegistry.getApiKeyAndHeaders(lookupModel);
     const authorization = auth?.ok && typeof auth.headers?.Authorization === "string"
       ? auth.headers.Authorization
@@ -108,12 +115,22 @@ export default async function (pi: ExtensionAPI) {
       (authorization.toLowerCase().startsWith("bearer ")
         ? authorization.slice("bearer ".length)
         : "");
-    if (!access) return;
+    if (!access) {
+      deferredRetryAfter = Date.now() + 5_000;
+      return;
+    }
     try {
-      const { selection, isCurrent } = await refreshCatalog(access, { forceRefresh: false });
-      if (isCurrent) applyCatalog(selection, true);
+      // The bearer became available only after pi's lock-protected refresh;
+      // revalidate entitlements instead of accepting a prior fresh cache.
+      const { selection, isCurrent } = await refreshCatalog(access, { forceRefresh: true });
+      if (isCurrent) {
+        applyCatalog(selection, true);
+        deferredRetryAfter = selection.needsAuthenticatedRefresh ? Date.now() + 60_000 : 0;
+      }
     } catch {
-      // A newer login/refresh superseded this attempt or the runtime shut down.
+      // A superseded older attempt must not shorten a newer transient
+      // refresh's one-minute retry deadline.
+      deferredRetryAfter = Math.max(deferredRetryAfter, Date.now() + 5_000);
     }
   };
 

--- a/extensions/xai-oauth.ts
+++ b/extensions/xai-oauth.ts
@@ -16,6 +16,8 @@ export default async function (pi: ExtensionAPI) {
   let needsSessionRefresh = false;
   let deferredRetryAfter = 0;
   let refreshGeneration = 0;
+  let loginCatalogGeneration = 0;
+  let activeLoginRefreshes = 0;
   let refreshAbortController: AbortController | undefined;
   let oauth: ReturnType<typeof createXaiOAuth>;
 
@@ -30,6 +32,17 @@ export default async function (pi: ExtensionAPI) {
     authHeader: true,
     streamSimple: streamSimpleXaiResponses as any,
     oauth: oauth as any,
+  });
+
+  const curatedFallbackSelection = (): XaiCatalogSelection => ({
+    models: CURATED_FALLBACK_MODELS.map((model) => ({
+      ...model,
+      input: [...model.input],
+      cost: { ...model.cost },
+      ...(model.thinkingLevelMap ? { thinkingLevelMap: { ...model.thinkingLevelMap } } : {}),
+    })),
+    source: "curated-fallback",
+    needsAuthenticatedRefresh: true,
   });
 
   const applyCatalog = (selection: XaiCatalogSelection, replaceExisting: boolean) => {
@@ -73,19 +86,35 @@ export default async function (pi: ExtensionAPI) {
   oauth = createXaiOAuth({
     getExistingCredentials: getGrokAuthCredentials,
     onLoginCredentials: async (credentials: OAuthCredentials, callbacks: OAuthLoginCallbacks) => {
-      const { selection, isCurrent } = await refreshCatalog(credentials.access, {
-        forceRefresh: true,
-        signal: callbacks.signal,
-      });
-      if (isCurrent) {
+      const loginGeneration = ++loginCatalogGeneration;
+      activeLoginRefreshes++;
+      try {
+        const { selection, isCurrent } = await refreshCatalog(credentials.access, {
+          forceRefresh: true,
+          signal: callbacks.signal,
+        });
+        // Deferred refreshes cannot start while login catalog work is active.
+        // If another login superseded this one, only the newest login may apply.
+        if (loginGeneration !== loginCatalogGeneration || !isCurrent) return;
         applyCatalog(selection, true);
-        if (selection.needsAuthenticatedRefresh) deferredRetryAfter = Date.now() + 60_000;
+        deferredRetryAfter = selection.needsAuthenticatedRefresh ? Date.now() + 60_000 : 0;
+        callbacks.onProgress?.(
+          selection.source === "remote"
+            ? `Refreshed ${selection.models.length} OAuth-visible xAI model${selection.models.length === 1 ? "" : "s"}.`
+            : "The authenticated xAI model catalog was unavailable; using the curated fallback.",
+        );
+      } catch (error) {
+        if (callbacks.signal?.aborted) throw error;
+        if (loginGeneration === loginCatalogGeneration) {
+          applyCatalog(curatedFallbackSelection(), true);
+          deferredRetryAfter = Date.now() + 60_000;
+          callbacks.onProgress?.(
+            "The authenticated xAI model catalog was unavailable; using the curated fallback.",
+          );
+        }
+      } finally {
+        activeLoginRefreshes--;
       }
-      callbacks.onProgress?.(
-        selection.source === "remote"
-          ? `Refreshed ${selection.models.length} OAuth-visible xAI model${selection.models.length === 1 ? "" : "s"}.`
-          : "The authenticated xAI model catalog was unavailable; using the curated fallback.",
-      );
     },
   });
 
@@ -98,7 +127,8 @@ export default async function (pi: ExtensionAPI) {
   applyCatalog(startupSelection, false);
 
   const refreshDeferredCatalog = async (ctx: any) => {
-    if (!needsSessionRefresh || Date.now() < deferredRetryAfter) return;
+    if (activeLoginRefreshes > 0 || !needsSessionRefresh || Date.now() < deferredRetryAfter) return;
+    const loginGenerationAtStart = loginCatalogGeneration;
     const lookupModel =
       ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, DEFAULT_XAI_MODEL) ||
       currentModels.map((model) => ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, model.id)).find(Boolean);
@@ -115,6 +145,7 @@ export default async function (pi: ExtensionAPI) {
       (authorization.toLowerCase().startsWith("bearer ")
         ? authorization.slice("bearer ".length)
         : "");
+    if (activeLoginRefreshes > 0 || loginGenerationAtStart !== loginCatalogGeneration) return;
     if (!access) {
       deferredRetryAfter = Date.now() + 5_000;
       return;
@@ -146,14 +177,14 @@ export default async function (pi: ExtensionAPI) {
     (pi as any).on("input", async (_event: any, ctx: any) => {
       await refreshDeferredCatalog(ctx);
       const activeModel = ctx?.model;
-      if (
-        activeModel?.provider !== XAI_PROVIDER_ID ||
-        ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, activeModel.id)
-      ) return { action: "continue" };
+      const entitled =
+        typeof activeModel?.id === "string" &&
+        currentModels.some((model) => model.id.toLowerCase() === activeModel.id.toLowerCase());
+      if (activeModel?.provider !== XAI_PROVIDER_ID || entitled) return { action: "continue" };
 
-      const replacement =
-        ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, DEFAULT_XAI_MODEL) ||
-        currentModels.map((model) => ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, model.id)).find(Boolean);
+      const replacement = currentModels
+        .map((model) => ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, model.id))
+        .find(Boolean);
       if (replacement && (await pi.setModel(replacement))) {
         ctx?.ui?.notify?.(
           `The refreshed xAI catalog no longer includes ${activeModel.id}; switched to ${replacement.id}.`,
@@ -173,13 +204,13 @@ export default async function (pi: ExtensionAPI) {
     (pi as any).on("before_agent_start", async (_event: any, ctx: any) => {
       await refreshDeferredCatalog(ctx);
       let activeModel = ctx?.model;
-      if (
-        activeModel?.provider === XAI_PROVIDER_ID &&
-        !ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, activeModel.id)
-      ) {
-        const replacement =
-          ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, DEFAULT_XAI_MODEL) ||
-          currentModels.map((model) => ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, model.id)).find(Boolean);
+      const entitled =
+        typeof activeModel?.id === "string" &&
+        currentModels.some((model) => model.id.toLowerCase() === activeModel.id.toLowerCase());
+      if (activeModel?.provider === XAI_PROVIDER_ID && !entitled) {
+        const replacement = currentModels
+          .map((model) => ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, model.id))
+          .find(Boolean);
         if (replacement && (await pi.setModel(replacement))) {
           activeModel = replacement;
           ctx?.ui?.notify?.(

--- a/extensions/xai-oauth.ts
+++ b/extensions/xai-oauth.ts
@@ -1,35 +1,184 @@
+import type { OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { getGrokAuthCredentials } from "./xai/auth";
-import { XAI_PROVIDER_ID } from "./xai/constants";
-import { MODELS } from "./xai/models";
+import { selectXaiModelCatalog, type XaiCatalogSelection } from "./xai/catalog";
+import { getGrokAuthCredentials, getStartupXaiCatalogAuth } from "./xai/auth";
+import { DEFAULT_XAI_MODEL, XAI_PROVIDER_ID } from "./xai/constants";
+import { CURATED_FALLBACK_MODELS, setXaiRuntimeModels, type XaiCatalogModel } from "./xai/models";
 import { createXaiOAuth } from "./xai/oauth";
 import { streamSimpleXaiResponses } from "./xai/responses";
 import { resolveXaiRoute } from "./xai/routing";
 import { registerXaiTools, syncXaiToolsForModel } from "./xai/tools";
 
-export default function (pi: ExtensionAPI) {
+/** Register the xAI OAuth provider and its authenticated model catalog. */
+export default async function (pi: ExtensionAPI) {
   const oauthResponsesRoute = resolveXaiRoute("oauth-session", "responses");
-  pi.registerProvider(XAI_PROVIDER_ID, {
+  let currentModels: readonly XaiCatalogModel[] = CURATED_FALLBACK_MODELS;
+  let needsSessionRefresh = false;
+  let refreshGeneration = 0;
+  let refreshAbortController: AbortController | undefined;
+  let oauth: ReturnType<typeof createXaiOAuth>;
+
+  const providerModels = (models: readonly XaiCatalogModel[]) =>
+    models.map(({ apiBackend: _apiBackend, ...model }) => model);
+
+  const providerConfig = () => ({
     name: "xAI (OAuth)",
     baseUrl: oauthResponsesRoute.baseUrl,
-    api: "xai-responses",
-    models: MODELS as any,
+    api: "xai-responses" as const,
+    models: providerModels(currentModels),
     authHeader: true,
     streamSimple: streamSimpleXaiResponses as any,
-    oauth: createXaiOAuth({ getExistingCredentials: getGrokAuthCredentials }) as any,
+    oauth: oauth as any,
   });
+
+  const applyCatalog = (selection: XaiCatalogSelection, replaceExisting: boolean) => {
+    currentModels = selection.models;
+    needsSessionRefresh = selection.needsAuthenticatedRefresh;
+    setXaiRuntimeModels(currentModels);
+    if (replaceExisting) pi.unregisterProvider(XAI_PROVIDER_ID);
+    pi.registerProvider(XAI_PROVIDER_ID, providerConfig() as any);
+  };
+
+  const refreshCatalog = async (
+    access: string,
+    options: { forceRefresh: boolean; signal?: AbortSignal },
+  ): Promise<{ selection: XaiCatalogSelection; isCurrent: boolean }> => {
+    // Never coalesce across credentials: a forced login may switch accounts
+    // while an older session refresh is still in flight.
+    const generation = ++refreshGeneration;
+    refreshAbortController?.abort();
+    const controller = new AbortController();
+    refreshAbortController = controller;
+    const forwardAbort = () => controller.abort();
+    options.signal?.addEventListener("abort", forwardAbort, { once: true });
+    if (options.signal?.aborted) controller.abort();
+    try {
+      const selection = await selectXaiModelCatalog({
+        credential: { access },
+        forceRefresh: options.forceRefresh,
+        signal: controller.signal,
+        commitAllowed: () => generation === refreshGeneration && !controller.signal.aborted,
+      });
+      return {
+        selection,
+        isCurrent: generation === refreshGeneration && !controller.signal.aborted,
+      };
+    } finally {
+      options.signal?.removeEventListener("abort", forwardAbort);
+      if (refreshAbortController === controller) refreshAbortController = undefined;
+    }
+  };
+
+  oauth = createXaiOAuth({
+    getExistingCredentials: getGrokAuthCredentials,
+    onLoginCredentials: async (credentials: OAuthCredentials, callbacks: OAuthLoginCallbacks) => {
+      const { selection, isCurrent } = await refreshCatalog(credentials.access, {
+        forceRefresh: true,
+        signal: callbacks.signal,
+      });
+      if (isCurrent) applyCatalog(selection, true);
+      callbacks.onProgress?.(
+        selection.source === "remote"
+          ? `Refreshed ${selection.models.length} OAuth-visible xAI model${selection.models.length === 1 ? "" : "s"}.`
+          : "The authenticated xAI model catalog was unavailable; using the curated fallback.",
+      );
+    },
+  });
+
+  const startupAuth = getStartupXaiCatalogAuth();
+  const startupSelection = await selectXaiModelCatalog({
+    credential: startupAuth.credential,
+    refreshWhenCredentialsAvailable: startupAuth.needsRegistryRefresh,
+    credentialChangedAt: startupAuth.credentialChangedAt,
+  });
+  applyCatalog(startupSelection, false);
+
+  const refreshDeferredCatalog = async (ctx: any) => {
+    if (!needsSessionRefresh) return;
+    const lookupModel =
+      ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, DEFAULT_XAI_MODEL) ||
+      currentModels.map((model) => ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, model.id)).find(Boolean);
+    if (!lookupModel || typeof ctx?.modelRegistry?.getApiKeyAndHeaders !== "function") return;
+    const auth = await ctx.modelRegistry.getApiKeyAndHeaders(lookupModel);
+    const authorization = auth?.ok && typeof auth.headers?.Authorization === "string"
+      ? auth.headers.Authorization
+      : "";
+    const access =
+      (auth?.ok && typeof auth.apiKey === "string" && auth.apiKey) ||
+      (authorization.toLowerCase().startsWith("bearer ")
+        ? authorization.slice("bearer ".length)
+        : "");
+    if (!access) return;
+    try {
+      const { selection, isCurrent } = await refreshCatalog(access, { forceRefresh: false });
+      if (isCurrent) applyCatalog(selection, true);
+    } catch {
+      // A newer login/refresh superseded this attempt or the runtime shut down.
+    }
+  };
 
   registerXaiTools(pi);
 
   if (typeof (pi as any).on === "function") {
     // Active-tool accessors belong to the ExtensionAPI (`pi`), while models
-    // are supplied by the event/context payload.
-    (pi as any).on("session_start", (_event: any, ctx: any) =>
-      syncXaiToolsForModel(pi, ctx?.model, { resetNetworkTools: true }),
-    );
+    // and pi-managed credentials are supplied by the event/context payload.
+    (pi as any).on("session_start", async (_event: any, ctx: any) => {
+      await refreshDeferredCatalog(ctx);
+      syncXaiToolsForModel(pi, ctx?.model, { resetNetworkTools: true });
+    });
+    (pi as any).on("input", async (_event: any, ctx: any) => {
+      await refreshDeferredCatalog(ctx);
+      const activeModel = ctx?.model;
+      if (
+        activeModel?.provider !== XAI_PROVIDER_ID ||
+        ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, activeModel.id)
+      ) return { action: "continue" };
+
+      const replacement =
+        ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, DEFAULT_XAI_MODEL) ||
+        currentModels.map((model) => ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, model.id)).find(Boolean);
+      if (replacement && (await pi.setModel(replacement))) {
+        ctx?.ui?.notify?.(
+          `The refreshed xAI catalog no longer includes ${activeModel.id}; switched to ${replacement.id}.`,
+          "warning",
+        );
+        return { action: "continue" };
+      }
+      ctx?.ui?.notify?.(
+        `The refreshed xAI catalog no longer includes ${activeModel.id}, and no entitled xAI replacement is available.`,
+        "error",
+      );
+      return { action: "handled" };
+    });
     (pi as any).on("model_select", (event: any, ctx: any) =>
       syncXaiToolsForModel(pi, event?.model ?? ctx?.model),
     );
-    (pi as any).on("before_agent_start", (_event: any, ctx: any) => syncXaiToolsForModel(pi, ctx?.model));
+    (pi as any).on("before_agent_start", async (_event: any, ctx: any) => {
+      await refreshDeferredCatalog(ctx);
+      let activeModel = ctx?.model;
+      if (
+        activeModel?.provider === XAI_PROVIDER_ID &&
+        !ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, activeModel.id)
+      ) {
+        const replacement =
+          ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, DEFAULT_XAI_MODEL) ||
+          currentModels.map((model) => ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, model.id)).find(Boolean);
+        if (replacement && (await pi.setModel(replacement))) {
+          activeModel = replacement;
+          ctx?.ui?.notify?.(
+            `The refreshed xAI catalog no longer includes ${ctx.model.id}; switched to ${replacement.id}.`,
+            "warning",
+          );
+        } else {
+          ctx?.ui?.notify?.(
+            `The refreshed xAI catalog no longer includes ${activeModel.id}, and no entitled xAI replacement is available.`,
+            "error",
+          );
+          // The provider transport also checks the active entitlement snapshot
+          // and returns a local error before any network request.
+        }
+      }
+      return syncXaiToolsForModel(pi, activeModel);
+    });
   }
 }

--- a/extensions/xai/auth.ts
+++ b/extensions/xai/auth.ts
@@ -89,19 +89,22 @@ export interface StartupXaiCatalogAuth {
 
 /**
  * Resolve a fresh startup-only OAuth bearer without refreshing or modifying
- * pi's credential store. Expired pi credentials are deferred to the bound
- * model registry so refresh-token rotation remains lock protected.
+ * pi's credential store. Expired pi credentials still defer lock-protected
+ * refresh to the bound model registry, while a fresh official Grok CLI bearer
+ * may be reused read-only for startup catalog selection.
  */
 export function getStartupXaiCatalogAuth(now = Date.now()): StartupXaiCatalogAuth {
+  let needsRegistryRefresh = false;
+  let credentialChangedAt: number | undefined;
   try {
     const authPath = join(getAgentDir(), "auth.json");
     const stored = AuthStorage.create(authPath).get(XAI_PROVIDER_ID);
-    const credentialChangedAt = existsSync(authPath) ? statSync(authPath).mtimeMs : undefined;
+    credentialChangedAt = existsSync(authPath) ? statSync(authPath).mtimeMs : undefined;
     if (stored?.type === "oauth" && typeof stored.access === "string" && stored.access) {
       if (typeof stored.expires === "number" && stored.expires > now) {
         return { credential: { access: stored.access }, needsRegistryRefresh: false, credentialChangedAt };
       }
-      return { credential: null, needsRegistryRefresh: true, credentialChangedAt };
+      needsRegistryRefresh = true;
     }
   } catch {
     // Fall through to read-only official Grok CLI credential reuse.
@@ -110,10 +113,18 @@ export function getStartupXaiCatalogAuth(now = Date.now()): StartupXaiCatalogAut
   const grok = getGrokAuthCredentials();
   if (grok?.access && typeof grok.expires === "number" && grok.expires > now) {
     const grokPath = join(homedir(), ".grok", "auth.json");
-    const credentialChangedAt = existsSync(grokPath) ? statSync(grokPath).mtimeMs : undefined;
-    return { credential: { access: grok.access }, needsRegistryRefresh: false, credentialChangedAt };
+    const grokChangedAt = existsSync(grokPath) ? statSync(grokPath).mtimeMs : undefined;
+    const changedAt =
+      typeof credentialChangedAt === "number" && typeof grokChangedAt === "number"
+        ? Math.max(credentialChangedAt, grokChangedAt)
+        : grokChangedAt ?? credentialChangedAt;
+    return {
+      credential: { access: grok.access },
+      needsRegistryRefresh,
+      credentialChangedAt: changedAt,
+    };
   }
-  return { credential: null, needsRegistryRefresh: false };
+  return { credential: null, needsRegistryRefresh, credentialChangedAt };
 }
 
 /** Resolve a tagged xAI OAuth credential from pi context or reusable Grok CLI credentials. */

--- a/extensions/xai/auth.ts
+++ b/extensions/xai/auth.ts
@@ -1,5 +1,6 @@
 import type { OAuthCredentials } from "@earendil-works/pi-ai";
-import { existsSync, readFileSync } from "fs";
+import { AuthStorage, getAgentDir } from "@earendil-works/pi-coding-agent";
+import { existsSync, readFileSync, statSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
 import {
@@ -76,6 +77,42 @@ export function getGrokAuthCredentials(): OAuthCredentials | null {
   }
 
   return null;
+}
+
+export interface StartupXaiCatalogAuth {
+  credential: { access: string } | null;
+  /** True when pi has an expired stored OAuth token that session_start should refresh under AuthStorage's lock. */
+  needsRegistryRefresh: boolean;
+  credentialChangedAt?: number;
+}
+
+/**
+ * Resolve a fresh startup-only OAuth bearer without refreshing or modifying
+ * pi's credential store. Expired pi credentials are deferred to the bound
+ * model registry so refresh-token rotation remains lock protected.
+ */
+export function getStartupXaiCatalogAuth(now = Date.now()): StartupXaiCatalogAuth {
+  try {
+    const authPath = join(getAgentDir(), "auth.json");
+    const stored = AuthStorage.create(authPath).get(XAI_PROVIDER_ID);
+    const credentialChangedAt = existsSync(authPath) ? statSync(authPath).mtimeMs : undefined;
+    if (stored?.type === "oauth" && typeof stored.access === "string" && stored.access) {
+      if (typeof stored.expires === "number" && stored.expires > now) {
+        return { credential: { access: stored.access }, needsRegistryRefresh: false, credentialChangedAt };
+      }
+      return { credential: null, needsRegistryRefresh: true, credentialChangedAt };
+    }
+  } catch {
+    // Fall through to read-only official Grok CLI credential reuse.
+  }
+
+  const grok = getGrokAuthCredentials();
+  if (grok?.access && typeof grok.expires === "number" && grok.expires > now) {
+    const grokPath = join(homedir(), ".grok", "auth.json");
+    const credentialChangedAt = existsSync(grokPath) ? statSync(grokPath).mtimeMs : undefined;
+    return { credential: { access: grok.access }, needsRegistryRefresh: false, credentialChangedAt };
+  }
+  return { credential: null, needsRegistryRefresh: false };
 }
 
 /** Resolve a tagged xAI OAuth credential from pi context or reusable Grok CLI credentials. */

--- a/extensions/xai/auth.ts
+++ b/extensions/xai/auth.ts
@@ -11,6 +11,7 @@ import {
   XAI_OAUTH_REFRESH_SKEW_MS,
   XAI_PROVIDER_ID,
 } from "./constants";
+import { getXaiRuntimeModels } from "./models";
 import { ensureFreshXaiCredentials } from "./oauth";
 import type { XaiCredential } from "./routing";
 
@@ -117,13 +118,21 @@ export function getStartupXaiCatalogAuth(now = Date.now()): StartupXaiCatalogAut
 
 /** Resolve a tagged xAI OAuth credential from pi context or reusable Grok CLI credentials. */
 export async function resolveXaiCredential(ctx: any): Promise<XaiCredential | null> {
-  const registryModel = ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, DEFAULT_XAI_MODEL);
-  if (registryModel && typeof ctx?.modelRegistry?.getApiKeyAndHeaders === "function") {
-    const auth = await ctx.modelRegistry.getApiKeyAndHeaders(registryModel);
-    if (auth?.ok && auth.apiKey) return { kind: "oauth-session", token: auth.apiKey };
-    const authorization = auth?.ok && typeof auth.headers?.Authorization === "string" ? auth.headers.Authorization : "";
-    if (authorization.toLowerCase().startsWith("bearer ")) {
-      return { kind: "oauth-session", token: authorization.slice("bearer ".length) };
+  if (typeof ctx?.modelRegistry?.find === "function" && typeof ctx?.modelRegistry?.getApiKeyAndHeaders === "function") {
+    const candidateIds = [
+      ctx?.model?.provider === XAI_PROVIDER_ID ? ctx.model.id : undefined,
+      DEFAULT_XAI_MODEL,
+      ...getXaiRuntimeModels().map((model) => model.id),
+    ].filter((id, index, values): id is string => typeof id === "string" && !!id && values.indexOf(id) === index);
+    for (const modelId of candidateIds) {
+      const registryModel = ctx.modelRegistry.find(XAI_PROVIDER_ID, modelId);
+      if (!registryModel) continue;
+      const auth = await ctx.modelRegistry.getApiKeyAndHeaders(registryModel);
+      if (auth?.ok && auth.apiKey) return { kind: "oauth-session", token: auth.apiKey };
+      const authorization = auth?.ok && typeof auth.headers?.Authorization === "string" ? auth.headers.Authorization : "";
+      if (authorization.toLowerCase().startsWith("bearer ")) {
+        return { kind: "oauth-session", token: authorization.slice("bearer ".length) };
+      }
     }
   }
   if (ctx?.apiKey) return { kind: "oauth-session", token: ctx.apiKey };

--- a/extensions/xai/catalog.ts
+++ b/extensions/xai/catalog.ts
@@ -243,13 +243,17 @@ function normalizeCatalogEntry(value: unknown): EntryResult {
   );
   const reasoning =
     explicitReasoning ??
-    (supportsReasoningEffort === true || !!defaultReasoningLevel || !!suppliedReasoningLevels?.length
-      ? true
-      : known?.reasoning ?? false);
+    (supportsReasoningEffort === false
+      ? false
+      : supportsReasoningEffort === true || !!defaultReasoningLevel || !!suppliedReasoningLevels?.length
+        ? true
+        : known?.reasoning ?? false);
 
   let levelMap: XaiCatalogModel["thinkingLevelMap"];
   if (!reasoning) {
     levelMap = known?.reasoning === false ? known.thinkingLevelMap : { off: "none" };
+  } else if (supportsReasoningEffort === false) {
+    levelMap = thinkingLevelMap([], normalizedId);
   } else if (suppliedReasoningLevels !== undefined) {
     levelMap = thinkingLevelMap(suppliedReasoningLevels, normalizedId);
   } else if (defaultReasoningLevel) {

--- a/extensions/xai/catalog.ts
+++ b/extensions/xai/catalog.ts
@@ -389,8 +389,35 @@ function validateCachedModel(value: unknown): XaiCatalogModel | undefined {
   };
 }
 
+function invalidationMarkerPath(cachePath: string): string {
+  return `${cachePath}.invalidated`;
+}
+
+async function hasInvalidationMarker(cachePath: string): Promise<boolean> {
+  try {
+    const info = await lstat(invalidationMarkerPath(cachePath));
+    return info.isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function writeInvalidationMarker(cachePath: string, now: number): Promise<void> {
+  const markerPath = invalidationMarkerPath(cachePath);
+  await mkdir(dirname(markerPath), { recursive: true, mode: 0o700 });
+  const handle = await open(markerPath, "w", 0o600);
+  try {
+    await handle.writeFile(`${XAI_MODEL_CATALOG_CACHE_SCHEMA}:${now}\n`, "utf8");
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  await chmod(markerPath, 0o600);
+}
+
 async function readCache(cachePath: string, now: number): Promise<CacheRecord | undefined> {
   try {
+    if (await hasInvalidationMarker(cachePath)) return undefined;
     const info = await lstat(cachePath);
     if (info.isSymbolicLink() || !info.isFile() || info.size <= 0 || info.size > XAI_MODEL_CATALOG_MAX_BYTES) return undefined;
     if ((info.mode & 0o077) !== 0) await chmod(cachePath, 0o600);
@@ -432,6 +459,7 @@ async function writeAtomicJson(
   cachePath: string,
   value: CacheRecord | CacheTombstone,
   commitAllowed: () => boolean = () => true,
+  clearInvalidationMarker = false,
 ): Promise<void> {
   const directory = dirname(cachePath);
   await mkdir(directory, { recursive: true, mode: 0o700 });
@@ -447,6 +475,9 @@ async function writeAtomicJson(
     if (!commitAllowed()) throw new XaiCatalogCancelledError();
     await rename(tempPath, cachePath);
     await chmod(cachePath, 0o600);
+    if (clearInvalidationMarker) {
+      await unlink(invalidationMarkerPath(cachePath)).catch(() => {});
+    }
   } catch (error) {
     await handle?.close().catch(() => {});
     await unlink(tempPath).catch(() => {});
@@ -469,7 +500,7 @@ async function cacheMatchesRecord(cachePath: string, expected: CacheRecord): Pro
 
 async function restorePreviousCache(cachePath: string, previous: CacheRecord | undefined): Promise<void> {
   if (previous) {
-    await writeAtomicJson(cachePath, previous);
+    await writeAtomicJson(cachePath, previous, () => true, true);
   } else {
     await unlink(cachePath).catch(() => {});
   }
@@ -495,7 +526,8 @@ async function invalidateCache(
     });
   } catch (error) {
     if (error instanceof XaiCatalogCancelledError) return;
-    await unlink(cachePath).catch(() => {});
+    const removed = await unlink(cachePath).then(() => true).catch(() => false);
+    if (!removed) await writeInvalidationMarker(cachePath, now).catch(() => {});
   }
 }
 
@@ -638,7 +670,7 @@ export async function selectXaiModelCatalog(options: XaiCatalogOptions = {}): Pr
     };
     try {
       await withCacheWriteQueue(cachePath, async () => {
-        await writeAtomicJson(cachePath, record, commitAllowed);
+        await writeAtomicJson(cachePath, record, commitAllowed, true);
         if (!commitAllowed()) {
           await restorePreviousCache(cachePath, cache);
           throw new XaiCatalogCancelledError();
@@ -654,6 +686,11 @@ export async function selectXaiModelCatalog(options: XaiCatalogOptions = {}): Pr
         commitAllowed,
         cache,
       );
+      if (!commitAllowed()) throw new XaiCatalogCancelledError();
+      // Invalidation is best-effort. Refuse to advertise remote success if an
+      // older readable entitlement cache could still be revived on reload.
+      if (await readCache(cachePath, now)) await unlink(cachePath).catch(() => {});
+      if (await readCache(cachePath, now)) return fallbackSelection(true);
     }
     if (!commitAllowed()) {
       await withCacheWriteQueue(cachePath, async () => {
@@ -663,7 +700,11 @@ export async function selectXaiModelCatalog(options: XaiCatalogOptions = {}): Pr
       });
       throw new XaiCatalogCancelledError();
     }
-    return { models: cloneModels(outcome.models), source: "remote", needsAuthenticatedRefresh: false };
+    return {
+      models: cloneModels(outcome.models),
+      source: "remote",
+      needsAuthenticatedRefresh: refreshWhenCredentialsAvailable,
+    };
   }
 
   if (!commitAllowed()) throw new XaiCatalogCancelledError();

--- a/extensions/xai/catalog.ts
+++ b/extensions/xai/catalog.ts
@@ -154,8 +154,7 @@ function canonicalReasoningLevel(value: unknown): ThinkingLevel | undefined {
 }
 
 function parseReasoningLevels(value: unknown): ThinkingLevel[] | undefined {
-  if (value === undefined) return undefined;
-  if (!Array.isArray(value)) return [];
+  if (value === undefined || !Array.isArray(value) || value.length === 0) return undefined;
   const result: ThinkingLevel[] = [];
   for (const entry of value) {
     const level = canonicalReasoningLevel(
@@ -163,7 +162,7 @@ function parseReasoningLevels(value: unknown): ThinkingLevel[] | undefined {
     );
     if (level && !result.includes(level)) result.push(level);
   }
-  return result;
+  return result.length > 0 ? result : undefined;
 }
 
 function thinkingLevelMap(levels: ThinkingLevel[], modelId: string): XaiCatalogModel["thinkingLevelMap"] {
@@ -668,18 +667,20 @@ export async function selectXaiModelCatalog(options: XaiCatalogOptions = {}): Pr
   }
 
   if (!commitAllowed()) throw new XaiCatalogCancelledError();
-  if (forceRefresh || outcome.kind === "auth" || outcome.kind === "permanent") {
-    await invalidateCache(
-      cachePath,
-      now,
-      commitAllowed,
-      cache,
-    );
+  if (outcome.kind === "auth" || outcome.kind === "permanent") {
+    await invalidateCache(cachePath, now, commitAllowed, cache);
     if (!commitAllowed()) throw new XaiCatalogCancelledError();
     return fallbackSelection(false);
+  }
+  if (forceRefresh) {
+    // Forced refresh never reuses stale account data, but transient failures
+    // remain retryable once pi has a bound, lock-refreshed credential.
+    await invalidateCache(cachePath, now, commitAllowed, cache);
+    if (!commitAllowed()) throw new XaiCatalogCancelledError();
+    return fallbackSelection(true);
   }
   if (cache) {
     return { models: cloneModels(cache.models), source: "stale-cache", needsAuthenticatedRefresh: false };
   }
-  return fallbackSelection(false);
+  return fallbackSelection(true);
 }

--- a/extensions/xai/catalog.ts
+++ b/extensions/xai/catalog.ts
@@ -1,0 +1,685 @@
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { chmod, lstat, mkdir, open, readFile, rename, unlink } from "fs/promises";
+import { dirname, join } from "path";
+import {
+  XAI_CLI_MODELS_URL,
+  XAI_CLIENT_IDENTIFIER,
+  XAI_CLIENT_VERSION,
+  XAI_MODEL_CATALOG_CACHE_SCHEMA,
+  XAI_MODEL_CATALOG_FRESH_TTL_MS,
+  XAI_MODEL_CATALOG_MAX_BYTES,
+  XAI_MODEL_CATALOG_MAX_STALE_MS,
+  XAI_MODEL_CATALOG_TIMEOUT_MS,
+} from "./constants";
+import {
+  CURATED_FALLBACK_MODELS,
+  knownXaiModelMetadata,
+  resolveXaiClientMode,
+  type XaiCatalogModel,
+} from "./models";
+
+const MAX_CATALOG_ENTRIES = 256;
+const MAX_MODEL_ID_LENGTH = 128;
+const MAX_MODEL_NAME_LENGTH = 200;
+const MAX_CONTEXT_WINDOW = 10_000_000;
+const MAX_OUTPUT_TOKENS = 1_000_000;
+const DEFAULT_UNKNOWN_MAX_TOKENS = 16_384;
+const API_KEY_ONLY_MODEL_IDS = new Set(["grok-build-0.1"]);
+const MODEL_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+type ThinkingLevel = (typeof THINKING_LEVELS)[number];
+
+export type XaiCatalogSource = "remote" | "fresh-cache" | "stale-cache" | "curated-fallback";
+
+export interface XaiCatalogSelection {
+  models: XaiCatalogModel[];
+  source: XaiCatalogSource;
+  /** True when session_start can safely ask pi's registry to refresh an expired stored credential. */
+  needsAuthenticatedRefresh: boolean;
+}
+
+export interface XaiCatalogCredential {
+  access: string;
+}
+
+export interface XaiCatalogOptions {
+  credential?: XaiCatalogCredential | null;
+  forceRefresh?: boolean;
+  signal?: AbortSignal;
+  cachePath?: string;
+  now?: number;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  /** Set when pi has stored OAuth credentials that must be refreshed under its registry lock. */
+  refreshWhenCredentialsAvailable?: boolean;
+  /** Modification time of pi's credential store; newer-than-cache credentials force discovery. */
+  credentialChangedAt?: number;
+  /** Runtime ownership guard checked immediately before an atomic cache commit. */
+  commitAllowed?: () => boolean;
+}
+
+type CacheRecord = {
+  schemaVersion: number;
+  fetchedAt: number;
+  models: XaiCatalogModel[];
+};
+
+type CacheTombstone = {
+  schemaVersion: number;
+  invalidatedAt: number;
+  invalidated: true;
+};
+
+type FetchOutcome =
+  | { kind: "success"; models: XaiCatalogModel[] }
+  | { kind: "auth" | "permanent" | "transient" | "invalid-success" | "cancelled" };
+
+export class XaiCatalogCancelledError extends Error {
+  constructor() {
+    super("xAI model catalog refresh was cancelled");
+    this.name = "XaiCatalogCancelledError";
+  }
+}
+
+export class XaiCatalogValidationError extends Error {
+  constructor() {
+    super("xAI model catalog response was invalid");
+    this.name = "XaiCatalogValidationError";
+  }
+}
+
+/** Return the token-free last-known-good catalog cache path. */
+export function defaultXaiCatalogCachePath(): string {
+  return join(getAgentDir(), "cache", "pi-xai-oauth", "models-v2.json");
+}
+
+function objectValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    const result = nonEmptyString(value);
+    if (result) return result;
+  }
+  return undefined;
+}
+
+function firstValue(obj: Record<string, unknown>, meta: Record<string, unknown> | undefined, keys: string[]): unknown {
+  for (const key of keys) {
+    if (obj[key] !== undefined) return obj[key];
+  }
+  if (meta) {
+    for (const key of keys) {
+      if (meta[key] !== undefined) return meta[key];
+    }
+  }
+  return undefined;
+}
+
+function positiveInteger(value: unknown, maximum: number): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 && value <= maximum
+    ? value
+    : undefined;
+}
+
+function safeModelId(value: unknown): string | undefined {
+  const id = nonEmptyString(value);
+  if (!id || id.length > MAX_MODEL_ID_LENGTH || !MODEL_ID_PATTERN.test(id)) return undefined;
+  return id;
+}
+
+function safeDisplayName(value: unknown, fallback: string): string | undefined {
+  const name = nonEmptyString(value) ?? fallback;
+  if (name.length > MAX_MODEL_NAME_LENGTH || /[\u0000-\u001f\u007f]/.test(name)) return undefined;
+  return name;
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function canonicalReasoningLevel(value: unknown): ThinkingLevel | undefined {
+  const level = nonEmptyString(value)?.toLowerCase();
+  if (!level) return undefined;
+  if (level === "none") return "off";
+  if (level === "max") return "xhigh";
+  return THINKING_LEVELS.includes(level as ThinkingLevel) ? (level as ThinkingLevel) : undefined;
+}
+
+function parseReasoningLevels(value: unknown): ThinkingLevel[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) return [];
+  const result: ThinkingLevel[] = [];
+  for (const entry of value) {
+    const level = canonicalReasoningLevel(
+      typeof entry === "string" ? entry : objectValue(entry)?.value,
+    );
+    if (level && !result.includes(level)) result.push(level);
+  }
+  return result;
+}
+
+function thinkingLevelMap(levels: ThinkingLevel[], modelId: string): XaiCatalogModel["thinkingLevelMap"] {
+  const map: Record<ThinkingLevel, string | null> = {
+    off: null,
+    minimal: null,
+    low: null,
+    medium: null,
+    high: null,
+    xhigh: null,
+    max: null,
+  };
+  for (const level of levels) {
+    if (level === "off") map.off = "none";
+    else if (level === "max") map.max = "max";
+    else map[level] = level;
+  }
+  // Preserve pi-xai-oauth's existing Grok 4.5 compatibility: pi's minimal
+  // level is sent as xAI low when low is in the authenticated catalog.
+  if (modelId === "grok-4.5" && map.low === "low") map.minimal = "low";
+  return map;
+}
+
+function hasApiKeyOnlyIndicator(obj: Record<string, unknown>, meta: Record<string, unknown> | undefined): boolean {
+  if (["apiKey", "api_key", "envKey", "env_key"].some((key) => obj[key] !== undefined || meta?.[key] !== undefined)) {
+    return true;
+  }
+  const authScheme = firstString(
+    obj.authScheme,
+    obj.auth_scheme,
+    obj.authType,
+    obj.auth_type,
+    meta?.authScheme,
+    meta?.auth_scheme,
+  )?.toLowerCase();
+  return !!authScheme && ["api-key", "api_key", "apikey", "bearer-api-key"].includes(authScheme);
+}
+
+type EntryResult = { kind: "model"; model: XaiCatalogModel } | { kind: "excluded" } | { kind: "malformed" };
+
+function normalizeCatalogEntry(value: unknown): EntryResult {
+  const obj = objectValue(value);
+  if (!obj) return { kind: "malformed" };
+  const meta = objectValue(obj._meta);
+  const id = safeModelId(firstString(obj.model, obj.modelId, obj.id, meta?.model, meta?.modelId));
+  if (!id) return { kind: "malformed" };
+  const normalizedId = id.toLowerCase();
+  if (API_KEY_ONLY_MODEL_IDS.has(normalizedId) || hasApiKeyOnlyIndicator(obj, meta)) return { kind: "excluded" };
+  if (booleanValue(firstValue(obj, meta, ["hidden"])) === true) return { kind: "excluded" };
+
+  const backend = firstString(obj.apiBackend, obj.api_backend, meta?.apiBackend, meta?.api_backend)?.toLowerCase();
+  if (!backend) return { kind: "malformed" };
+  if (backend !== "responses") return { kind: "excluded" };
+
+  const contextValue = firstValue(obj, meta, ["contextWindow", "context_window", "totalContextTokens"]);
+  const contextWindow = positiveInteger(contextValue, MAX_CONTEXT_WINDOW);
+  if (!contextWindow) return { kind: "malformed" };
+
+  const maxValue = firstValue(obj, meta, ["maxCompletionTokens", "max_completion_tokens"]);
+  const suppliedMaxTokens = maxValue === undefined ? undefined : positiveInteger(maxValue, MAX_OUTPUT_TOKENS);
+  if (maxValue !== undefined && (!suppliedMaxTokens || suppliedMaxTokens > contextWindow)) {
+    return { kind: "malformed" };
+  }
+
+  const name = safeDisplayName(firstValue(obj, meta, ["name"]), id);
+  if (!name) return { kind: "malformed" };
+
+  const known = knownXaiModelMetadata(normalizedId);
+  const supportsReasoningEffort = booleanValue(
+    firstValue(obj, meta, ["supportsReasoningEffort", "supports_reasoning_effort"]),
+  );
+  const explicitReasoning = booleanValue(firstValue(obj, meta, ["reasoning", "supportsReasoning"]));
+  const defaultReasoningLevel = canonicalReasoningLevel(
+    firstValue(obj, meta, ["reasoningEffort", "reasoning_effort"]),
+  );
+  const suppliedReasoningLevels = parseReasoningLevels(
+    firstValue(obj, meta, ["reasoningEfforts", "reasoning_efforts"]),
+  );
+  const reasoning =
+    explicitReasoning ??
+    (supportsReasoningEffort === true || !!defaultReasoningLevel || !!suppliedReasoningLevels?.length
+      ? true
+      : known?.reasoning ?? false);
+
+  let levelMap: XaiCatalogModel["thinkingLevelMap"];
+  if (!reasoning) {
+    levelMap = known?.reasoning === false ? known.thinkingLevelMap : { off: "none" };
+  } else if (suppliedReasoningLevels !== undefined) {
+    levelMap = thinkingLevelMap(suppliedReasoningLevels, normalizedId);
+  } else if (defaultReasoningLevel) {
+    levelMap = thinkingLevelMap([defaultReasoningLevel], normalizedId);
+  } else if (supportsReasoningEffort === true) {
+    levelMap = thinkingLevelMap(["low", "medium", "high"], normalizedId);
+  } else {
+    levelMap = known?.thinkingLevelMap;
+  }
+
+  return {
+    kind: "model",
+    model: {
+      id,
+      name,
+      apiBackend: "responses",
+      reasoning,
+      input: known ? [...known.input] : ["text"],
+      cost: known ? { ...known.cost } : { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow,
+      maxTokens: Math.min(
+        suppliedMaxTokens ?? known?.maxTokens ?? DEFAULT_UNKNOWN_MAX_TOKENS,
+        contextWindow,
+      ),
+      ...(levelMap ? { thinkingLevelMap: levelMap } : {}),
+    },
+  };
+}
+
+/** Normalize an official `/models-v2` response into exact pi model definitions. */
+export function normalizeXaiCatalogPayload(payload: unknown): XaiCatalogModel[] {
+  const root = objectValue(payload);
+  if (!root || !Array.isArray(root.data) || root.data.length > MAX_CATALOG_ENTRIES) {
+    throw new XaiCatalogValidationError();
+  }
+
+  const models: XaiCatalogModel[] = [];
+  const seen = new Set<string>();
+  let excluded = 0;
+  let malformed = 0;
+  for (const entry of root.data) {
+    const result = normalizeCatalogEntry(entry);
+    if (result.kind === "excluded") {
+      excluded++;
+      continue;
+    }
+    if (result.kind === "malformed") {
+      malformed++;
+      continue;
+    }
+    const key = result.model.id.toLowerCase();
+    if (seen.has(key)) {
+      excluded++;
+      continue;
+    }
+    seen.add(key);
+    models.push(result.model);
+  }
+
+  if (root.data.length > 0 && models.length === 0 && malformed > 0) {
+    throw new XaiCatalogValidationError();
+  }
+  return models;
+}
+
+function cloneModels(models: readonly XaiCatalogModel[]): XaiCatalogModel[] {
+  return models.map((model) => ({
+    ...model,
+    input: [...model.input],
+    cost: { ...model.cost },
+    ...(model.thinkingLevelMap ? { thinkingLevelMap: { ...model.thinkingLevelMap } } : {}),
+  }));
+}
+
+function fallbackSelection(needsAuthenticatedRefresh: boolean): XaiCatalogSelection {
+  return {
+    models: cloneModels(CURATED_FALLBACK_MODELS),
+    source: "curated-fallback",
+    needsAuthenticatedRefresh,
+  };
+}
+
+function validateCachedModel(value: unknown): XaiCatalogModel | undefined {
+  const obj = objectValue(value);
+  if (!obj) return undefined;
+  const id = safeModelId(obj.id);
+  const name = id ? safeDisplayName(obj.name, id) : undefined;
+  const contextWindow = positiveInteger(obj.contextWindow, MAX_CONTEXT_WINDOW);
+  const maxTokens = positiveInteger(obj.maxTokens, MAX_OUTPUT_TOKENS);
+  const cost = objectValue(obj.cost);
+  const input = Array.isArray(obj.input)
+    ? obj.input.filter((item): item is "text" | "image" => item === "text" || item === "image")
+    : [];
+  if (
+    !id ||
+    !name ||
+    obj.apiBackend !== "responses" ||
+    typeof obj.reasoning !== "boolean" ||
+    !contextWindow ||
+    !maxTokens ||
+    maxTokens > contextWindow ||
+    !cost ||
+    input.length === 0
+  ) return undefined;
+  const rates = [cost.input, cost.output, cost.cacheRead, cost.cacheWrite];
+  if (!rates.every((rate) => typeof rate === "number" && Number.isFinite(rate) && rate >= 0)) return undefined;
+
+  let map: XaiCatalogModel["thinkingLevelMap"];
+  if (obj.thinkingLevelMap !== undefined) {
+    const rawMap = objectValue(obj.thinkingLevelMap);
+    if (!rawMap) return undefined;
+    const normalized: Partial<Record<ThinkingLevel, string | null>> = {};
+    for (const level of THINKING_LEVELS) {
+      const mapped = rawMap[level];
+      if (mapped === undefined) continue;
+      if (mapped !== null && (typeof mapped !== "string" || !mapped.trim() || mapped.length > 32)) return undefined;
+      normalized[level] = mapped;
+    }
+    map = normalized;
+  }
+
+  return {
+    id,
+    name,
+    apiBackend: "responses",
+    reasoning: obj.reasoning,
+    input: [...new Set(input)],
+    cost: {
+      input: cost.input as number,
+      output: cost.output as number,
+      cacheRead: cost.cacheRead as number,
+      cacheWrite: cost.cacheWrite as number,
+    },
+    contextWindow,
+    maxTokens,
+    ...(map ? { thinkingLevelMap: map } : {}),
+  };
+}
+
+async function readCache(cachePath: string, now: number): Promise<CacheRecord | undefined> {
+  try {
+    const info = await lstat(cachePath);
+    if (info.isSymbolicLink() || !info.isFile() || info.size <= 0 || info.size > XAI_MODEL_CATALOG_MAX_BYTES) return undefined;
+    if ((info.mode & 0o077) !== 0) await chmod(cachePath, 0o600);
+    await chmod(dirname(cachePath), 0o700).catch(() => {});
+    const parsed = JSON.parse(await readFile(cachePath, "utf8")) as unknown;
+    const obj = objectValue(parsed);
+    if (!obj || obj.schemaVersion !== XAI_MODEL_CATALOG_CACHE_SCHEMA || obj.invalidated === true) return undefined;
+    const fetchedAt = typeof obj.fetchedAt === "number" && Number.isFinite(obj.fetchedAt) ? obj.fetchedAt : undefined;
+    if (!fetchedAt || fetchedAt > now + 5 * 60 * 1000 || now - fetchedAt > XAI_MODEL_CATALOG_MAX_STALE_MS) return undefined;
+    if (!Array.isArray(obj.models) || obj.models.length > MAX_CATALOG_ENTRIES) return undefined;
+    const models = obj.models.map(validateCachedModel);
+    if (models.some((model) => !model)) return undefined;
+    const ids = new Set<string>();
+    for (const model of models as XaiCatalogModel[]) {
+      const key = model.id.toLowerCase();
+      if (ids.has(key) || API_KEY_ONLY_MODEL_IDS.has(key)) return undefined;
+      ids.add(key);
+    }
+    return { schemaVersion: XAI_MODEL_CATALOG_CACHE_SCHEMA, fetchedAt, models: models as XaiCatalogModel[] };
+  } catch {
+    return undefined;
+  }
+}
+
+const cacheWriteQueues = new Map<string, Promise<void>>();
+
+async function withCacheWriteQueue(cachePath: string, operation: () => Promise<void>): Promise<void> {
+  const previous = cacheWriteQueues.get(cachePath) ?? Promise.resolve();
+  const current = previous.catch(() => {}).then(operation);
+  cacheWriteQueues.set(cachePath, current);
+  try {
+    await current;
+  } finally {
+    if (cacheWriteQueues.get(cachePath) === current) cacheWriteQueues.delete(cachePath);
+  }
+}
+
+async function writeAtomicJson(
+  cachePath: string,
+  value: CacheRecord | CacheTombstone,
+  commitAllowed: () => boolean = () => true,
+): Promise<void> {
+  const directory = dirname(cachePath);
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  await chmod(directory, 0o700);
+  const tempPath = join(directory, `.models-v2-${process.pid}-${crypto.randomUUID()}.tmp`);
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    handle = await open(tempPath, "wx", 0o600);
+    await handle.writeFile(`${JSON.stringify(value)}\n`, "utf8");
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    if (!commitAllowed()) throw new XaiCatalogCancelledError();
+    await rename(tempPath, cachePath);
+    await chmod(cachePath, 0o600);
+  } catch (error) {
+    await handle?.close().catch(() => {});
+    await unlink(tempPath).catch(() => {});
+    throw error;
+  }
+}
+
+async function cacheMatchesRecord(cachePath: string, expected: CacheRecord): Promise<boolean> {
+  try {
+    const value = JSON.parse(await readFile(cachePath, "utf8")) as unknown;
+    const obj = objectValue(value);
+    return !!obj &&
+      obj.schemaVersion === expected.schemaVersion &&
+      obj.fetchedAt === expected.fetchedAt &&
+      JSON.stringify(obj.models) === JSON.stringify(expected.models);
+  } catch {
+    return false;
+  }
+}
+
+async function restorePreviousCache(cachePath: string, previous: CacheRecord | undefined): Promise<void> {
+  if (previous) {
+    await writeAtomicJson(cachePath, previous);
+  } else {
+    await unlink(cachePath).catch(() => {});
+  }
+}
+
+async function invalidateCache(
+  cachePath: string,
+  now: number,
+  commitAllowed: () => boolean = () => true,
+  previous?: CacheRecord,
+): Promise<void> {
+  try {
+    await withCacheWriteQueue(cachePath, async () => {
+      await writeAtomicJson(cachePath, {
+        schemaVersion: XAI_MODEL_CATALOG_CACHE_SCHEMA,
+        invalidatedAt: now,
+        invalidated: true,
+      }, commitAllowed);
+      if (!commitAllowed()) {
+        await restorePreviousCache(cachePath, previous);
+        throw new XaiCatalogCancelledError();
+      }
+    });
+  } catch (error) {
+    if (error instanceof XaiCatalogCancelledError) return;
+    await unlink(cachePath).catch(() => {});
+  }
+}
+
+async function readBoundedBody(response: Response): Promise<string> {
+  const contentLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > XAI_MODEL_CATALOG_MAX_BYTES) {
+    throw new XaiCatalogValidationError();
+  }
+  if (!response.body) {
+    const text = await response.text();
+    if (Buffer.byteLength(text) > XAI_MODEL_CATALOG_MAX_BYTES) throw new XaiCatalogValidationError();
+    return text;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > XAI_MODEL_CATALOG_MAX_BYTES) throw new XaiCatalogValidationError();
+      chunks.push(value);
+    }
+  } catch (error) {
+    await reader.cancel().catch(() => {});
+    throw error;
+  }
+  return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk))).toString("utf8");
+}
+
+function composeAbortSignal(signal: AbortSignal | undefined, timeoutMs: number): {
+  signal: AbortSignal;
+  dispose: () => void;
+} {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const abort = () => controller.abort();
+  signal?.addEventListener("abort", abort, { once: true });
+  if (signal?.aborted) controller.abort();
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", abort);
+    },
+  };
+}
+
+/** Fetch and normalize the authenticated OAuth-visible catalog from the pinned proxy. */
+export async function fetchXaiModelCatalog(
+  credential: XaiCatalogCredential,
+  options: Pick<XaiCatalogOptions, "signal" | "fetchImpl" | "timeoutMs"> = {},
+): Promise<FetchOutcome> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const abort = composeAbortSignal(options.signal, options.timeoutMs ?? XAI_MODEL_CATALOG_TIMEOUT_MS);
+  try {
+    let response: Response;
+    try {
+      response = await fetchImpl(XAI_CLI_MODELS_URL, {
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${credential.access}`,
+          "X-XAI-Token-Auth": "xai-grok-cli",
+          "x-grok-client-identifier": XAI_CLIENT_IDENTIFIER,
+          "x-grok-client-version": XAI_CLIENT_VERSION,
+          "x-grok-client-mode": resolveXaiClientMode(),
+        },
+        redirect: "error",
+        signal: abort.signal,
+      });
+    } catch {
+      return { kind: options.signal?.aborted ? "cancelled" : "transient" };
+    }
+
+    if (options.signal?.aborted) return { kind: "cancelled" };
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403) return { kind: "auth" };
+      if (response.status === 408 || response.status === 425 || response.status === 429 || response.status >= 500) {
+        return { kind: "transient" };
+      }
+      return { kind: "permanent" };
+    }
+
+    try {
+      const body = await readBoundedBody(response);
+      if (options.signal?.aborted) return { kind: "cancelled" };
+      const models = normalizeXaiCatalogPayload(JSON.parse(body));
+      if (options.signal?.aborted) return { kind: "cancelled" };
+      return { kind: "success", models };
+    } catch {
+      return { kind: options.signal?.aborted ? "cancelled" : "invalid-success" };
+    }
+  } finally {
+    abort.dispose();
+  }
+}
+
+/**
+ * Select a startup/login catalog from fresh cache, authenticated discovery,
+ * stale-if-transient last-known-good data, or the curated fallback.
+ */
+export async function selectXaiModelCatalog(options: XaiCatalogOptions = {}): Promise<XaiCatalogSelection> {
+  const now = options.now ?? Date.now();
+  const cachePath = options.cachePath ?? defaultXaiCatalogCachePath();
+  const cache = await readCache(cachePath, now);
+  const forceRefresh = options.forceRefresh === true;
+
+  const refreshWhenCredentialsAvailable = options.refreshWhenCredentialsAvailable === true;
+  if (!options.credential?.access && !refreshWhenCredentialsAvailable) {
+    return fallbackSelection(false);
+  }
+  const credentialsChanged =
+    typeof options.credentialChangedAt === "number" &&
+    Number.isFinite(options.credentialChangedAt) &&
+    !!cache &&
+    options.credentialChangedAt > cache.fetchedAt;
+  if (!forceRefresh && !credentialsChanged && cache && now - cache.fetchedAt < XAI_MODEL_CATALOG_FRESH_TTL_MS) {
+    return {
+      models: cloneModels(cache.models),
+      source: "fresh-cache",
+      needsAuthenticatedRefresh: refreshWhenCredentialsAvailable,
+    };
+  }
+  if (!options.credential?.access) return fallbackSelection(refreshWhenCredentialsAvailable);
+
+  const commitAllowed = () => !options.signal?.aborted && options.commitAllowed?.() !== false;
+  const outcome = await fetchXaiModelCatalog(options.credential, options);
+  if (outcome.kind === "cancelled" || !commitAllowed()) {
+    throw new XaiCatalogCancelledError();
+  }
+  if (outcome.kind === "success") {
+    const record: CacheRecord = {
+      schemaVersion: XAI_MODEL_CATALOG_CACHE_SCHEMA,
+      fetchedAt: now,
+      models: cloneModels(outcome.models),
+    };
+    try {
+      await withCacheWriteQueue(cachePath, async () => {
+        await writeAtomicJson(cachePath, record, commitAllowed);
+        if (!commitAllowed()) {
+          await restorePreviousCache(cachePath, cache);
+          throw new XaiCatalogCancelledError();
+        }
+      });
+    } catch (error) {
+      if (error instanceof XaiCatalogCancelledError) throw error;
+      // Never leave a previous account's cache looking fresh after a successful
+      // response that could not be committed atomically.
+      await invalidateCache(
+        cachePath,
+        now,
+        commitAllowed,
+        cache,
+      );
+    }
+    if (!commitAllowed()) {
+      await withCacheWriteQueue(cachePath, async () => {
+        if (await cacheMatchesRecord(cachePath, record)) {
+          await restorePreviousCache(cachePath, cache);
+        }
+      });
+      throw new XaiCatalogCancelledError();
+    }
+    return { models: cloneModels(outcome.models), source: "remote", needsAuthenticatedRefresh: false };
+  }
+
+  if (!commitAllowed()) throw new XaiCatalogCancelledError();
+  if (forceRefresh || outcome.kind === "auth" || outcome.kind === "permanent") {
+    await invalidateCache(
+      cachePath,
+      now,
+      commitAllowed,
+      cache,
+    );
+    if (!commitAllowed()) throw new XaiCatalogCancelledError();
+    return fallbackSelection(false);
+  }
+  if (cache) {
+    return { models: cloneModels(cache.models), source: "stale-cache", needsAuthenticatedRefresh: false };
+  }
+  return fallbackSelection(false);
+}

--- a/extensions/xai/constants.ts
+++ b/extensions/xai/constants.ts
@@ -19,7 +19,14 @@ export const XAI_API_BASE_URL = "https://api.x.ai/v1";
 export const XAI_CLI_BASE_URL = "https://cli-chat-proxy.grok.com/v1";
 export const XAI_RESPONSES_URL = "https://api.x.ai/v1/responses";
 export const XAI_CLI_RESPONSES_URL = "https://cli-chat-proxy.grok.com/v1/responses";
+export const XAI_CLI_MODELS_URL = "https://cli-chat-proxy.grok.com/v1/models-v2";
 export const XAI_IMAGES_GENERATIONS_URL = "https://api.x.ai/v1/images/generations";
+
+export const XAI_MODEL_CATALOG_CACHE_SCHEMA = 1;
+export const XAI_MODEL_CATALOG_FRESH_TTL_MS = 15 * 60 * 1000;
+export const XAI_MODEL_CATALOG_MAX_STALE_MS = 7 * 24 * 60 * 60 * 1000;
+export const XAI_MODEL_CATALOG_TIMEOUT_MS = 5 * 1000;
+export const XAI_MODEL_CATALOG_MAX_BYTES = 1024 * 1024;
 
 export const XAI_CLIENT_IDENTIFIER = packageMetadata.name;
 export const XAI_CLIENT_VERSION = packageMetadata.version;

--- a/extensions/xai/models.ts
+++ b/extensions/xai/models.ts
@@ -7,10 +7,30 @@ import {
 } from "./constants";
 import { resolveXaiRoute, type XaiCredentialKind } from "./routing";
 
-export const MODELS = [
+export type XaiCatalogModel = {
+  id: string;
+  name: string;
+  apiBackend: "responses";
+  reasoning: boolean;
+  input: ("text" | "image")[];
+  cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
+  contextWindow: number;
+  maxTokens: number;
+  thinkingLevelMap?: Model<Api>["thinkingLevelMap"];
+};
+
+/**
+ * Curated metadata for known xAI models.
+ *
+ * This table enriches models that the authenticated catalog actually returns;
+ * it is not the provider advertisement and must never be unioned into a
+ * successful entitlement response.
+ */
+export const KNOWN_XAI_MODEL_METADATA: readonly XaiCatalogModel[] = [
   {
     id: "grok-4.5",
     name: "Grok 4.5",
+    apiBackend: "responses",
     reasoning: true,
     input: ["text", "image"],
     cost: { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 0 },
@@ -30,6 +50,7 @@ export const MODELS = [
   {
     id: "grok-4.3",
     name: "Grok 4.3",
+    apiBackend: "responses",
     reasoning: true,
     input: ["text", "image"],
     cost: { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 0 },
@@ -39,6 +60,7 @@ export const MODELS = [
   {
     id: "grok-build",
     name: "Grok Build",
+    apiBackend: "responses",
     reasoning: true,
     input: ["text", "image"],
     cost: { input: 1, output: 2, cacheRead: 0.2, cacheWrite: 0.2 },
@@ -48,6 +70,7 @@ export const MODELS = [
   {
     id: "grok-composer-2.5-fast",
     name: "Composer 2.5 Fast",
+    apiBackend: "responses",
     reasoning: false,
     input: ["text", "image"],
     cost: { input: 3, output: 15, cacheRead: 0.5, cacheWrite: 0 },
@@ -65,6 +88,7 @@ export const MODELS = [
   {
     id: "grok-4.20-0309-reasoning",
     name: "Grok 4.20 Reasoning",
+    apiBackend: "responses",
     reasoning: true,
     input: ["text", "image"],
     cost: { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 0 },
@@ -74,6 +98,7 @@ export const MODELS = [
   {
     id: "grok-4.20-0309-non-reasoning",
     name: "Grok 4.20 Non-Reasoning",
+    apiBackend: "responses",
     reasoning: false,
     input: ["text", "image"],
     cost: { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 0 },
@@ -83,6 +108,7 @@ export const MODELS = [
   {
     id: "grok-4.20-multi-agent-0309",
     name: "Grok 4.20 Multi-Agent",
+    apiBackend: "responses",
     reasoning: true,
     input: ["text", "image"],
     cost: { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 0 },
@@ -91,13 +117,52 @@ export const MODELS = [
   },
 ];
 
+const KNOWN_MODEL_MAP = new Map(KNOWN_XAI_MODEL_METADATA.map((model) => [model.id, model]));
+
+/** Minimal catalog used only when authenticated discovery cannot be used safely. */
+export const CURATED_FALLBACK_MODELS: readonly XaiCatalogModel[] = [
+  { ...KNOWN_MODEL_MAP.get(DEFAULT_XAI_MODEL)! },
+];
+
+/** Backward-compatible alias for the curated offline fallback. */
+export const MODELS = CURATED_FALLBACK_MODELS;
+
+let runtimeModels: readonly XaiCatalogModel[] = CURATED_FALLBACK_MODELS;
+
+/** Replace request-helper metadata with the current entitlement snapshot. */
+export function setXaiRuntimeModels(models: readonly XaiCatalogModel[]): void {
+  runtimeModels = models.map((model) => ({ ...model }));
+}
+
+/** Return the current entitlement snapshot used by direct request helpers. */
+export function getXaiRuntimeModels(): readonly XaiCatalogModel[] {
+  return runtimeModels;
+}
+
+/** Return true only when the active OAuth catalog currently advertises a model. */
+export function isXaiRuntimeModelEntitled(modelId: string): boolean {
+  const normalized = normalizedXaiModelId(modelId);
+  return runtimeModels.some((model) => model.id.toLowerCase() === normalized);
+}
+
+/** Choose the default model from the active OAuth catalog, if one exists. */
+export function defaultXaiRuntimeModelId(): string | undefined {
+  return runtimeModels.find((model) => model.id === DEFAULT_XAI_MODEL)?.id ?? runtimeModels[0]?.id;
+}
+
+/** Return curated metadata for a known model without advertising it. */
+export function knownXaiModelMetadata(modelId: string): XaiCatalogModel | undefined {
+  return KNOWN_MODEL_MAP.get(normalizedXaiModelId(modelId));
+}
+
 /** Build a pi model object for a credential-aware direct xAI request. */
 export function xaiModelForRequest(modelId: string | undefined, credentialKind: XaiCredentialKind): Model<Api> {
   const id = modelId || DEFAULT_XAI_MODEL;
   const model =
-    MODELS.find((candidate) => candidate.id === id) ||
-    MODELS.find((candidate) => candidate.id === DEFAULT_XAI_MODEL) ||
-    MODELS[0];
+    runtimeModels.find((candidate) => candidate.id === id) ||
+    knownXaiModelMetadata(id) ||
+    runtimeModels.find((candidate) => candidate.id === DEFAULT_XAI_MODEL) ||
+    CURATED_FALLBACK_MODELS[0];
   return {
     ...model,
     id,
@@ -172,6 +237,12 @@ export function xaiProxyRequestHeaders(
 /** Return true when xAI accepts an explicit Responses reasoning effort. */
 export function grokSupportsReasoningEffort(modelId: string): boolean {
   const normalized = normalizedXaiModelId(modelId);
+  const runtime = runtimeModels.find((model) => model.id === normalized);
+  if (runtime?.thinkingLevelMap) {
+    return ["minimal", "low", "medium", "high", "xhigh", "max"].some(
+      (level) => typeof (runtime.thinkingLevelMap as Record<string, unknown>)[level] === "string",
+    );
+  }
   return (
     normalized.startsWith("grok-3-mini") ||
     normalized.startsWith("grok-4.20-multi-agent") ||

--- a/extensions/xai/models.ts
+++ b/extensions/xai/models.ts
@@ -237,7 +237,7 @@ export function xaiProxyRequestHeaders(
 /** Return true when xAI accepts an explicit Responses reasoning effort. */
 export function grokSupportsReasoningEffort(modelId: string): boolean {
   const normalized = normalizedXaiModelId(modelId);
-  const runtime = runtimeModels.find((model) => model.id === normalized);
+  const runtime = runtimeModels.find((model) => model.id.toLowerCase() === normalized);
   if (runtime?.thinkingLevelMap) {
     return ["minimal", "low", "medium", "high", "xhigh", "max"].some(
       (level) => typeof (runtime.thinkingLevelMap as Record<string, unknown>)[level] === "string",

--- a/extensions/xai/oauth.ts
+++ b/extensions/xai/oauth.ts
@@ -36,6 +36,7 @@ const RAW_CODE_MIGRATION_MESSAGE =
 
 type XaiOAuthOptions = {
   getExistingCredentials: () => OAuthCredentials | null;
+  onLoginCredentials?: (credentials: OAuthCredentials, callbacks: OAuthLoginCallbacks) => Promise<void>;
 };
 
 function messageFromError(error: unknown): string {
@@ -337,7 +338,24 @@ function credentialsFromTokenPayload(
 }
 
 /** Build pi's OAuth provider config for xAI/Grok login and refresh. */
-export function createXaiOAuth({ getExistingCredentials }: XaiOAuthOptions) {
+export function createXaiOAuth({ getExistingCredentials, onLoginCredentials }: XaiOAuthOptions) {
+  const finishLogin = async (
+    credentials: OAuthCredentials,
+    callbacks: OAuthLoginCallbacks,
+  ): Promise<OAuthCredentials> => {
+    assertLoginNotCancelled(callbacks.signal);
+    if (!onLoginCredentials) return credentials;
+    try {
+      await onLoginCredentials(credentials, callbacks);
+      assertLoginNotCancelled(callbacks.signal);
+    } catch (error) {
+      if (callbacks.signal?.aborted) throw new Error("xAI OAuth login was cancelled");
+      // Catalog discovery must never discard an otherwise valid OAuth login.
+      callbacks.onProgress?.("xAI login succeeded, but the model catalog could not be refreshed; using the curated fallback.");
+    }
+    return credentials;
+  };
+
   return {
     usesCallbackServer: true,
     name: "xAI (Grok)",
@@ -351,9 +369,10 @@ export function createXaiOAuth({ getExistingCredentials }: XaiOAuthOptions) {
         });
         if (useExisting.toLowerCase().startsWith("y")) {
           try {
-            return await runAbortableLoginStep(callbacks.signal, () =>
+            const credentials = await runAbortableLoginStep(callbacks.signal, () =>
               ensureFreshXaiCredentials(existingCredentials, callbacks.signal),
             );
+            return finishLogin(credentials, callbacks);
           } catch (error) {
             callbacks.onProgress?.(
               `Existing Grok CLI credentials could not be refreshed (${messageFromError(error)}). Starting a fresh xAI OAuth login...`,
@@ -456,7 +475,10 @@ export function createXaiOAuth({ getExistingCredentials }: XaiOAuthOptions) {
       );
       assertLoginNotCancelled(callbacks.signal);
 
-      return credentialsFromTokenPayload(data, discovery.token_endpoint, "", data.id_token);
+      return finishLogin(
+        credentialsFromTokenPayload(data, discovery.token_endpoint, "", data.id_token),
+        callbacks,
+      );
     },
 
     async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {

--- a/extensions/xai/responses.ts
+++ b/extensions/xai/responses.ts
@@ -2,7 +2,7 @@ import type { Api, Context, Model, SimpleStreamOptions } from "@earendil-works/p
 import { openAIResponsesApi } from "@earendil-works/pi-ai/compat";
 import { randomUUID } from "crypto";
 import { compactXaiInlineImages } from "./images";
-import { xaiModelForRequest, xaiProxyRequestHeaders } from "./models";
+import { isXaiRuntimeModelEntitled, xaiModelForRequest, xaiProxyRequestHeaders } from "./models";
 import { rewriteXaiResponsesPayload } from "./payload";
 import { resolveXaiRoute, type XaiCredential } from "./routing";
 
@@ -147,7 +147,11 @@ export async function createXaiResponse(
   body: Record<string, any>,
   signal?: AbortSignal,
 ): Promise<any> {
-  const model = xaiModelForRequest(typeof body.model === "string" ? body.model : undefined, credential.kind);
+  const requestedModel = typeof body.model === "string" ? body.model : undefined;
+  const model = xaiModelForRequest(requestedModel, credential.kind);
+  if (credential.kind === "oauth-session" && !isXaiRuntimeModelEntitled(model.id)) {
+    throw new Error(`xAI OAuth model ${model.id} is not present in the authenticated model catalog`);
+  }
   const route = resolveXaiRoute(credential.kind, "responses");
   const rewritten = rewriteXaiResponsesPayload(body, model);
   const payload = (await compactXaiInlineImages(rewritten)) as Record<string, any>;
@@ -177,6 +181,17 @@ export async function createXaiResponse(
  * @returns A forwarding assistant stream compatible with pi's async iterator and `result()` contract.
  */
 export function streamSimpleXaiResponses(model: Model<Api>, context: Context, options?: SimpleStreamOptions) {
+  if (!isXaiRuntimeModelEntitled(model.id)) {
+    const stream = createForwardingAssistantStream();
+    const message = streamErrorMessage(
+      model,
+      new Error(`xAI OAuth model ${model.id} is not present in the authenticated model catalog`),
+    );
+    stream.push({ type: "error", reason: "error", error: message });
+    stream.end(message);
+    return stream;
+  }
+
   // The registered xai-auth provider is OAuth-only, so bind its stream to
   // session-token routing instead of inferring credential provenance from the
   // bearer string.

--- a/extensions/xai/tools/custom-tools.ts
+++ b/extensions/xai/tools/custom-tools.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { resolveXaiCredential } from "../auth";
 import { DEFAULT_XAI_IMAGE_MODEL, DEFAULT_XAI_MODEL } from "../constants";
 import { normalizeXaiImageInput } from "../images";
-import { grokSupportsReasoningEffort, normalizedXaiModelId } from "../models";
+import { defaultXaiRuntimeModelId, grokSupportsReasoningEffort, normalizedXaiModelId } from "../models";
 import { createXaiResponse, postXaiJson } from "../responses";
 import { resolveXaiRoute } from "../routing";
 import { extractResponsesText, messageFromError, statusFromError } from "../text";
@@ -33,7 +33,7 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
         type: "object",
         properties: {
           prompt: { type: "string", description: "The prompt or question" },
-          model: { type: "string", description: "Model to use", default: DEFAULT_XAI_MODEL },
+          model: { type: "string", description: "Entitled OAuth model to use; defaults to the active xAI model" },
           reasoning_effort: {
             type: "string",
             enum: ["none", "low", "medium", "high"],
@@ -47,15 +47,14 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
         required: ["prompt"],
       },
       execute: async (_toolCallId: string, params: any, _signal: any, _onUpdate: any, ctx: any) => {
-        if (!activeModelForXaiTool(pi, ctx, "xai_generate_text")) {
-          return xaiToolDisabledError("xai_generate_text", { prompt: params?.prompt });
-        }
+        const activeModel = activeModelForXaiTool(pi, ctx, "xai_generate_text");
+        if (!activeModel) return xaiToolDisabledError("xai_generate_text", { prompt: params?.prompt });
         const credential = await resolveXaiCredential(ctx);
         if (!credential) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { reasoning: "", response_id: "" });
         }
 
-        const model = params.model || DEFAULT_XAI_MODEL;
+        const model = params.model || activeModel.id || defaultXaiRuntimeModelId() || DEFAULT_XAI_MODEL;
         const imageUrl = normalizeXaiImageInput(params.image_url);
         const input = imageUrl
           ? [
@@ -270,9 +269,8 @@ Be specific and cite examples where helpful.`;
         required: ["code"],
       },
       execute: async (_toolCallId: string, params: { code?: string }, _signal: any, _onUpdate: any, ctx: any) => {
-        if (!activeModelForXaiTool(pi, ctx, "xai_code_execution")) {
-          return xaiToolDisabledError("xai_code_execution", { code: params?.code });
-        }
+        const activeModel = activeModelForXaiTool(pi, ctx, "xai_code_execution");
+        if (!activeModel) return xaiToolDisabledError("xai_code_execution", { code: params?.code });
         const credential = await resolveXaiCredential(ctx);
         if (!credential) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { code: params?.code });
@@ -281,7 +279,7 @@ Be specific and cite examples where helpful.`;
         let data: any;
         try {
           data = await createXaiResponse(credential, {
-            model: DEFAULT_XAI_MODEL,
+            model: activeModel.id,
             input: xaiTextInput(prompt),
             reasoning: { effort: "low" },
             tools: [{ type: "code_interpreter" }],
@@ -372,9 +370,8 @@ Be specific and cite examples where helpful.`;
         required: ["content"],
       },
       execute: async (_toolCallId: string, params: { content?: string; aspect?: string; tone?: string }, _signal: any, _onUpdate: any, ctx: any) => {
-        if (!activeModelForXaiTool(pi, ctx, "xai_critique")) {
-          return xaiToolDisabledError("xai_critique", { content: params?.content });
-        }
+        const activeModel = activeModelForXaiTool(pi, ctx, "xai_critique");
+        if (!activeModel) return xaiToolDisabledError("xai_critique", { content: params?.content });
         const credential = await resolveXaiCredential(ctx);
         if (!credential) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { content: params?.content });
@@ -384,7 +381,7 @@ Be specific and cite examples where helpful.`;
         const prompt = `Provide a ${tone} critique focused on ${aspect}.\n\nContent to critique:\n${params.content}\n\nStructure your response with:\n- Strengths\n- Weaknesses / Issues\n- Specific suggestions for improvement\n- Overall assessment (score 1-10)\nUse step-by-step reasoning.`;
         let data: any;
         try {
-          data = await createXaiResponse(credential, { model: DEFAULT_XAI_MODEL, input: xaiTextInput(prompt), reasoning: { effort: "high" } }, _signal);
+          data = await createXaiResponse(credential, { model: activeModel.id, input: xaiTextInput(prompt), reasoning: { effort: "high" } }, _signal);
         } catch (error) {
           const status = statusFromError(error);
           return xaiToolError(`xAI API Error${status ? ` ${status}` : ""}: ${messageFromError(error)}`, { error: true, status });
@@ -408,9 +405,8 @@ Be specific and cite examples where helpful.`;
         required: ["image"],
       },
       execute: async (_toolCallId: string, params: { image?: string; question?: string }, _signal: any, _onUpdate: any, ctx: any) => {
-        if (!activeModelForXaiTool(pi, ctx, "xai_analyze_image")) {
-          return xaiToolDisabledError("xai_analyze_image", { image: params?.image });
-        }
+        const activeModel = activeModelForXaiTool(pi, ctx, "xai_analyze_image");
+        if (!activeModel) return xaiToolDisabledError("xai_analyze_image", { image: params?.image });
         const credential = await resolveXaiCredential(ctx);
         if (!credential) {
           return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { image: params?.image });
@@ -420,7 +416,7 @@ Be specific and cite examples where helpful.`;
         const input = [{ role: "user", content: [{ type: "input_image", image_url: imageInput, detail: "high" }, { type: "input_text", text: question }] }];
         let data: any;
         try {
-          data = await createXaiResponse(credential, { model: DEFAULT_XAI_MODEL, input, reasoning: { effort: "medium" } }, _signal);
+          data = await createXaiResponse(credential, { model: activeModel.id, input, reasoning: { effort: "medium" } }, _signal);
         } catch (error) {
           const status = statusFromError(error);
           return xaiToolError(`xAI API Error${status ? ` ${status}` : ""}: ${messageFromError(error)}`, { error: true, status, image: params.image });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-xai-oauth",
   "version": "1.3.5",
-  "description": "One-command installer for xAI OAuth provider + Grok 4.5, Grok Build, and Composer models in pi",
+  "description": "xAI OAuth provider with an authenticated account-specific Grok model catalog for pi",
   "keywords": [
     "pi-package",
     "xai",
@@ -23,7 +23,7 @@
   "scripts": {
     "scaffold": "node bin/setup.js --scaffold",
     "setup": "node bin/setup.js",
-    "test": "node scripts/verify-extension.js && node scripts/verify-setup.js",
+    "test": "node scripts/verify-catalog.js && node scripts/verify-extension.js && node scripts/verify-setup.js",
     "typecheck": "npx tsc --noEmit"
   },
   "pi": {

--- a/scripts/fixtures/models-v2/additions.json
+++ b/scripts/fixtures/models-v2/additions.json
@@ -1,0 +1,39 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "grok-4.5",
+      "model": "grok-4.5",
+      "name": "Grok 4.5",
+      "api_backend": "responses",
+      "context_window": 500000,
+      "supports_reasoning_effort": true,
+      "reasoning_effort": "high",
+      "reasoning_efforts": [
+        { "id": "high", "value": "high", "label": "High Effort", "default": true },
+        { "id": "medium", "value": "medium", "label": "Medium Effort", "default": false },
+        "low"
+      ]
+    },
+    {
+      "modelId": "grok-composer-2.5-fast",
+      "name": "Composer 2.5",
+      "apiBackend": "responses",
+      "contextWindow": 200000,
+      "maxCompletionTokens": 30000
+    },
+    {
+      "id": "grok-new-oauth-model",
+      "name": "Grok New OAuth Model",
+      "apiBackend": "responses",
+      "contextWindow": 262144,
+      "maxCompletionTokens": 24576,
+      "supportsReasoningEffort": true,
+      "reasoningEfforts": [
+        { "id": "deep", "value": "xhigh", "label": "Deep" },
+        { "value": "invalid" },
+        "medium"
+      ]
+    }
+  ]
+}

--- a/scripts/fixtures/models-v2/api-key-only.json
+++ b/scripts/fixtures/models-v2/api-key-only.json
@@ -1,0 +1,41 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "model": "grok-build-0.1",
+      "name": "Grok Build 0.1",
+      "api_backend": "responses",
+      "context_window": 131072
+    },
+    {
+      "model": "explicit-api-key-model",
+      "apiBackend": "responses",
+      "contextWindow": 131072,
+      "apiKey": "MUST_NOT_REACH_CACHE"
+    },
+    {
+      "model": "env-api-key-model",
+      "api_backend": "responses",
+      "context_window": 131072,
+      "env_key": "XAI_API_KEY"
+    },
+    {
+      "model": "auth-scheme-api-key-model",
+      "api_backend": "responses",
+      "context_window": 131072,
+      "auth_scheme": "api-key"
+    },
+    {
+      "model": "oauth-safe-model",
+      "name": "OAuth Safe Model",
+      "api_backend": "responses",
+      "context_window": 131072
+    },
+    {
+      "model": "oauth-safe-model",
+      "name": "Duplicate Must Not Win",
+      "api_backend": "responses",
+      "context_window": 999999
+    }
+  ]
+}

--- a/scripts/fixtures/models-v2/malformed.json
+++ b/scripts/fixtures/models-v2/malformed.json
@@ -1,0 +1,23 @@
+{
+  "object": "list",
+  "data": [
+    null,
+    "not-an-object",
+    { "model": "missing-backend", "context_window": 100000 },
+    { "model": "missing-context", "api_backend": "responses" },
+    { "model": "bad context", "api_backend": "responses", "context_window": 100000 },
+    { "model": "negative-context", "api_backend": "responses", "context_window": -1 },
+    { "model": "oversized-output", "api_backend": "responses", "context_window": 10000, "max_completion_tokens": 20000 },
+    { "model": "hidden-model", "api_backend": "responses", "context_window": 100000, "hidden": true },
+    { "model": "chat-only-model", "api_backend": "chat_completions", "context_window": 100000 },
+    {
+      "_meta": {
+        "model": "meta-valid-model",
+        "name": "Meta Valid Model",
+        "apiBackend": "responses",
+        "totalContextTokens": 131072,
+        "reasoningEfforts": [{ "value": "high" }]
+      }
+    }
+  ]
+}

--- a/scripts/fixtures/models-v2/removals.json
+++ b/scripts/fixtures/models-v2/removals.json
@@ -1,0 +1,11 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "model": "grok-composer-2.5-fast",
+      "name": "Composer 2.5",
+      "api_backend": "responses",
+      "context_window": 200000
+    }
+  ]
+}

--- a/scripts/verify-catalog.js
+++ b/scripts/verify-catalog.js
@@ -95,6 +95,17 @@ async function main() {
     assert.equal(normalized.thinkingLevelMap.low, "low", "empty/malformed level lists should use capability defaults");
     assert.equal(normalized.thinkingLevelMap.high, "high");
   }
+  const deniedKnownReasoning = normalizeXaiCatalogPayload({ data: [{
+    model: "grok-4.5",
+    api_backend: "responses",
+    context_window: 500_000,
+    supports_reasoning_effort: false,
+    reasoning_efforts: ["low", "high"],
+  }] })[0];
+  assert.equal(deniedKnownReasoning.reasoning, false, "authenticated reasoning denial must override known metadata");
+  assert.equal(deniedKnownReasoning.thinkingLevelMap.off, "none");
+  assert.equal(deniedKnownReasoning.thinkingLevelMap.low, undefined);
+
   const clampedKnownOutput = normalizeXaiCatalogPayload({ data: [{
     model: "grok-4.5",
     api_backend: "responses",

--- a/scripts/verify-catalog.js
+++ b/scripts/verify-catalog.js
@@ -84,6 +84,17 @@ async function main() {
   assert.equal(implicitReasoningLevels.thinkingLevelMap.low, "low");
   assert.equal(implicitReasoningLevels.thinkingLevelMap.medium, "medium");
   assert.equal(implicitReasoningLevels.thinkingLevelMap.high, "high");
+  for (const reasoningEfforts of [[], "malformed"]) {
+    const normalized = normalizeXaiCatalogPayload({ data: [{
+      model: "empty-levels",
+      api_backend: "responses",
+      context_window: 100_000,
+      supports_reasoning_effort: true,
+      reasoning_efforts: reasoningEfforts,
+    }] })[0];
+    assert.equal(normalized.thinkingLevelMap.low, "low", "empty/malformed level lists should use capability defaults");
+    assert.equal(normalized.thinkingLevelMap.high, "high");
+  }
   const clampedKnownOutput = normalizeXaiCatalogPayload({ data: [{
     model: "grok-4.5",
     api_backend: "responses",
@@ -256,7 +267,17 @@ async function main() {
       fetchImpl: async () => { throw new Error("new account offline"); },
     });
     assert.equal(forcedTransient.source, "curated-fallback", "post-login refresh must not reuse another account's stale cache");
+    assert.equal(forcedTransient.needsAuthenticatedRefresh, true, "transient forced failure should remain retryable");
     assert.equal(JSON.parse(await fs.readFile(stalePath, "utf8")).invalidated, true, "failed forced refresh must invalidate old account cache");
+
+    const noCacheTransient = await selectXaiModelCatalog({
+      credential: { access: TOKEN_SENTINEL },
+      cachePath: path.join(tempDir, "transient-missing", "models-v2.json"),
+      now,
+      fetchImpl: async () => { throw new Error("offline"); },
+    });
+    assert.equal(noCacheTransient.source, "curated-fallback");
+    assert.equal(noCacheTransient.needsAuthenticatedRefresh, true);
 
     const tooOldPath = path.join(tempDir, "too-old", "models-v2.json");
     await writeCache(tooOldPath, now - XAI_MODEL_CATALOG_MAX_STALE_MS - 1, additions);

--- a/scripts/verify-catalog.js
+++ b/scripts/verify-catalog.js
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+
+const assert = require("assert");
+const fs = require("fs/promises");
+const os = require("os");
+const path = require("path");
+const { createJiti } = require("jiti");
+
+const repoRoot = path.resolve(__dirname, "..");
+const jiti = createJiti(__filename, { interopDefault: true });
+const {
+  XaiCatalogCancelledError,
+  XaiCatalogValidationError,
+  fetchXaiModelCatalog,
+  normalizeXaiCatalogPayload,
+  selectXaiModelCatalog,
+} = jiti(path.join(repoRoot, "extensions", "xai", "catalog.ts"));
+const {
+  XAI_CLI_MODELS_URL,
+  XAI_MODEL_CATALOG_CACHE_SCHEMA,
+  XAI_MODEL_CATALOG_FRESH_TTL_MS,
+  XAI_MODEL_CATALOG_MAX_BYTES,
+  XAI_MODEL_CATALOG_MAX_STALE_MS,
+} = jiti(path.join(repoRoot, "extensions", "xai", "constants.ts"));
+
+const fixtureDir = path.join(repoRoot, "scripts", "fixtures", "models-v2");
+const TOKEN_SENTINEL = "OAUTH_TOKEN_MUST_NEVER_REACH_CACHE";
+
+async function fixture(name) {
+  return JSON.parse(await fs.readFile(path.join(fixtureDir, name), "utf8"));
+}
+
+function jsonResponse(body, status = 200, headers = {}) {
+  const text = JSON.stringify(body);
+  return new Response(text, {
+    status,
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+}
+
+async function writeCache(cachePath, fetchedAt, models) {
+  await fs.mkdir(path.dirname(cachePath), { recursive: true });
+  await fs.writeFile(cachePath, JSON.stringify({
+    schemaVersion: XAI_MODEL_CATALOG_CACHE_SCHEMA,
+    fetchedAt,
+    models,
+  }));
+}
+
+async function main() {
+  const additionsFixture = await fixture("additions.json");
+  const removalsFixture = await fixture("removals.json");
+  const malformedFixture = await fixture("malformed.json");
+  const apiKeyOnlyFixture = await fixture("api-key-only.json");
+
+  const additions = normalizeXaiCatalogPayload(additionsFixture);
+  assert.deepEqual(additions.map((model) => model.id), [
+    "grok-4.5",
+    "grok-composer-2.5-fast",
+    "grok-new-oauth-model",
+  ]);
+  assert.equal(additions[0].contextWindow, 500_000);
+  assert.equal(additions[0].maxTokens, 131_072, "known output metadata should fill an omitted remote limit");
+  assert.equal(additions[0].thinkingLevelMap.off, null);
+  assert.equal(additions[0].thinkingLevelMap.minimal, "low", "Grok 4.5 minimal compatibility should remain low");
+  assert.equal(additions[2].thinkingLevelMap.xhigh, "xhigh");
+  assert.equal(additions[2].thinkingLevelMap.medium, "medium");
+  assert.equal(additions[2].input.join(","), "text", "unknown models should use conservative text-only input");
+  assert.deepEqual(additions[2].cost, { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+  const noneReasoning = normalizeXaiCatalogPayload({ data: [{
+    model: "none-capable",
+    api_backend: "responses",
+    context_window: 100_000,
+    supports_reasoning_effort: true,
+    reasoning_efforts: ["none", "low"],
+  }] })[0];
+  assert.equal(noneReasoning.thinkingLevelMap.off, "none", "official none effort should map to pi off");
+  const implicitReasoningLevels = normalizeXaiCatalogPayload({ data: [{
+    model: "implicit-levels",
+    api_backend: "responses",
+    context_window: 100_000,
+    supports_reasoning_effort: true,
+  }] })[0];
+  assert.equal(implicitReasoningLevels.thinkingLevelMap.low, "low");
+  assert.equal(implicitReasoningLevels.thinkingLevelMap.medium, "medium");
+  assert.equal(implicitReasoningLevels.thinkingLevelMap.high, "high");
+  const clampedKnownOutput = normalizeXaiCatalogPayload({ data: [{
+    model: "grok-4.5",
+    api_backend: "responses",
+    context_window: 100_000,
+  }] })[0];
+  assert.equal(clampedKnownOutput.maxTokens, 100_000, "known output fallback must not exceed remote context");
+
+  const removals = normalizeXaiCatalogPayload(removalsFixture);
+  assert.deepEqual(removals.map((model) => model.id), ["grok-composer-2.5-fast"]);
+  assert.deepEqual(normalizeXaiCatalogPayload({ data: [] }), [], "an authenticated empty catalog is an exact empty entitlement set");
+
+  const malformed = normalizeXaiCatalogPayload(malformedFixture);
+  assert.deepEqual(malformed.map((model) => model.id), ["meta-valid-model"]);
+  assert.throws(
+    () => normalizeXaiCatalogPayload({ data: [{ model: "bad", context_window: 1000 }] }),
+    XaiCatalogValidationError,
+    "an all-malformed non-empty catalog should not replace last-known-good data",
+  );
+  assert.throws(() => normalizeXaiCatalogPayload({ models: [] }), XaiCatalogValidationError);
+
+  const apiFiltered = normalizeXaiCatalogPayload(apiKeyOnlyFixture);
+  assert.deepEqual(apiFiltered.map((model) => model.id), ["oauth-safe-model"]);
+  assert.equal(apiFiltered[0].name, "OAuth Safe Model", "first duplicate should win deterministically");
+  assert.doesNotMatch(JSON.stringify(apiFiltered), /MUST_NOT_REACH_CACHE|XAI_API_KEY/);
+
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-xai-catalog-test-"));
+  try {
+    const now = 2_000_000_000_000;
+    const freshPath = path.join(tempDir, "fresh", "models-v2.json");
+    await writeCache(freshPath, now - XAI_MODEL_CATALOG_FRESH_TTL_MS + 1, additions);
+    let freshFetches = 0;
+    const fresh = await selectXaiModelCatalog({
+      credential: { access: TOKEN_SENTINEL },
+      cachePath: freshPath,
+      now,
+      fetchImpl: async () => { freshFetches++; throw new Error("must not fetch"); },
+    });
+    assert.equal(fresh.source, "fresh-cache");
+    assert.equal(freshFetches, 0, "fresh cache must avoid startup network delay");
+    await fs.chmod(freshPath, 0o644);
+    const tightened = await selectXaiModelCatalog({
+      credential: { access: TOKEN_SENTINEL },
+      cachePath: freshPath,
+      now,
+      fetchImpl: async () => { throw new Error("must not fetch"); },
+    });
+    assert.equal(tightened.source, "fresh-cache");
+    assert.equal((await fs.stat(freshPath)).mode & 0o777, 0o600, "preexisting permissive cache should be tightened");
+    const noCredentialFresh = await selectXaiModelCatalog({ cachePath: freshPath, now });
+    assert.equal(noCredentialFresh.source, "curated-fallback", "logout must not advertise a previous account's fresh cache");
+
+    const stalePath = path.join(tempDir, "stale", "models-v2.json");
+    await writeCache(stalePath, now - XAI_MODEL_CATALOG_FRESH_TTL_MS, additions);
+    let capturedRequest;
+    const refreshed = await selectXaiModelCatalog({
+      credential: { access: TOKEN_SENTINEL },
+      cachePath: stalePath,
+      now,
+      fetchImpl: async (url, init) => {
+        capturedRequest = { url: String(url), init };
+        return jsonResponse(removalsFixture);
+      },
+    });
+    assert.equal(refreshed.source, "remote");
+    assert.deepEqual(refreshed.models.map((model) => model.id), ["grok-composer-2.5-fast"], "successful refresh must replace, not merge");
+    assert.equal(capturedRequest.url, XAI_CLI_MODELS_URL);
+    assert.equal(capturedRequest.init.method, "GET");
+    assert.equal(capturedRequest.init.redirect, "error");
+    assert.equal(capturedRequest.init.headers["X-XAI-Token-Auth"], "xai-grok-cli");
+    assert.equal(capturedRequest.init.headers.Authorization, `Bearer ${TOKEN_SENTINEL}`);
+    const refreshedCache = await fs.readFile(stalePath, "utf8");
+    assert.doesNotMatch(refreshedCache, new RegExp(TOKEN_SENTINEL));
+    assert.deepEqual(JSON.parse(refreshedCache).models.map((model) => model.id), ["grok-composer-2.5-fast"]);
+    assert.equal((await fs.stat(stalePath)).mode & 0o777, 0o600, "cache should be user-readable only");
+
+    await writeCache(stalePath, now - XAI_MODEL_CATALOG_FRESH_TTL_MS, additions);
+    await writeCache(freshPath, now - 1, additions);
+    let changedCredentialFetches = 0;
+    const changedCredential = await selectXaiModelCatalog({
+      credential: { access: TOKEN_SENTINEL },
+      credentialChangedAt: now,
+      cachePath: freshPath,
+      now,
+      fetchImpl: async () => {
+        changedCredentialFetches++;
+        return jsonResponse(removalsFixture);
+      },
+    });
+    assert.equal(changedCredential.source, "remote", "credential-store changes newer than cache must force discovery");
+    assert.equal(changedCredentialFetches, 1);
+
+    const staleNetwork = await selectXaiModelCatalog({
+      credential: { access: TOKEN_SENTINEL },
+      cachePath: stalePath,
+      now,
+      fetchImpl: async () => { throw new Error("offline"); },
+    });
+    assert.equal(staleNetwork.source, "stale-cache");
+    assert.deepEqual(staleNetwork.models.map((model) => model.id), additions.map((model) => model.id));
+
+    const oversized = await selectXaiModelCatalog({
+      credential: { access: TOKEN_SENTINEL },
+      cachePath: stalePath,
+      now,
+      fetchImpl: async () => jsonResponse({}, 200, { "Content-Length": String(XAI_MODEL_CATALOG_MAX_BYTES + 1) }),
+    });
+    assert.equal(oversized.source, "stale-cache", "oversized successful response should preserve last-known-good data");
+
+    const invalidSuccess = await selectXaiModelCatalog({
+      credential: { access: TOKEN_SENTINEL },
+      cachePath: stalePath,
+      now,
+      fetchImpl: async () => jsonResponse({ data: [{ model: "broken" }] }),
+    });
+    assert.equal(invalidSuccess.source, "stale-cache", "malformed 2xx should preserve last-known-good data");
+
+    const cancelledController = new AbortController();
+    const cacheBeforeCancellation = await fs.readFile(stalePath, "utf8");
+    let markCancelledFetchStarted;
+    let resolveCancelledFetch;
+    const cancelledFetchStarted = new Promise((resolve) => { markCancelledFetchStarted = resolve; });
+    const cancelledSelection = selectXaiModelCatalog({
+      credential: { access: TOKEN_SENTINEL },
+      cachePath: stalePath,
+      now,
+      forceRefresh: true,
+      signal: cancelledController.signal,
+      fetchImpl: async () => new Promise((resolve) => {
+        resolveCancelledFetch = resolve;
+        markCancelledFetchStarted();
+      }),
+    });
+    await cancelledFetchStarted;
+    cancelledController.abort();
+    resolveCancelledFetch(jsonResponse(removalsFixture));
+    await assert.rejects(cancelledSelection, XaiCatalogCancelledError);
+    assert.equal(await fs.readFile(stalePath, "utf8"), cacheBeforeCancellation, "caller cancellation must not mutate cache state");
+
+    let commitChecks = 0;
+    const cancelledDuringCommit = selectXaiModelCatalog({
+      credential: { access: TOKEN_SENTINEL },
+      cachePath: stalePath,
+      now,
+      commitAllowed: () => ++commitChecks < 4,
+      fetchImpl: async () => jsonResponse(removalsFixture),
+    });
+    await assert.rejects(cancelledDuringCommit, XaiCatalogCancelledError);
+    assert.deepEqual(
+      JSON.parse(await fs.readFile(stalePath, "utf8")).models.map((model) => model.id),
+      additions.map((model) => model.id),
+      "cancellation after queued commit must conditionally restore the previous cache",
+    );
+
+    const authFailure = await selectXaiModelCatalog({
+      credential: { access: TOKEN_SENTINEL },
+      cachePath: stalePath,
+      now,
+      fetchImpl: async () => jsonResponse({}, 401),
+    });
+    assert.equal(authFailure.source, "curated-fallback");
+    assert.deepEqual(authFailure.models.map((model) => model.id), ["grok-4.5"]);
+    assert.equal(JSON.parse(await fs.readFile(stalePath, "utf8")).invalidated, true, "auth failure must invalidate cached entitlements durably");
+
+    await writeCache(stalePath, now - XAI_MODEL_CATALOG_FRESH_TTL_MS, additions);
+    const forcedTransient = await selectXaiModelCatalog({
+      credential: { access: TOKEN_SENTINEL },
+      cachePath: stalePath,
+      now,
+      forceRefresh: true,
+      fetchImpl: async () => { throw new Error("new account offline"); },
+    });
+    assert.equal(forcedTransient.source, "curated-fallback", "post-login refresh must not reuse another account's stale cache");
+    assert.equal(JSON.parse(await fs.readFile(stalePath, "utf8")).invalidated, true, "failed forced refresh must invalidate old account cache");
+
+    const tooOldPath = path.join(tempDir, "too-old", "models-v2.json");
+    await writeCache(tooOldPath, now - XAI_MODEL_CATALOG_MAX_STALE_MS - 1, additions);
+    const tooOld = await selectXaiModelCatalog({
+      credential: { access: TOKEN_SENTINEL },
+      cachePath: tooOldPath,
+      now,
+      fetchImpl: async () => { throw new Error("offline"); },
+    });
+    assert.equal(tooOld.source, "curated-fallback");
+
+    const noCredentials = await selectXaiModelCatalog({
+      cachePath: path.join(tempDir, "missing", "models-v2.json"),
+      now,
+      refreshWhenCredentialsAvailable: true,
+    });
+    assert.equal(noCredentials.source, "curated-fallback");
+    assert.equal(noCredentials.needsAuthenticatedRefresh, true);
+
+    const secretFilterPath = path.join(tempDir, "secret-filter", "models-v2.json");
+    const secretFiltered = await selectXaiModelCatalog({
+      credential: { access: TOKEN_SENTINEL },
+      cachePath: secretFilterPath,
+      now,
+      fetchImpl: async () => jsonResponse(apiKeyOnlyFixture),
+    });
+    assert.equal(secretFiltered.source, "remote");
+    assert.deepEqual(secretFiltered.models.map((model) => model.id), ["oauth-safe-model"]);
+    const secretFilteredCache = await fs.readFile(secretFilterPath, "utf8");
+    assert.doesNotMatch(secretFilteredCache, /MUST_NOT_REACH_CACHE|XAI_API_KEY|OAUTH_TOKEN_MUST_NEVER_REACH_CACHE/);
+
+    const directFetch = await fetchXaiModelCatalog(
+      { access: TOKEN_SENTINEL },
+      { fetchImpl: async () => jsonResponse(additionsFixture) },
+    );
+    assert.equal(directFetch.kind, "success");
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+
+  console.log("verify-catalog: ok");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/verify-catalog.js
+++ b/scripts/verify-catalog.js
@@ -314,6 +314,32 @@ async function main() {
       { fetchImpl: async () => jsonResponse(additionsFixture) },
     );
     assert.equal(directFetch.kind, "success");
+
+    const grokStartupPath = path.join(tempDir, "grok-startup", "models-v2.json");
+    const grokStartup = await selectXaiModelCatalog({
+      credential: { access: TOKEN_SENTINEL },
+      refreshWhenCredentialsAvailable: true,
+      cachePath: grokStartupPath,
+      now,
+      fetchImpl: async () => jsonResponse(additionsFixture),
+    });
+    assert.equal(grokStartup.source, "remote");
+    assert.equal(grokStartup.needsAuthenticatedRefresh, true, "Grok-backed startup must preserve deferred pi refresh intent");
+
+    await fs.writeFile(`${grokStartupPath}.invalidated`, `1:${now}\n`);
+    let markerFetches = 0;
+    const markerSelection = await selectXaiModelCatalog({
+      credential: { access: TOKEN_SENTINEL },
+      cachePath: grokStartupPath,
+      now: now + 1,
+      fetchImpl: async () => {
+        markerFetches++;
+        return jsonResponse(removalsFixture);
+      },
+    });
+    assert.equal(markerSelection.source, "remote", "invalidation sidecar must suppress an otherwise fresh cache");
+    assert.equal(markerFetches, 1);
+    await assert.rejects(fs.stat(`${grokStartupPath}.invalidated`), { code: "ENOENT" });
   } finally {
     await fs.rm(tempDir, { recursive: true, force: true });
   }

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -3,6 +3,7 @@
 const assert = require("assert");
 const crypto = require("crypto");
 const path = require("path");
+const os = require("os");
 const fs = require("fs/promises");
 const { createJiti } = require("jiti");
 
@@ -15,7 +16,12 @@ const { compactXaiInlineImages, MAX_XAI_INLINE_IMAGE_BASE64_BYTES } = jiti(
   path.join(repoRoot, "extensions", "xai", "images.ts"),
 );
 const { rewriteXaiResponsesPayload } = jiti(path.join(repoRoot, "extensions", "xai", "payload.ts"));
-const { resolveXaiClientMode } = jiti(path.join(repoRoot, "extensions", "xai", "models.ts"));
+const {
+  KNOWN_XAI_MODEL_METADATA,
+  getXaiRuntimeModels,
+  resolveXaiClientMode,
+  setXaiRuntimeModels,
+} = jiti(path.join(repoRoot, "extensions", "xai", "models.ts"));
 const { createXaiResponse } = jiti(path.join(repoRoot, "extensions", "xai", "responses.ts"));
 const { resolveXaiRoute } = jiti(path.join(repoRoot, "extensions", "xai", "routing.ts"));
 const { XAI_NETWORK_TOOL_NAMES } = jiti(path.join(repoRoot, "extensions", "xai", "tools", "model-scope.ts"));
@@ -37,6 +43,28 @@ let nextJwksDocument;
 let nextRefreshTokenResponse;
 let abortNextOAuthFetch;
 let nextXaiResponse;
+let nextCatalogResponse;
+const catalogResponseQueue = [];
+
+const DEFAULT_CATALOG_RESPONSE = {
+  object: "list",
+  data: [
+    {
+      model: "grok-4.5",
+      name: "Grok 4.5",
+      api_backend: "responses",
+      context_window: 500_000,
+      supports_reasoning_effort: true,
+      reasoning_efforts: ["low", "medium", "high"],
+    },
+    {
+      model: "grok-composer-2.5-fast",
+      name: "Composer 2.5",
+      api_backend: "responses",
+      context_window: 200_000,
+    },
+  ],
+};
 
 const TEST_XAI_MODEL = {
   id: "grok-4.5",
@@ -194,6 +222,17 @@ function installFetchMock() {
       });
     }
 
+    if (href === "https://cli-chat-proxy.grok.com/v1/models-v2") {
+      assert.equal(init.method, "GET", "catalog discovery must be GET-only");
+      assert.equal(init.redirect, "error", "catalog discovery must refuse redirects");
+      requests.push({ url: href, method: init.method, headers: init.headers || {}, signal: init.signal });
+      const queuedCatalog = catalogResponseQueue.shift();
+      if (typeof queuedCatalog === "function") return queuedCatalog(href, init);
+      const catalog = queuedCatalog ?? nextCatalogResponse ?? DEFAULT_CATALOG_RESPONSE;
+      nextCatalogResponse = undefined;
+      return jsonResponse(catalog.body ?? catalog, { status: catalog.status });
+    }
+
     const body = init.body ? JSON.parse(String(init.body)) : undefined;
     requests.push({ url: href, method: init.method, headers: init.headers || {}, body, signal: init.signal });
     if (nextXaiResponse && href.endsWith("/responses")) {
@@ -260,7 +299,7 @@ function urlOriginIs(url, expectedOrigin) {
   }
 }
 
-function loadExtension() {
+async function loadExtension() {
   const providers = new Map();
   const tools = new Map();
   const handlers = new Map();
@@ -268,12 +307,16 @@ function loadExtension() {
   let activeTools = ["read", "bash", "edit", "write"];
   let throwOnGetActiveTools = false;
   let throwOnSetActiveTools = false;
-  extension({
+  const selectedModels = [];
+  await extension({
     on(event, handler) {
       handlers.set(event, handler);
     },
     registerProvider(name, config) {
       providers.set(name, config);
+    },
+    unregisterProvider(name) {
+      providers.delete(name);
     },
     registerTool(tool) {
       tools.set(tool.name, tool);
@@ -290,6 +333,10 @@ function loadExtension() {
       if (throwOnSetActiveTools) throw new Error("tool registry temporarily unavailable");
       activeTools = toolNames;
     },
+    async setModel(model) {
+      selectedModels.push(model);
+      return true;
+    },
   });
   return {
     providers,
@@ -298,6 +345,7 @@ function loadExtension() {
     commands,
     getActiveTools: () => activeTools,
     setActiveTools: (toolNames) => { activeTools = toolNames; },
+    selectedModels,
     setToolRegistryFailures({ get = false, set = false } = {}) {
       throwOnGetActiveTools = get;
       throwOnSetActiveTools = set;
@@ -1129,7 +1177,7 @@ async function verifyXaiResponsesTransport(provider) {
     message = await captureStreamResultMessage(() =>
       provider.streamSimple(
         {
-          id: "grok-4.3",
+          id: "grok-4.5",
           provider: "xai-auth",
           api: "xai-responses",
           baseUrl: "https://cli-chat-proxy.grok.com/v1",
@@ -1174,9 +1222,14 @@ function verifyCredentialAwareRouteMatrix() {
 }
 
 async function verifyOAuthResponsesRouting(provider) {
-  for (const modelId of OAUTH_RESPONSES_MODEL_IDS) {
-    const catalogModel = provider.models.find((model) => model.id === modelId);
-    assert.ok(catalogModel, `${modelId} should exist in the provider catalog`);
+  const previousModels = getXaiRuntimeModels();
+  setXaiRuntimeModels(KNOWN_XAI_MODEL_METADATA);
+  try {
+    for (const modelId of OAUTH_RESPONSES_MODEL_IDS) {
+    const catalogModel =
+      provider.models.find((model) => model.id === modelId) ||
+      KNOWN_XAI_MODEL_METADATA.find((model) => model.id === modelId);
+    assert.ok(catalogModel, `${modelId} should retain known compatibility metadata`);
     const model = {
       ...catalogModel,
       provider: "xai-auth",
@@ -1239,7 +1292,10 @@ async function verifyOAuthResponsesRouting(provider) {
       directConversationId,
       `${modelId} direct helper`,
     );
-    assert.notEqual(directRequestId, streamRequestId, `${modelId} stream and direct calls need distinct request ids`);
+      assert.notEqual(directRequestId, streamRequestId, `${modelId} stream and direct calls need distinct request ids`);
+    }
+  } finally {
+    setXaiRuntimeModels(previousModels);
   }
 }
 
@@ -1306,7 +1362,7 @@ function verifyXaiClientModeResolution() {
   assert.equal(resolveXaiClientMode(["--mode", "--print"], true, true), "interactive");
 }
 
-async function verifyOAuthCallbackState(provider) {
+async function verifyOAuthCallbackState(provider, loadResult) {
   const before = requests.length;
   let authUrl;
   let expectedIdToken;
@@ -1349,6 +1405,152 @@ async function verifyOAuthCallbackState(provider) {
   );
   const exchanges = requests.slice(before).filter((entry) => entry.body?.grant_type === "authorization_code");
   assert.deepStrictEqual(exchanges.map((entry) => entry.body.code), ["good-code"], "wrong-state code substitution must not reach token exchange");
+  const catalogRequest = requests.slice(before).find((entry) => entry.url === "https://cli-chat-proxy.grok.com/v1/models-v2");
+  assert.ok(catalogRequest, "successful login should force an authenticated catalog refresh");
+  assert.equal(headerValue(catalogRequest.headers, "X-XAI-Token-Auth"), "xai-grok-cli");
+  assert.deepEqual(
+    loadResult.providers.get("xai-auth").models.map((model) => model.id),
+    ["grok-4.5", "grok-composer-2.5-fast"],
+    "post-login provider replacement should expose the authenticated catalog immediately",
+  );
+  const inputResult = await loadResult.handlers.get("input")?.({}, {
+    model: { ...TEST_XAI_MODEL, id: "removed-model" },
+    modelRegistry: {
+      find: (_provider, id) => id === "grok-4.5" ? TEST_XAI_MODEL : undefined,
+    },
+    ui: { notify() {} },
+  });
+  assert.deepEqual(inputResult, { action: "continue" });
+  assert.equal(loadResult.selectedModels.at(-1)?.id, "grok-4.5", "removed active model should switch before prompt execution");
+}
+
+async function verifyOAuthEmptyCatalogReplacement(provider, loadResult) {
+  nextCatalogResponse = { data: [] };
+  let authUrl;
+  const login = provider.oauth.login({
+    onPrompt: async () => "n",
+    onProgress: () => {},
+    onAuth(auth) {
+      authUrl = new URL(auth.url);
+      const code = "empty-catalog-code";
+      queueValidOAuthToken(code, authUrl);
+      setTimeout(async () => {
+        const callback = new URL(authUrl.searchParams.get("redirect_uri"));
+        callback.searchParams.set("code", code);
+        callback.searchParams.set("state", authUrl.searchParams.get("state"));
+        await originalFetch(callback);
+      }, 10);
+    },
+  });
+  await login;
+  assert.ok(authUrl, "empty-catalog login should open authorization");
+  assert.deepEqual(
+    loadResult.providers.get("xai-auth").models,
+    [],
+    "an authenticated empty catalog must remove every previously registered xAI model",
+  );
+  const notifications = [];
+  const inputResult = await loadResult.handlers.get("input")?.({}, {
+    model: TEST_XAI_MODEL,
+    modelRegistry: { find: () => undefined },
+    ui: { notify: (message, type) => notifications.push({ message, type }) },
+  });
+  assert.deepEqual(inputResult, { action: "handled" }, "no-replacement removal should stop the prompt before agent start");
+  assert.match(notifications.at(-1).message, /no entitled xAI replacement/);
+}
+
+async function verifyCatalogRefreshIsolation() {
+  const previousHome = process.env.HOME;
+  const isolationHome = await fs.mkdtemp(path.join(os.tmpdir(), "pi-xai-account-isolation-test-"));
+  process.env.HOME = isolationHome;
+  try {
+    const authPath = path.join(isolationHome, ".pi", "agent", "auth.json");
+    await fs.mkdir(path.dirname(authPath), { recursive: true });
+    await fs.writeFile(authPath, JSON.stringify({
+      "xai-auth": {
+        type: "oauth",
+        access: "expired-old-access",
+        refresh: "old-refresh",
+        expires: 1,
+        tokenEndpoint: "https://auth.x.ai/oauth2/token",
+      },
+    }));
+
+    const loadResult = await loadExtension();
+    const provider = loadResult.providers.get("xai-auth");
+    const catalogBearers = [];
+    let oldRequestStarted;
+    let resolveOldCatalog;
+    const oldStarted = new Promise((resolve) => { oldRequestStarted = resolve; });
+    catalogResponseQueue.push(
+      async (_url, init) => {
+        catalogBearers.push(headerValue(init.headers, "Authorization"));
+        oldRequestStarted();
+        return new Promise((resolve) => {
+          // Deliberately ignore abort and complete late: the catalog commit
+          // guard, not a cooperative transport, must protect the new account.
+          resolveOldCatalog = () => resolve(jsonResponse({ data: [{
+            model: "old-account-only",
+            api_backend: "responses",
+            context_window: 100_000,
+          }] }));
+        });
+      },
+      async (_url, init) => {
+        catalogBearers.push(headerValue(init.headers, "Authorization"));
+        return jsonResponse({ data: [{
+          model: "new-account-only",
+          name: "New Account Only",
+          api_backend: "responses",
+          context_window: 100_000,
+        }] });
+      },
+    );
+
+    const oldSessionRefresh = loadResult.handlers.get("session_start")?.({}, {
+      model: TEST_XAI_MODEL,
+      modelRegistry: {
+        find: (_provider, id) => ({ ...TEST_XAI_MODEL, id }),
+        async getApiKeyAndHeaders() {
+          return { ok: true, apiKey: "OLD_ACCOUNT" };
+        },
+      },
+    });
+    await oldStarted;
+
+    let authUrl;
+    const login = provider.oauth.login({
+      onPrompt: async () => "n",
+      onProgress: () => {},
+      onAuth(auth) {
+        authUrl = new URL(auth.url);
+        const code = "new-account-isolation-code";
+        queueValidOAuthToken(code, authUrl);
+        setTimeout(async () => {
+          const callback = new URL(authUrl.searchParams.get("redirect_uri"));
+          callback.searchParams.set("code", code);
+          callback.searchParams.set("state", authUrl.searchParams.get("state"));
+          await originalFetch(callback);
+        }, 10);
+      },
+    });
+    await login;
+    resolveOldCatalog();
+    await oldSessionRefresh;
+
+    assert.deepEqual(catalogBearers, ["Bearer OLD_ACCOUNT", "Bearer access-new-account-isolation-code"]);
+    assert.deepEqual(
+      loadResult.providers.get("xai-auth").models.map((model) => model.id),
+      ["new-account-only"],
+      "a superseded old-account refresh must not overwrite the new login catalog",
+    );
+    const cache = JSON.parse(await fs.readFile(path.join(isolationHome, ".pi", "agent", "cache", "pi-xai-oauth", "models-v2.json"), "utf8"));
+    assert.deepEqual(cache.models.map((model) => model.id), ["new-account-only"]);
+  } finally {
+    catalogResponseQueue.length = 0;
+    process.env.HOME = previousHome;
+    await fs.rm(isolationHome, { recursive: true, force: true });
+  }
 }
 
 async function verifyLegacyOAuthRefresh(provider) {
@@ -1920,14 +2122,15 @@ async function verifyOAuthCancellationAndCleanup(provider) {
 }
 
 async function main() {
-  process.env.HOME = path.join(repoRoot, ".tmp-empty-home-for-tests");
+  const testHome = await fs.mkdtemp(path.join(os.tmpdir(), "pi-xai-extension-test-"));
+  process.env.HOME = testHome;
   process.env.XAI_API_KEY = "must-not-be-used";
   installFetchMock();
 
   try {
-    const firstLoad = loadExtension();
+    const firstLoad = await loadExtension();
     const { providers, tools } = firstLoad;
-    const secondLoad = loadExtension();
+    const secondLoad = await loadExtension();
     const provider = providers.get("xai-auth");
     assert.ok(provider, "xai-auth provider should be registered");
     assert.equal(secondLoad.tools.size, tools.size, "extension reloads should register tools on the new pi API object");
@@ -1943,12 +2146,20 @@ async function main() {
     assert.equal(grok45?.cost.cacheRead, 0.5);
     assert.equal(grok45?.cost.output, 6);
     assert.equal(grok45?.thinkingLevelMap?.off, null, "Grok 4.5 reasoning cannot be disabled");
-    assert.equal(provider.models.find((model) => model.id === "grok-4.3")?.contextWindow, 1_000_000);
-    assert.equal(provider.models.find((model) => model.id === "grok-build")?.contextWindow, 512_000);
-    assert.equal(provider.models.find((model) => model.id === "grok-composer-2.5-fast")?.contextWindow, 200_000);
-    assert.equal(provider.models.find((model) => model.id === "grok-composer-2.5-fast")?.reasoning, false);
-    assert.equal(provider.models.find((model) => model.id === "grok-4.20-0309-reasoning")?.contextWindow, 2_000_000);
-    assert.ok(provider.models.some((model) => model.id === "grok-4.20-multi-agent-0309"));
+    assert.deepEqual(
+      provider.models.map((model) => model.id),
+      ["grok-4.5"],
+      "offline startup should advertise only the documented curated fallback",
+    );
+    assert.equal(
+      KNOWN_XAI_MODEL_METADATA.find((model) => model.id === "grok-build")?.contextWindow,
+      512_000,
+      "Grok Build compatibility metadata must remain available without being advertised",
+    );
+    assert.equal(
+      KNOWN_XAI_MODEL_METADATA.find((model) => model.id === "grok-composer-2.5-fast")?.reasoning,
+      false,
+    );
 
     await verifyXaiNetworkToolActivation(firstLoad);
     await verifyXaiToolsCommand(firstLoad);
@@ -1966,10 +2177,12 @@ async function main() {
     await verifyXaiImageTransport(provider);
     await verifyXaiStreamErrorPrefix(provider);
 
+    setXaiRuntimeModels(KNOWN_XAI_MODEL_METADATA);
     await verifyCursorToolActivation(firstLoad);
     await verifyCursorToolShims(firstLoad);
 
-    await verifyOAuthCallbackState(provider);
+    await verifyOAuthCallbackState(provider, firstLoad);
+    await verifyOAuthEmptyCatalogReplacement(provider, firstLoad);
     await verifyLegacyOAuthRefresh(provider);
     await verifyOAuthManualRawCodeRejected(provider);
     await verifyOAuthManualCallbackUrlState(provider);
@@ -1982,6 +2195,18 @@ async function main() {
     await verifyOAuthAuthorizationErrorRedaction(provider);
     await verifyOAuthTokenErrorRedaction(provider);
     await verifyOAuthCancellationAndCleanup(provider);
+
+    const beforeUnentitledDirect = requests.length;
+    await assert.rejects(
+      () => createXaiResponse(OAUTH_CREDENTIAL, { model: "grok-4.20-multi-agent-0309", input: "must stay local" }),
+      /not present in the authenticated model catalog/,
+      "direct OAuth helpers must reject a model absent from the active entitlement snapshot",
+    );
+    assert.equal(requests.length, beforeUnentitledDirect, "unentitled direct model rejection must happen before network access");
+
+    // Preserve the pre-#64 routing/tool regression matrix by simulating an
+    // account whose authenticated catalog contains every known model.
+    setXaiRuntimeModels(KNOWN_XAI_MODEL_METADATA);
 
     await firstLoad.commands.get("xai-tools").handler(
       "enable xai_generate_text",
@@ -2129,9 +2354,12 @@ async function main() {
     assert.ok(multiAgentBody.tools.some((tool) => tool.type === "web_search"));
     assert.ok(multiAgentBody.tools.some((tool) => tool.type === "x_search"));
 
+    await verifyCatalogRefreshIsolation();
+
     console.log("verify-extension: ok");
   } finally {
     restoreFetchMock();
+    await fs.rm(testHome, { recursive: true, force: true });
   }
 }
 

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -15,7 +15,7 @@ const extension = extensionModule.default || extensionModule;
 const { compactXaiInlineImages, MAX_XAI_INLINE_IMAGE_BASE64_BYTES } = jiti(
   path.join(repoRoot, "extensions", "xai", "images.ts"),
 );
-const { resolveXaiCredential } = jiti(path.join(repoRoot, "extensions", "xai", "auth.ts"));
+const { getStartupXaiCatalogAuth, resolveXaiCredential } = jiti(path.join(repoRoot, "extensions", "xai", "auth.ts"));
 const { rewriteXaiResponsesPayload } = jiti(path.join(repoRoot, "extensions", "xai", "payload.ts"));
 const {
   KNOWN_XAI_MODEL_METADATA,
@@ -1462,11 +1462,45 @@ async function verifyOAuthEmptyCatalogReplacement(provider, loadResult) {
   const notifications = [];
   const inputResult = await loadResult.handlers.get("input")?.({}, {
     model: TEST_XAI_MODEL,
-    modelRegistry: { find: () => undefined },
+    modelRegistry: { find: () => TEST_XAI_MODEL },
     ui: { notify: (message, type) => notifications.push({ message, type }) },
   });
   assert.deepEqual(inputResult, { action: "handled" }, "no-replacement removal should stop the prompt before agent start");
   assert.match(notifications.at(-1).message, /no entitled xAI replacement/);
+}
+
+async function verifyStartupAuthFallback() {
+  const previousHome = process.env.HOME;
+  const authHome = await fs.mkdtemp(path.join(os.tmpdir(), "pi-xai-startup-auth-test-"));
+  process.env.HOME = authHome;
+  try {
+    const piAuthPath = path.join(authHome, ".pi", "agent", "auth.json");
+    await fs.mkdir(path.dirname(piAuthPath), { recursive: true });
+    await fs.writeFile(piAuthPath, JSON.stringify({
+      "xai-auth": {
+        type: "oauth",
+        access: "expired-pi-access",
+        refresh: "pi-refresh",
+        expires: 1,
+      },
+    }));
+    const grokAuthPath = path.join(authHome, ".grok", "auth.json");
+    await fs.mkdir(path.dirname(grokAuthPath), { recursive: true });
+    await fs.writeFile(grokAuthPath, JSON.stringify({
+      "https://auth.x.ai::b1a00492-073a-47ea-816f-4c329264a828": {
+        key: "fresh-grok-access",
+        refresh_token: "grok-refresh",
+        expires_at: Date.now() + 60 * 60 * 1000,
+      },
+    }));
+
+    const startup = getStartupXaiCatalogAuth();
+    assert.deepEqual(startup.credential, { access: "fresh-grok-access" });
+    assert.equal(startup.needsRegistryRefresh, true, "expired pi auth should still be refreshed under pi's lock");
+  } finally {
+    process.env.HOME = previousHome;
+    await fs.rm(authHome, { recursive: true, force: true });
+  }
 }
 
 async function verifyCatalogRefreshIsolation() {
@@ -1567,6 +1601,84 @@ async function verifyCatalogRefreshIsolation() {
     catalogResponseQueue.length = 0;
     process.env.HOME = previousHome;
     await fs.rm(isolationHome, { recursive: true, force: true });
+  }
+}
+
+async function verifyLoginWinsDeferredCredentialLookup() {
+  const previousHome = process.env.HOME;
+  const testHome = await fs.mkdtemp(path.join(os.tmpdir(), "pi-xai-login-priority-test-"));
+  process.env.HOME = testHome;
+  try {
+    const authPath = path.join(testHome, ".pi", "agent", "auth.json");
+    await fs.mkdir(path.dirname(authPath), { recursive: true });
+    await fs.writeFile(authPath, JSON.stringify({
+      "xai-auth": { type: "oauth", access: "expired", refresh: "refresh", expires: 1 },
+    }));
+    const cachePath = path.join(testHome, ".pi", "agent", "cache", "pi-xai-oauth", "models-v2.json");
+    await fs.mkdir(path.dirname(cachePath), { recursive: true });
+    await fs.writeFile(cachePath, JSON.stringify({
+      schemaVersion: 1,
+      fetchedAt: Date.now(),
+      models: [KNOWN_XAI_MODEL_METADATA[0]],
+    }));
+
+    const loadResult = await loadExtension();
+    let resolveAuthLookup;
+    let markAuthLookupStarted;
+    const authLookupStarted = new Promise((resolve) => { markAuthLookupStarted = resolve; });
+    const sessionStart = loadResult.handlers.get("session_start")?.({}, {
+      model: TEST_XAI_MODEL,
+      modelRegistry: {
+        find: (_provider, id) => ({ ...TEST_XAI_MODEL, id }),
+        async getApiKeyAndHeaders() {
+          markAuthLookupStarted();
+          return new Promise((resolve) => { resolveAuthLookup = resolve; });
+        },
+      },
+    });
+    await authLookupStarted;
+
+    const catalogBearers = [];
+    catalogResponseQueue.push(async (_url, init) => {
+      catalogBearers.push(headerValue(init.headers, "Authorization"));
+      return jsonResponse({ data: [{
+        model: "login-priority-model",
+        api_backend: "responses",
+        context_window: 100_000,
+      }] });
+    });
+
+    const provider = loadResult.providers.get("xai-auth");
+    let authUrl;
+    const login = provider.oauth.login({
+      onPrompt: async () => "n",
+      onProgress: () => {},
+      onAuth(auth) {
+        authUrl = new URL(auth.url);
+        const code = "login-priority-code";
+        queueValidOAuthToken(code, authUrl);
+        setTimeout(async () => {
+          const callback = new URL(authUrl.searchParams.get("redirect_uri"));
+          callback.searchParams.set("code", code);
+          callback.searchParams.set("state", authUrl.searchParams.get("state"));
+          await originalFetch(callback);
+        }, 10);
+      },
+    });
+    await login;
+    resolveAuthLookup({ ok: true, apiKey: "PRE_LOGIN_ACCOUNT" });
+    await sessionStart;
+
+    assert.deepEqual(catalogBearers, ["Bearer access-login-priority-code"]);
+    assert.deepEqual(
+      loadResult.providers.get("xai-auth").models.map((model) => model.id),
+      ["login-priority-model"],
+      "a deferred lookup started before login must not supersede the login catalog",
+    );
+  } finally {
+    catalogResponseQueue.length = 0;
+    process.env.HOME = previousHome;
+    await fs.rm(testHome, { recursive: true, force: true });
   }
 }
 
@@ -2387,7 +2499,9 @@ async function main() {
     assert.ok(multiAgentBody.tools.some((tool) => tool.type === "web_search"));
     assert.ok(multiAgentBody.tools.some((tool) => tool.type === "x_search"));
 
+    await verifyStartupAuthFallback();
     await verifyCatalogRefreshIsolation();
+    await verifyLoginWinsDeferredCredentialLookup();
 
     console.log("verify-extension: ok");
   } finally {

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -15,10 +15,12 @@ const extension = extensionModule.default || extensionModule;
 const { compactXaiInlineImages, MAX_XAI_INLINE_IMAGE_BASE64_BYTES } = jiti(
   path.join(repoRoot, "extensions", "xai", "images.ts"),
 );
+const { resolveXaiCredential } = jiti(path.join(repoRoot, "extensions", "xai", "auth.ts"));
 const { rewriteXaiResponsesPayload } = jiti(path.join(repoRoot, "extensions", "xai", "payload.ts"));
 const {
   KNOWN_XAI_MODEL_METADATA,
   getXaiRuntimeModels,
+  grokSupportsReasoningEffort,
   resolveXaiClientMode,
   setXaiRuntimeModels,
 } = jiti(path.join(repoRoot, "extensions", "xai", "models.ts"));
@@ -1348,6 +1350,14 @@ async function verifyApiKeyResponsesRouting() {
 }
 
 function verifyXaiClientModeResolution() {
+  const previousModels = getXaiRuntimeModels();
+  setXaiRuntimeModels([{
+    ...KNOWN_XAI_MODEL_METADATA[0],
+    id: "Mixed-Case-Reasoning",
+    thinkingLevelMap: { low: "low" },
+  }]);
+  assert.equal(grokSupportsReasoningEffort("mixed-case-reasoning"), true, "runtime reasoning lookup should be case-insensitive");
+  setXaiRuntimeModels(previousModels);
   assert.equal(resolveXaiClientMode([], true, true), "interactive");
   assert.equal(resolveXaiClientMode(["--model", "grok-4.5"], true, true), "interactive");
   assert.equal(resolveXaiClientMode(["--mode", "text"], true, true), "interactive");
@@ -1475,6 +1485,13 @@ async function verifyCatalogRefreshIsolation() {
         tokenEndpoint: "https://auth.x.ai/oauth2/token",
       },
     }));
+    const cachePath = path.join(isolationHome, ".pi", "agent", "cache", "pi-xai-oauth", "models-v2.json");
+    await fs.mkdir(path.dirname(cachePath), { recursive: true });
+    await fs.writeFile(cachePath, JSON.stringify({
+      schemaVersion: 1,
+      fetchedAt: Date.now(),
+      models: [KNOWN_XAI_MODEL_METADATA[0]],
+    }));
 
     const loadResult = await loadExtension();
     const provider = loadResult.providers.get("xai-auth");
@@ -1544,7 +1561,7 @@ async function verifyCatalogRefreshIsolation() {
       ["new-account-only"],
       "a superseded old-account refresh must not overwrite the new login catalog",
     );
-    const cache = JSON.parse(await fs.readFile(path.join(isolationHome, ".pi", "agent", "cache", "pi-xai-oauth", "models-v2.json"), "utf8"));
+    const cache = JSON.parse(await fs.readFile(cachePath, "utf8"));
     assert.deepEqual(cache.models.map((model) => model.id), ["new-account-only"]);
   } finally {
     catalogResponseQueue.length = 0;
@@ -2219,6 +2236,22 @@ async function main() {
       },
     });
     assert.match(noAuthResult.content[0].text, /No xAI OAuth credentials/, "tools should not fall back to XAI_API_KEY");
+
+    const composerOnlyModel = { ...TEST_XAI_MODEL, id: "grok-composer-2.5-fast" };
+    const composerOnlyCredential = await resolveXaiCredential({
+      model: composerOnlyModel,
+      modelRegistry: {
+        find: (_provider, modelId) => modelId === composerOnlyModel.id ? composerOnlyModel : undefined,
+        async getApiKeyAndHeaders() {
+          return { ok: true, apiKey: "composer-only-token" };
+        },
+      },
+    });
+    assert.deepEqual(
+      composerOnlyCredential,
+      { kind: "oauth-session", token: "composer-only-token" },
+      "credential lookup should use the active entitled model when Grok 4.5 is absent",
+    );
 
     const { body: grok45TextBody } = await runTool(tools, "xai_generate_text", {
       prompt: "hi",


### PR DESCRIPTION
## Description

Fixes #64.

Replace the release-bound `xai-auth` model advertisement with an authenticated, entitlement-aware catalog from the official Grok CLI proxy:

- fetch `GET https://cli-chat-proxy.grok.com/v1/models-v2` with the OAuth session bearer and official proxy metadata
- normalize model ID/name, Responses backend, context/output limits, reasoning capability, and supplied reasoning levels
- treat successful non-empty and empty catalogs as exact account state so additions/removals take effect without merging old models
- filter hidden, malformed, unsupported-backend, secret-bearing, duplicate, and known API-key-only entries such as `grok-build-0.1`
- keep known model pricing/input/thinking compatibility as enrichment only, without advertising unreturned IDs
- use an atomic 0600 token-free normalized cache at `~/.pi/agent/cache/pi-xai-oauth/models-v2.json`
- apply a 15-minute fresh TTL, 5-second bounded refresh, and 7-day stale-if-transient policy
- invalidate entitlements on auth/permanent or failed forced-login refresh; login never reuses stale account data
- make extension startup async, defer expired pi-token refresh through pi's lock-protected registry, refresh immediately after login, and integrate with `/reload` and `/model`
- reject removed/unentitled models locally before any Responses request and default separate helpers to the active entitled model

Credential-aware routing from #63, proxy scopes/headers from #65, OAuth/OIDC hardening from #67, direct Images routing, paid-tool opt-in, and existing model-specific payload/tool behavior are preserved.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [x] Documentation update

## How Has This Been Tested?

- [x] Changed TypeScript LSP diagnostics: no errors or warnings
- [x] `npm test`
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] `npm pack --dry-run --json` (43 intended files; runtime catalog and fixtures included; no scaffold, subagent, credential, cache, environment, or session artifacts)
- [x] Fixture tests for additions, removals, empty catalogs, malformed entries, API-key-only filtering, reasoning levels, limits, fresh/stale cache, auth/network/cancellation failures, account changes, permissions, and fallback selection
- [x] Concurrent old/new account regression where the old fetch ignores abort and completes late; only the new account may update provider state/cache
- [x] Independent correctness, security/privacy, cache/normalization, test, docs, and package reviews; accepted fixes applied; final focused race review reported `CLEAN`
- [x] Safe live authenticated GET-only `/models-v2` smoke with no paid tool invocation and no token/header logging

Live smoke result:

- source: `remote`
- HTTP path: official `/models-v2`
- normalized count: 2
- model IDs: `grok-4.5`, `grok-composer-2.5-fast`

## Cache policy

- Path: `~/.pi/agent/cache/pi-xai-oauth/models-v2.json`
- Fresh: 15 minutes, no startup network request
- Refresh bound: 5 seconds
- Stale-if-transient: up to 7 days for network/timeout/408/429/5xx/invalid-success failures
- Auth/permanent failures: invalidate and use curated `grok-4.5` fallback
- Successful login: force refresh; no stale reuse; immediate provider replacement
- Contents: normalized model definitions/timestamps only; never tokens, auth headers, identities, endpoints, or raw responses

## Residual risks

- The token-free cache cannot distinguish an external credential replacement that deliberately preserves the auth file timestamp. `/login xai-auth` always bypasses and replaces the cache.
- Pi exposes no extension API to remove disk-defined `xai-auth` entries when the authenticated catalog is empty. The README warns not to define that provider in `models.json`; input and transport guards still refuse absent IDs before network access.
- Catalog selection runs inside OAuth login before pi persists the returned credential so models update immediately. A rare credential-storage write failure could leave the newly fetched catalog active while the old credential remains stored; the next authenticated request fails closed/requires login.
- The curated fallback can be visible during discovery failure even when the account ultimately lacks that model; the proxy remains authoritative when a request is attempted.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented the code where cache/account concurrency is non-obvious
- [x] I have made corresponding documentation changes
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] New and existing tests pass locally

## Screenshots

Not applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how models are advertised and cached at startup/login with concurrency guards; entitlement mistakes could hide models or allow wrong-model requests, though transport guards and extensive fixture/extension tests mitigate this. OAuth routing, OIDC, and proxy behavior are explicitly preserved.
> 
> **Overview**
> Replaces the static `xai-auth` model list with an **account-specific catalog** from the pinned CLI proxy `GET /models-v2`, so `/model` and provider registration reflect what xAI returns for the signed-in user (additions and removals replace the prior set; no merge with old entries).
> 
> Adds **`catalog.ts`** for defensive normalization (Responses-only, hidden/API-key-only/malformed filtering, reasoning metadata), a **token-free atomic cache** (`~/.pi/agent/cache/pi-xai-oauth/models-v2.json`) with **15m fresh / 5s bounded refresh / 7d stale-if-transient**, invalidation on **401/403** and failed forced login refresh, and a **`grok-4.5` curated fallback** when discovery is unsafe or unavailable.
> 
> Makes the extension factory **async**: startup selects catalog via **`getStartupXaiCatalogAuth`** (expired pi tokens defer refresh to **`session_start`** under the model registry lock); **login forces refresh** and immediately **unregister/register** the provider; **input / before_agent_start** reconcile removed models and **Responses streaming / direct helpers** fail closed when a model is not in the active entitlement snapshot. Known model metadata in **`models.ts`** enriches returned IDs only; separate xAI tools default to the **active entitled model**.
> 
> Documentation, CHANGELOG, **`verify-catalog.js`**, and extended **`verify-extension.js`** cover cache policy, concurrency (login vs deferred refresh), and regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e51b80e5b55dd4934103fee74d07475bc7fa9a43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->