### PR TITLE
feat: add /xai-usage for SuperGrok weekly usage limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and
   - [Switching Models](#switching-models)
   - [Reasoning / Thinking Levels](#reasoning--thinking-levels)
 - [Custom Tools](#custom-tools)
+- [Usage limits (`/xai-usage`)](#usage-limits-xai-usage)
 - [Quick Reference](#quick-reference)
 - [Troubleshooting](#troubleshooting)
 - [Updating](#updating)
@@ -463,6 +464,24 @@ Opt-in research using the active xAI model plus native web and X search tools. E
 
 ---
 
+
+## Usage limits (`/xai-usage`)
+
+Show your SuperGrok / Grok Build **account** weekly (or monthly) usage pool — the same billing surface as the official Grok Build CLI `/usage` command.
+
+```text
+/xai-usage            # show limit %, reset time, product breakdown
+/xai-usage refresh    # force re-fetch (skip short cache)
+/xai-usage manage     # print billing / upgrade URLs
+```
+
+- Footer status: `xAI Weekly N%` (or `xAI Monthly N%`) after session start
+- Auto-refresh: once at session start, then every hour while the session is open
+- Account-level pool (not per-model). Switching away from `xai-auth` does not change the number
+- Manage credits in the browser: https://grok.com/?_s=usage
+
+Requires `/login xai-auth` (or an existing `grok login` session). Uses the Grok CLI chat proxy billing endpoint; fail-soft if the payload changes.
+
 ## Quick Reference
 
 | Action | Command |
@@ -477,6 +496,7 @@ Opt-in research using the active xAI model plus native web and X search tools. E
 | Set default model | `/model grok-4.5` (in TUI) |
 | Set thinking level | `/think high` (in TUI) |
 | Manage outbound xAI tools | `/xai-tools` (in TUI) |
+| SuperGrok weekly/monthly usage | `/xai-usage` (footer: `xAI Weekly N%`) |
 | Recreate extension/catalog state | `/reload` (respects the 15-minute cache TTL) |
 
 ---

--- a/extensions/xai/tools/index.ts
+++ b/extensions/xai/tools/index.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { Api, Model } from "@earendil-works/pi-ai";
+import { registerXaiUsage } from "../usage";
 import { registerXaiToolsCommand } from "./commands";
 import { registerCursorToolShims, syncCursorToolShimsForModel } from "./cursor-shims";
 import { registerCustomXaiTools } from "./custom-tools";
@@ -15,6 +16,7 @@ export function registerXaiTools(pi: ExtensionAPI) {
   registerCursorToolShims(pi);
   registerCustomXaiTools(pi);
   registerXaiToolsCommand(pi);
+  registerXaiUsage(pi);
 }
 
 /** Synchronize all model-scoped xAI tool availability without making network requests. */

--- a/extensions/xai/usage.ts
+++ b/extensions/xai/usage.ts
@@ -1,0 +1,382 @@
+/**
+ * SuperGrok / Grok Build account usage (weekly/monthly credit pool).
+ *
+ * Mirrors the official Grok Build CLI `/usage` surface by calling:
+ *   GET https://cli-chat-proxy.grok.com/v1/billing?format=credits
+ *
+ * Commands: /xai-usage [show|manage|refresh]
+ * Footer:   "xAI Weekly N%" (account pool; independent of the active model)
+ *
+ * The billing endpoint is used by the open-source Grok Build CLI; it is not a
+ * public docs.x.ai REST resource. Parsing fails soft if the payload changes.
+ */
+
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { resolveXaiCredential } from "./auth";
+import { XAI_CLIENT_IDENTIFIER, XAI_CLIENT_VERSION, XAI_CLI_BASE_URL } from "./constants";
+
+export const XAI_USAGE_STATUS_KEY = "xai-usage";
+export const XAI_BILLING_URL = `${XAI_CLI_BASE_URL}/billing?format=credits`;
+export const XAI_USAGE_MANAGE_URL = "https://grok.com/?_s=usage";
+export const XAI_USAGE_UPGRADE_URL = "https://grok.com/supergrok?referrer=pi-xai-oauth";
+
+const CACHE_TTL_MS = 60_000;
+const FETCH_TIMEOUT_MS = 15_000;
+/** Background billing refresh interval while a session is open. */
+const AUTO_REFRESH_MS = 60 * 60 * 1000;
+
+export interface Cent {
+  val?: number;
+}
+
+export interface UsagePeriod {
+  type?: string;
+  start?: string;
+  end?: string;
+}
+
+export interface BillingConfig {
+  creditUsagePercent?: number;
+  currentPeriod?: UsagePeriod;
+  monthlyLimit?: Cent;
+  used?: Cent;
+  onDemandCap?: Cent;
+  onDemandUsed?: Cent;
+  prepaidBalance?: Cent;
+  isUnifiedBillingUser?: boolean;
+  billingPeriodStart?: string;
+  billingPeriodEnd?: string;
+  productUsage?: Array<{ product?: string; usagePercent?: number }>;
+}
+
+export interface BillingConfigResponse {
+  config?: BillingConfig | null;
+  onDemandEnabled?: boolean | null;
+  subscriptionTier?: string | null;
+  subscription_tier?: string | null;
+}
+
+export interface UsageSnapshot {
+  fetchedAt: number;
+  usagePct: number;
+  periodType?: string;
+  periodStart?: string;
+  periodEnd?: string;
+  prepaidBalanceCents?: number;
+  onDemandCapCents?: number;
+  onDemandUsedCents?: number;
+  payAsYouGo: boolean;
+  isUnifiedBillingUser?: boolean;
+  subscriptionTier?: string;
+  productLines: string[];
+}
+
+interface UsageRuntime {
+  cache: UsageSnapshot | null;
+  inFlight: Promise<UsageSnapshot> | null;
+  refreshTimer: ReturnType<typeof setInterval> | null;
+}
+
+const runtime: UsageRuntime = {
+  cache: null,
+  inFlight: null,
+  refreshTimer: null,
+};
+
+const usageRegistrations = new WeakSet<object>();
+
+/** Register `/xai-usage` and session footer refresh (once per ExtensionAPI). */
+export function registerXaiUsage(pi: ExtensionAPI): void {
+  if (usageRegistrations.has(pi as object)) return;
+  usageRegistrations.add(pi as object);
+
+  const handler = async (args: string, ctx: ExtensionCommandContext) => {
+    await handleXaiUsageCommand(args, ctx);
+  };
+
+  const getArgumentCompletions = (argumentPrefix: string) => {
+    const options = ["show", "manage", "refresh"];
+    const prefix = argumentPrefix.trim().toLowerCase();
+    return options.filter((option) => option.startsWith(prefix)).map((option) => ({
+      value: option,
+      label: option,
+    }));
+  };
+
+  pi.registerCommand("xai-usage", {
+    description: "Show SuperGrok / Grok Build weekly usage limit",
+    getArgumentCompletions,
+    handler,
+  });
+
+  if (typeof (pi as any).on === "function") {
+    (pi as any).on("session_start", async (_event: unknown, ctx: ExtensionContext) => {
+      void refreshUsageQuiet(ctx, false);
+      stopAutoRefresh();
+      runtime.refreshTimer = setInterval(() => {
+        void refreshUsageQuiet(ctx, true);
+      }, AUTO_REFRESH_MS);
+      if (typeof runtime.refreshTimer === "object" && runtime.refreshTimer && "unref" in runtime.refreshTimer) {
+        (runtime.refreshTimer as NodeJS.Timeout).unref?.();
+      }
+    });
+
+    (pi as any).on("session_shutdown", async () => {
+      stopAutoRefresh();
+      runtime.cache = null;
+      runtime.inFlight = null;
+    });
+  }
+}
+
+function stopAutoRefresh(): void {
+  if (runtime.refreshTimer) {
+    clearInterval(runtime.refreshTimer);
+    runtime.refreshTimer = null;
+  }
+}
+
+export async function handleXaiUsageCommand(args: string, ctx: ExtensionCommandContext): Promise<void> {
+  const arg = args.trim().toLowerCase();
+  if (arg === "manage") {
+    ctx.ui.notify(
+      ["Open billing / usage management:", XAI_USAGE_MANAGE_URL, "", "Upgrade SuperGrok:", XAI_USAGE_UPGRADE_URL].join(
+        "\n",
+      ),
+      "info",
+    );
+    return;
+  }
+
+  const force = arg === "refresh";
+  if (arg && arg !== "show" && arg !== "refresh") {
+    ctx.ui.notify("Usage: /xai-usage [show|manage|refresh]", "error");
+    return;
+  }
+
+  try {
+    const snap = await getUsage(ctx, force);
+    paintStatus(ctx, snap);
+    ctx.ui.notify(formatUsageSummary(snap), "info");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    ctx.ui.setStatus(XAI_USAGE_STATUS_KEY, undefined);
+    ctx.ui.notify(`xAI usage unavailable: ${message}`, "error");
+  }
+}
+
+async function refreshUsageQuiet(ctx: ExtensionContext, force: boolean): Promise<void> {
+  try {
+    const snap = await getUsage(ctx, force);
+    paintStatus(ctx, snap);
+  } catch {
+    // Silent: user can run /xai-usage for diagnostics.
+  }
+}
+
+export async function getUsage(ctx: ExtensionContext, force: boolean): Promise<UsageSnapshot> {
+  if (!force && runtime.cache && Date.now() - runtime.cache.fetchedAt < CACHE_TTL_MS) {
+    return runtime.cache;
+  }
+  if (!force && runtime.inFlight) return runtime.inFlight;
+
+  runtime.inFlight = (async () => {
+    const credential = await resolveXaiCredential(ctx);
+    const token = credential?.token?.trim();
+    if (!token) {
+      throw new Error("No xAI OAuth token found. Run `/login xai-auth` (or `grok login`), then retry.");
+    }
+
+    const response = await fetch(XAI_BILLING_URL, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+        "User-Agent": `${XAI_CLIENT_IDENTIFIER}/${XAI_CLIENT_VERSION}`,
+      },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+
+    const text = await response.text();
+    if (!response.ok) {
+      const detail = extractErrorDetail(text) || `HTTP ${response.status}`;
+      if (response.status === 401 || response.status === 403) {
+        throw new Error(`${detail}. Re-auth with /login xai-auth.`);
+      }
+      throw new Error(detail);
+    }
+
+    let body: BillingConfigResponse;
+    try {
+      body = JSON.parse(text) as BillingConfigResponse;
+    } catch {
+      throw new Error("Billing response was not valid JSON");
+    }
+
+    const snap = billingResponseToSnapshot(body, Date.now());
+    runtime.cache = snap;
+    return snap;
+  })();
+
+  try {
+    return await runtime.inFlight;
+  } finally {
+    runtime.inFlight = null;
+  }
+}
+
+/** Pure: map billing JSON into a display snapshot. */
+export function billingResponseToSnapshot(body: BillingConfigResponse, fetchedAt = Date.now()): UsageSnapshot {
+  const config = body.config || {};
+  const period = config.currentPeriod;
+
+  const usagePct = normalizePct(
+    config.creditUsagePercent ?? deriveLegacyPct(config.used?.val, config.monthlyLimit?.val) ?? 0,
+  );
+
+  const onDemandCap = config.onDemandCap?.val ?? 0;
+  const onDemandUsed = config.onDemandUsed?.val ?? 0;
+  const payAsYouGo = Math.abs(onDemandCap) > 0;
+
+  const productLines = (config.productUsage || [])
+    .filter((product) => product && (product.product || product.usagePercent != null))
+    .map((product) => {
+      const name = product.product || "product";
+      const pct = product.usagePercent != null ? `${normalizePct(product.usagePercent)}%` : "?";
+      return `${name}: ${pct}`;
+    });
+
+  const tier = body.subscriptionTier || body.subscription_tier || undefined;
+
+  return {
+    fetchedAt,
+    usagePct,
+    periodType: period?.type || undefined,
+    periodStart: period?.start || config.billingPeriodStart || undefined,
+    periodEnd: period?.end || config.billingPeriodEnd || undefined,
+    prepaidBalanceCents: config.prepaidBalance?.val,
+    onDemandCapCents: onDemandCap || undefined,
+    onDemandUsedCents: onDemandUsed || undefined,
+    payAsYouGo,
+    isUnifiedBillingUser: config.isUnifiedBillingUser,
+    subscriptionTier: typeof tier === "string" ? tier : undefined,
+    productLines,
+  };
+}
+
+export function formatUsageSummary(snap: UsageSnapshot): string {
+  // Floor % like Grok Build (never show 100 until truly exhausted).
+  const pct = Math.floor(snap.usagePct);
+  const lines: string[] = [];
+  lines.push(`${usageLabel(snap.periodType)}: ${pct}%`);
+
+  const reset = formatPeriodEnd(snap.periodEnd);
+  if (reset) lines.push(`Next reset: ${reset}`);
+
+  if (snap.subscriptionTier) lines.push(`Plan: ${snap.subscriptionTier}`);
+
+  if (snap.isUnifiedBillingUser != null) {
+    lines.push(`Billing: ${snap.isUnifiedBillingUser ? "unified pool" : "legacy / PAYG"}`);
+  }
+
+  const prepaid = snap.prepaidBalanceCents;
+  if (prepaid != null && Math.abs(prepaid) > 0) {
+    lines.push("");
+    lines.push(`Credits: ${fmtDollarsFromCents(prepaid)}`);
+  }
+
+  if (snap.payAsYouGo) {
+    const used = snap.onDemandUsedCents ?? 0;
+    const cap = snap.onDemandCapCents ?? 0;
+    lines.push("");
+    lines.push(`Pay-as-you-go: ${fmtDollarsFromCents(used)} used of ${fmtDollarsFromCents(cap)} limit`);
+  }
+
+  if (snap.productLines.length > 0) {
+    lines.push("");
+    lines.push("By product:");
+    for (const line of snap.productLines) lines.push(`  ${line}`);
+  }
+
+  lines.push("");
+  lines.push(`Manage: ${XAI_USAGE_MANAGE_URL}`);
+  if (pct >= 80) lines.push(`Upgrade: ${XAI_USAGE_UPGRADE_URL}`);
+  lines.push(`Fetched: ${new Date(snap.fetchedAt).toLocaleTimeString()}`);
+
+  return lines.join("\n");
+}
+
+export function formatUsageStatus(snap: UsageSnapshot): string {
+  const pct = Math.floor(snap.usagePct);
+  const period = footerPeriodLabel(snap.periodType);
+  return period ? `xAI ${period} ${pct}%` : `xAI ${pct}%`;
+}
+
+function paintStatus(ctx: ExtensionContext | ExtensionCommandContext, snap: UsageSnapshot): void {
+  ctx.ui.setStatus(XAI_USAGE_STATUS_KEY, formatUsageStatus(snap));
+}
+
+function usageLabel(periodType?: string): string {
+  const type = (periodType || "").toUpperCase();
+  if (type.includes("WEEKLY")) return "Weekly limit";
+  if (type.includes("MONTHLY")) return "Monthly limit";
+  return "Usage";
+}
+
+function footerPeriodLabel(periodType?: string): string | undefined {
+  const type = (periodType || "").toUpperCase();
+  if (type.includes("WEEKLY")) return "Weekly";
+  if (type.includes("MONTHLY")) return "Monthly";
+  return undefined;
+}
+
+function formatPeriodEnd(iso?: string): string | undefined {
+  if (!iso) return undefined;
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function fmtDollarsFromCents(cents: number): string {
+  const dollars = Math.abs(cents) / 100;
+  if (dollars === Math.trunc(dollars)) return `$${dollars.toFixed(0)}`;
+  return `$${dollars.toFixed(2)}`;
+}
+
+function deriveLegacyPct(used?: number, limit?: number): number | undefined {
+  if (used == null || limit == null) return undefined;
+  const absoluteUsed = Math.abs(used);
+  const absoluteLimit = Math.abs(limit);
+  if (absoluteLimit <= 0) return undefined;
+  return (absoluteUsed / absoluteLimit) * 100;
+}
+
+function normalizePct(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(100, Math.max(0, value));
+}
+
+function extractErrorDetail(body: string): string | null {
+  try {
+    const parsed = JSON.parse(body) as any;
+    if (typeof parsed?.error === "string") return parsed.error;
+    if (typeof parsed?.error?.message === "string") return parsed.error.message;
+    if (typeof parsed?.message === "string") return parsed.message;
+  } catch {
+    // ignore
+  }
+  const trimmed = body.trim();
+  return trimmed ? trimmed.slice(0, 200) : null;
+}
+
+/** Test helper: clear module runtime state. */
+export function resetXaiUsageRuntimeForTests(): void {
+  stopAutoRefresh();
+  runtime.cache = null;
+  runtime.inFlight = null;
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "scaffold": "node bin/setup.js --scaffold",
     "setup": "node bin/setup.js",
-    "test": "node scripts/verify-device-auth.js && node scripts/verify-catalog.js && node scripts/verify-extension.js && node scripts/verify-setup.js",
+    "test": "node scripts/verify-device-auth.js && node scripts/verify-catalog.js && node scripts/verify-usage.js && node scripts/verify-extension.js && node scripts/verify-setup.js",
     "typecheck": "npx tsc --noEmit"
   },
   "pi": {

--- a/scripts/verify-extension.js
+++ b/scripts/verify-extension.js
@@ -2368,6 +2368,8 @@ async function main() {
     assert.ok(provider, "xai-auth provider should be registered");
     assert.equal(secondLoad.tools.size, tools.size, "extension reloads should register tools on the new pi API object");
     assert.ok(firstLoad.commands.has("xai-tools"), "the xAI paid-tool command should be registered");
+    assert.ok(firstLoad.commands.has("xai-usage"), "the SuperGrok /xai-usage command should be registered");
+    assert.ok(!firstLoad.commands.has("usage"), "bare /usage should not be registered by this package");
     assert.equal(secondLoad.commands.size, firstLoad.commands.size, "extension reloads should register commands on the new pi API object");
     assert.equal(provider.api, "xai-responses");
     assert.equal(provider.baseUrl, "https://cli-chat-proxy.grok.com/v1", "xai-auth should register the OAuth session endpoint");

--- a/scripts/verify-usage.js
+++ b/scripts/verify-usage.js
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+const assert = require("assert");
+const path = require("path");
+const { createJiti } = require("jiti");
+
+const repoRoot = path.resolve(__dirname, "..");
+const jiti = createJiti(__filename, { interopDefault: true });
+const {
+  billingResponseToSnapshot,
+  formatUsageStatus,
+  formatUsageSummary,
+  XAI_BILLING_URL,
+  XAI_USAGE_MANAGE_URL,
+  resetXaiUsageRuntimeForTests,
+} = jiti(path.join(repoRoot, "extensions", "xai", "usage.ts"));
+
+function testBillingSnapshotWeekly() {
+  const snap = billingResponseToSnapshot(
+    {
+      config: {
+        currentPeriod: {
+          type: "USAGE_PERIOD_TYPE_WEEKLY",
+          start: "2026-07-13T09:30:46.497923+00:00",
+          end: "2026-07-20T09:30:46.497923+00:00",
+        },
+        creditUsagePercent: 4.7,
+        onDemandCap: { val: 0 },
+        onDemandUsed: { val: 0 },
+        productUsage: [{ product: "GrokBuild", usagePercent: 4.0 }],
+        isUnifiedBillingUser: true,
+        prepaidBalance: { val: 0 },
+      },
+      subscriptionTier: "SuperGrok",
+    },
+    Date.parse("2026-07-16T12:00:00.000Z"),
+  );
+
+  assert.strictEqual(snap.usagePct, 4.7);
+  assert.strictEqual(snap.periodType, "USAGE_PERIOD_TYPE_WEEKLY");
+  assert.strictEqual(snap.isUnifiedBillingUser, true);
+  assert.strictEqual(snap.payAsYouGo, false);
+  assert.deepStrictEqual(snap.productLines, ["GrokBuild: 4%"]);
+  assert.strictEqual(formatUsageStatus(snap), "xAI Weekly 4%");
+
+  const summary = formatUsageSummary(snap);
+  assert.match(summary, /Weekly limit: 4%/);
+  assert.match(summary, /Billing: unified pool/);
+  assert.match(summary, /By product:/);
+  assert.match(summary, /GrokBuild: 4%/);
+  assert.ok(summary.includes(XAI_USAGE_MANAGE_URL));
+  assert.ok(!summary.includes("Upgrade:"), "upgrade line only at high usage");
+}
+
+function testBillingSnapshotHighUsageUpgrade() {
+  const snap = billingResponseToSnapshot({
+    config: {
+      currentPeriod: { type: "USAGE_PERIOD_TYPE_MONTHLY" },
+      creditUsagePercent: 81.2,
+      isUnifiedBillingUser: true,
+    },
+  });
+  assert.strictEqual(formatUsageStatus(snap), "xAI Monthly 81%");
+  assert.match(formatUsageSummary(snap), /Upgrade:/);
+}
+
+function testLegacyMonthlyFields() {
+  const snap = billingResponseToSnapshot({
+    config: {
+      monthlyLimit: { val: 1000 },
+      used: { val: 250 },
+      billingPeriodEnd: "2026-08-01T00:00:00.000Z",
+    },
+  });
+  assert.strictEqual(snap.usagePct, 25);
+  assert.strictEqual(snap.periodEnd, "2026-08-01T00:00:00.000Z");
+}
+
+function testPayAsYouGoAndCredits() {
+  const snap = billingResponseToSnapshot({
+    config: {
+      creditUsagePercent: 10,
+      onDemandCap: { val: 5000 },
+      onDemandUsed: { val: 1234 },
+      prepaidBalance: { val: -1500 },
+      isUnifiedBillingUser: false,
+    },
+  });
+  assert.strictEqual(snap.payAsYouGo, true);
+  const summary = formatUsageSummary(snap);
+  assert.match(summary, /Credits: \$15/);
+  assert.match(summary, /Pay-as-you-go: \$12\.34 used of \$50 limit/);
+  assert.match(summary, /legacy \/ PAYG/);
+}
+
+function testBillingUrl() {
+  assert.strictEqual(XAI_BILLING_URL, "https://cli-chat-proxy.grok.com/v1/billing?format=credits");
+}
+
+function testCommandRegistration() {
+  resetXaiUsageRuntimeForTests();
+  const { registerXaiUsage } = jiti(path.join(repoRoot, "extensions", "xai", "usage.ts"));
+  const commands = new Map();
+  const events = [];
+  const pi = {
+    registerCommand(name, command) {
+      commands.set(name, command);
+    },
+    on(event, handler) {
+      events.push([event, handler]);
+    },
+  };
+  registerXaiUsage(pi);
+  registerXaiUsage(pi); // idempotent
+  assert.ok(commands.has("xai-usage"), "should register /xai-usage");
+  assert.ok(!commands.has("usage"), "should not register bare /usage");
+  assert.ok(!commands.has("cost"), "should not register /cost");
+  assert.ok(events.some(([name]) => name === "session_start"));
+  assert.ok(events.some(([name]) => name === "session_shutdown"));
+
+  const completions = commands.get("xai-usage").getArgumentCompletions("re");
+  assert.deepStrictEqual(
+    completions.map((item) => item.value),
+    ["refresh"],
+  );
+}
+
+async function main() {
+  testBillingUrl();
+  testBillingSnapshotWeekly();
+  testBillingSnapshotHighUsageUpgrade();
+  testLegacyMonthlyFields();
+  testPayAsYouGoAndCredits();
+  testCommandRegistration();
+  console.log("verify-usage: ok");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Adds **`/xai-usage`** so pi can show SuperGrok / Grok Build **account** weekly (or monthly) usage — the same billing surface as the official Grok Build CLI `/usage` command.

This is useful because OAuth/session users hit plan limits, but pi only had session token/cost in the footer (not remaining SuperGrok quota).

### What it does

- **`/xai-usage`** — show limit %, next reset, plan/billing mode, product breakdown, manage URL  
- **`/xai-usage refresh`** — force re-fetch  
- **`/xai-usage manage`** — print https://grok.com/?_s=usage and upgrade URL  
- **Footer status**: `xAI Weekly N%` (or `xAI Monthly N%`)  
- **Auto-refresh**: session start + every hour while the session is open  
- Account-level pool (independent of the currently selected model)

### Implementation notes

- Endpoint: `GET https://cli-chat-proxy.grok.com/v1/billing?format=credits`  
  (used by open-source [xai-org/grok-build](https://github.com/xai-org/grok-build); not a public docs.x.ai resource — parsing fails soft)
- Reuses existing `resolveXaiCredential()` for OAuth tokens  
- Only registers **`/xai-usage`** (no bare `/usage` or `/cost`, to avoid clashing with pi)

### Tests

- `scripts/verify-usage.js` (snapshot/format/command registration)
- `scripts/verify-extension.js` asserts `/xai-usage` is registered

```bash
node scripts/verify-usage.js
npm run typecheck
```

## Test plan

- [x] `node scripts/verify-usage.js`
- [x] `npm run typecheck`
- [ ] `pi update` / install branch; `/login xai-auth` if needed
- [ ] New session shows footer `xAI Weekly N%`
- [ ] `/xai-usage` shows weekly % + next reset
- [ ] `/xai-usage refresh` re-fetches
- [ ] `/xai-usage manage` prints manage/upgrade URLs
- [ ] Switching model does not break `/xai-usage` (still account pool)