### PR TITLE
docs: add Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,3 +110,12 @@ When complex work is needed:
 4. Use parallel subagents for heavy lifting
 
 This file should be updated whenever architecture, commands, or rules change.
+
+## Cursor Cloud specific instructions
+
+This repo is a **pi extension package (a library/CLI), not a standalone server**. There is nothing to "boot" — dependency install happens automatically via the startup update script (`npm ci`). Node engine note: the pi peer deps request Node `>=22.19.0` and the pod ships `22.14.0`, so `npm ci` prints `EBADENGINE` warnings; these are non-blocking — typecheck, tests, and extension load all pass.
+
+- Build / typecheck gate: `npm run typecheck` (`tsc --noEmit`). There is **no separate lint tool** configured; typecheck is the static gate.
+- Tests: `npm test` runs `scripts/verify-*.js` (catalog normalization/cache, extension load, setup CLI). Note `verify-setup.js` writes to temp dirs only.
+- Running the "app": full end-to-end use (`pi`, `/login xai-auth`, live Grok streaming) needs the external `pi` CLI, an interactive browser OAuth flow, and a real xAI/Grok account, so it is **not runnable headless** here. To exercise the real extension offline, load `extensions/xai-oauth.ts` via `jiti` with a mock `ExtensionAPI` (implement `registerProvider`/`unregisterProvider`/`registerTool`/`registerCommand`/`on`/`setModel`); logged-out load registers the `xai-auth` provider with the curated `grok-4.5` fallback plus all tools/commands. Mock the authenticated catalog by passing `fetchImpl` to `selectXaiModelCatalog` (see `scripts/verify-catalog.js` and `scripts/fixtures/models-v2/`).
+- Any temporary demo script that imports deps must live inside the repo root (so it resolves `node_modules`), not `/tmp`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Sets up and verifies the development environment for `pi-xai-oauth` in Cursor Cloud, and documents durable, non-obvious dev/run caveats for future agents.

This repo is a **pi extension package (library/CLI), not a standalone server**. Setup is: `npm ci` → `npm run typecheck` → `npm test`. The only code change is an `AGENTS.md` addition (`## Cursor Cloud specific instructions`); no product code was touched.

## Type of change

- [x] Documentation update

## How Has This Been Tested?

All commands run on the cloud VM (Node v22.14.0):

- [x] `npm ci` — installs 231 packages (non-blocking `EBADENGINE` warnings: pi deps want Node `>=22.19.0`)
- [x] `npm run typecheck` — `tsc --noEmit` passes clean
- [x] `npm test` — `verify-catalog`, `verify-extension`, `verify-setup` all `ok`
- [x] Hello-world: loaded `extensions/xai-oauth.ts` via `jiti` with a mock `ExtensionAPI` → registered the `xai-auth` provider (offline `grok-4.5` fallback), 19 tools, `/xai-tools` command, and 4 session events; normalized a mocked authenticated `/models-v2` payload into the account catalog and confirmed no token leaks into the cache.

Verification log:

[env_setup_verification.log](https://cursor.com/agents/bc-0af88328-8f33-42c3-9a7a-0ad440056bfd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenv_setup_verification.log)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0af88328-8f33-42c3-9a7a-0ad440056bfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0af88328-8f33-42c3-9a7a-0ad440056bfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

