### PR TITLE
Bound and test Pi peer compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: "24"
+  NPM_VERSION: "11.6.2"
+
+jobs:
+  policy:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.matrix.outputs.versions }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - name: Pin npm resolver
+        run: npm install --global npm@${NPM_VERSION}
+      - name: Install locked development dependencies
+        run: npm ci --strict-peer-deps
+      - name: Export exact compatibility matrix
+        id: matrix
+        run: echo "versions=$(node scripts/verify-compatibility.js matrix)" >> "$GITHUB_OUTPUT"
+      - name: Verify compatibility policy and range boundaries
+        run: node scripts/verify-compatibility.js policy
+      - name: Detect unreviewed releases inside the allowed range
+        run: node scripts/verify-compatibility.js registry
+      - name: Run tests
+        run: npm test
+      - name: Type-check
+        run: npm run typecheck
+      - name: Verify packed manifest and contents
+        run: node scripts/verify-compatibility.js pack
+      - name: Verify unsupported peer diagnostics
+        run: node scripts/verify-compatibility.js unsupported
+      - name: Inspect package dry run
+        run: npm pack --dry-run --json
+
+  compatibility:
+    needs: policy
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pi-version: ${{ fromJSON(needs.policy.outputs.versions) }}
+    name: Pi ${{ matrix.pi-version }} compatibility
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Pin npm resolver
+        run: npm install --global npm@${NPM_VERSION}
+      - name: Install and report exact Pi pair from the packed package
+        run: node scripts/run-compatibility-matrix.js "${{ matrix.pi-version }}"

--- a/.scaffold/constraints.md
+++ b/.scaffold/constraints.md
@@ -1,22 +1,21 @@
-# Constraints & Safety Rules — Issue #66
+# Constraints & Safety Rules — Issue #69
 
 ## Hard Boundaries (MUST NOT)
-- Never print, log, persist outside pi auth storage, or include in errors OAuth codes, opaque device codes, access/refresh/ID tokens, PKCE verifiers, state, nonce, raw token/device responses, or authenticated headers.
-- Never accept response-provided device/token endpoints, arbitrary discovery/JWKS/token URLs, arbitrary `*.x.ai` trust, raw browser codes, or callbacks without matching state.
-- Never retain an unvalidated device-flow ID token or weaken browser OIDC validation.
-- Never delete, revoke, migrate, or overwrite existing credentials except when pi persists a successfully completed selected login.
-- Never alter credential-aware Responses routing, proxy scopes/headers, authenticated catalog exactness, or paid-tool opt-in behavior.
-- Never attempt a live device flow without explicit user interaction in this pane.
+- Never advertise Pi releases that have not passed the packed-package compatibility suite.
+- Never let a matrix cell reuse the repository lockfile's Pi versions or pass without asserting the exact requested/resolved pair.
+- Never use `--legacy-peer-deps` or `--force` to make a supported compatibility cell pass.
+- Never widen into an untested pre-1.0 minor line; keep a conservative exclusive upper bound.
+- Never migrate the test framework, implement issue #68, modernize publishing, or upgrade unrelated dependencies.
+- Never alter OAuth, routing, proxy-header, catalog, OIDC/state, device-login, or paid-tool runtime behavior from issues #63-#67.
 
 ## Required Practices (MUST)
-- Work only on `feature/issue-66-device-code-auth` from merged main through PR #73.
-- Keep browser authorization-code + PKCE first/default in pi's native selector.
-- Use pinned `https://auth.x.ai/oauth2/device/code` and `https://auth.x.ai/oauth2/token`, the current public client ID, and the frozen ordered eight-scope string.
-- Wait before every token poll; honor at least the server interval; add five seconds cumulatively for `slow_down`; stop at the advertised expiry capped at 15 minutes.
-- Pass AbortSignal through initiation, sleeps, polling, and post-login catalog work; cancellation must return no credentials.
-- Use fixed local errors and bounded JSON/schema validation.
-- Keep environment detection advisory-only for selector copy; never auto-switch or reorder methods.
-- Update progress after major steps and complete strict validation plus independent review before delivery.
+- Work only on `feature/issue-69-pi-peer-range` from current merged `origin/main` through PR #75.
+- Keep both Pi peer ranges byte-identical unless a documented package constraint proves otherwise.
+- Keep normal development dependencies exact at the checked-in latest allowed release; use isolated exact installs for the minimum matrix boundary.
+- Verify source metadata, lock metadata, CI policy, registry maximum, and packed manifest cannot drift silently.
+- Prove older and next-minor versions fail the range and produce npm peer-resolution diagnostics before runtime loading.
+- Document a deliberate review/test process before changing the minimum, latest tested release, or upper bound.
+- Update scaffold progress after major steps and complete independent dependency/CI/correctness/docs review before delivery.
 
-## Live-flow Safety
-A live flow, if explicitly requested during this task, must remain in this pane, show only pi's native verification URL/user code UI, invoke no paid model/tool request, never print tokens or opaque device codes, and leave existing credentials unchanged unless the complete flow succeeds.
+## npm Test Safety
+`--force` is allowed only in a temporary negative consumer fixture to prove npm emits an unsupported-peer warning. Positive installs must use strict peer resolution in a clean packed-package sandbox.

--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -1,39 +1,30 @@
-# Shared Agent Context — Issue #66
+# Shared Agent Context — Issue #69
 
 **Project:** pi-xai-oauth
-**Branch:** feature/issue-66-device-code-auth
-**Date:** 2026-07-16
+**Branch:** feature/issue-69-pi-peer-range
+**Date:** 2026-07-17
 
 ## Issue Contract
-Add device authorization as a clear `/login xai-auth` option for SSH, WSL, containers, remote workspaces/VMs, and human-operated headless sessions. Browser authorization-code + PKCE remains the normal desktop default.
+Replace wildcard Pi peers with one aligned, bounded, evidence-backed pre-1.0 range. CI must install and report the exact minimum and latest allowed releases from the packed package, run the relevant tests/typecheck, detect policy drift, verify packed metadata, and prove unsupported peers are rejected or warned about during npm resolution.
 
-## Authoritative Protocol
-- Device endpoint: `https://auth.x.ai/oauth2/device/code`.
-- Token endpoint: `https://auth.x.ai/oauth2/token`.
-- Client ID: existing `b1a00492-073a-47ea-816f-4c329264a828`.
-- Scopes: existing ordered `openid profile email offline_access grok-cli:access api:access conversations:read conversations:write`.
-- Initiation is form-encoded `client_id`, `scope`, and truthful referrer/metadata; polling is form-encoded device grant URN, opaque `device_code`, and client ID.
-- Sleep before the first request; default omitted interval to 5 seconds, floor to 1 second, preserve pending cadence, and add 5 seconds cumulatively on `slow_down`.
-- Honor positive server `expires_in` and cap total flow at 15 minutes. This intentionally follows RFC/pi bounded expiry rather than the pinned official client's 10-minute minimum-floor quirk.
+## Compatibility History
+- 1.2.4 / `de8d667` + `c36901b`: adapted and tested Pi 0.79.8's OpenAI Responses API guard.
+- 1.3.2 / `39e8f53`: moved from the removed Pi 0.80 root Responses helper to the new subpath.
+- 1.3.3 / `9283e3f`: moved to `@earendil-works/pi-ai/compat` after the Pi 0.80 extension loader rewrote the subpath incorrectly.
+- Historical `eb3a700` proposed aligned `>=0.80.3 <0.81.0`, but that side-branch metadata/CI did not land on current main.
 
-## Pi Runtime Contract
-- `onSelect` preserves provider option order and highlights index zero; selector cancellation returns `undefined` without aborting.
-- `onDeviceCode` displays a clickable verification URL, user code, waiting text, and cancel hint; the provider owns polling.
-- Dialog cancellation aborts `callbacks.signal`; device initiation, sleep, polls, and catalog handoff must consume it.
-- `AuthStorage.login` persists only after provider login resolves, so rejection/cancellation preserves existing pi credentials.
-- `usesCallbackServer` remains enabled provider-wide for browser/manual redirect input; device mode avoids `onAuth` and manual input.
+## npm Contract
+- Peers express host compatibility; npm 7+ resolves them and strict-peer mode turns conflicts into install failures.
+- For stable releases, `^0.80.1` is effectively the 0.80 patch line; the explicit `>=0.80.1 <0.81.0` form communicates the reviewed breaking-line boundary.
+- A repository lock proves only one tree. Matrix cells must start from the packed tarball in a clean directory, install exact root Pi dev versions, and assert both resolved versions before tests.
+- A checked-in latest endpoint plus a registry-drift check makes future compatible-line releases deliberate rather than silently dynamic.
+
+## Selected Boundary
+Both peers use `>=0.80.1 <0.81.0`. Pi 0.80.1 is the first published 0.80 release, contains the required compat export/loader-alias contract, and passes the full packed `npm test` plus typecheck suite. Exact 0.80.7 is the latest allowed/tested endpoint. The exclusive upper bound remains `<0.81.0` until a reviewed 0.81 release passes as a temporary candidate before metadata is widened.
 
 ## Preservation Boundaries
-Browser state/raw-code/PKCE/OIDC validation from #67; scopes/proxy headers from #65; credential-aware routing from #63/#70; exact authenticated catalog/cache/account isolation from #64/#73; and refresh-token rotation/preservation all remain unchanged.
-
-## Delivery
-Reviewed implementation commit `9968f3b` was pushed on `feature/issue-66-device-code-auth`; unmerged PR #75 targets `main` and closes issue #66: https://github.com/BlockedPath/pi-xai-oauth/pull/75
-
-No live device flow was attempted. Deterministic protocol, registered-provider/catalog, and real pi AuthStorage integration tests validated behavior without touching existing credentials.
+All runtime behavior from issues #63-#67 remains unchanged. This task may change dependency/test/CI/docs metadata and a brittle test-only import path, but not production OAuth, catalog, transport, or tool behavior.
 
 ## Research Artifacts
-- `/tmp/issue66-official-research.md`
-- `/tmp/issue66-local-scout.md`
-- `/tmp/issue66-pi-context.md`
-- `/tmp/issue66-plan-review.md`
-- `/tmp/issue66-oracle.md`
+- `.pi-subagents/artifacts/outputs/cba02feb-19ae-45cf-92de-c9e58a1ea772/research.md`
+- `.pi-subagents/artifacts/outputs/cba02feb-19ae-45cf-92de-c9e58a1ea772/context.md`

--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -23,7 +23,10 @@ Replace wildcard Pi peers with one aligned, bounded, evidence-backed pre-1.0 ran
 Both peers use `>=0.80.1 <0.81.0`. Pi 0.80.1 is the first published 0.80 release, contains the required compat export/loader-alias contract, and passes the full packed `npm test` plus typecheck suite. Exact 0.80.7 is the latest allowed/tested endpoint. The exclusive upper bound remains `<0.81.0` until a reviewed 0.81 release passes as a temporary candidate before metadata is widened.
 
 ## Preservation Boundaries
-All runtime behavior from issues #63-#67 remains unchanged. This task may change dependency/test/CI/docs metadata and a brittle test-only import path, but not production OAuth, catalog, transport, or tool behavior.
+All runtime behavior from issues #63-#67 remains unchanged. This task changed dependency/test/CI/docs metadata and a brittle test-only import path, but no production OAuth, catalog, transport, or tool behavior.
+
+## Delivery
+Reviewed implementation commit `4ec249e` was pushed on `feature/issue-69-pi-peer-range`; unmerged PR #77 targets `main` and closes issue #69: https://github.com/BlockedPath/pi-xai-oauth/pull/77
 
 ## Research Artifacts
 - `.pi-subagents/artifacts/outputs/cba02feb-19ae-45cf-92de-c9e58a1ea772/research.md`

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -33,6 +33,6 @@ Publish an evidence-backed, bounded, aligned compatibility contract for `@earend
 - [x] Independent dependency, CI, correctness, and docs reviews; accepted fixes applied and focused re-review reported CLEAN.
 
 ## Delivery
-- [ ] Commit reviewed changes.
-- [ ] Push `feature/issue-69-pi-peer-range`.
-- [ ] Open an unmerged PR against `main` closing #69.
+- [x] Committed reviewed changes as `4ec249e` (`fix: bound and test Pi peer compatibility`).
+- [x] Pushed `feature/issue-69-pi-peer-range`.
+- [x] Opened unmerged PR #77 against `main`, closing #69: https://github.com/BlockedPath/pi-xai-oauth/pull/77

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,38 +1,38 @@
-# Implementation Plan: Issue #66 device-code authentication
+# Implementation Plan: Issue #69 bounded Pi peer compatibility
 
-**Branch:** feature/issue-66-device-code-auth
-**Date:** 2026-07-16
+**Branch:** feature/issue-69-pi-peer-range
+**Date:** 2026-07-17
 
 ## Goal
-Add secure, cancellable xAI device authorization for remote/headless human login while keeping browser authorization-code + PKCE first/default and preserving OAuth/OIDC, refresh, catalog, routing, and credential behavior from PRs #70-#73.
+Publish an evidence-backed, bounded, aligned compatibility contract for `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent`, and prove both exact matrix boundaries from the packed package without reusing the repository lockfile.
+
+## Research and Decision
+- [x] Read issue #69, current merged main, package/lock/workflow/test metadata, Pi package/extension/custom-provider docs and examples, npm peer/semver guidance, and compatibility-release history.
+- [x] Prove the earliest current Pi 0.80 release that passes the full packed test/typecheck suite after removing the test-only nested dependency-layout assumption.
+- [x] Record the selected aligned peer range, exact matrix endpoints, and conservative next-minor upper bound.
 
 ## Implementation
-- [x] Add pinned device endpoint/protocol constants and a focused dependency-injected device authorization module.
-- [x] Validate incrementally bounded device/token JSON, exact first-party URLs, safe user codes, intervals/expiry, and required access/refresh tokens without reflecting secrets or raw bodies.
-- [x] Poll with an initial wait, at least the server interval, cumulative 5-second `slow_down`, AbortSignal cancellation, bounded requests, and `min(expires_in, 15 minutes)` timeout.
-- [x] Add pi-native browser/device selection with browser first/default; environment detection changes recommendation text only.
-- [x] Send device success through the existing credential converter, post-login catalog refresh, and pi persistence path; ignore device ID tokens.
-- [x] Add deterministic focused protocol/method/context/timing/error/cancellation/rotation tests plus provider/catalog and AuthStorage integration coverage.
-- [x] Document browser versus device choice and `/login`/`/reload`/catalog behavior; update setup, changelog, AGENTS, and scaffold state.
+- [x] Add one checked-in compatibility policy shared by metadata tests, CI matrix generation, and local validation.
+- [x] Align peer, exact development, and lock metadata without widening the published support claim.
+- [x] Add plain-Node policy/range/registry-drift, packed-manifest, and unsupported-peer install verification.
+- [x] Add isolated packed-package matrix validation that installs and reports exact requested Pi pairs before running `npm test` and typecheck.
+- [x] Add PR/main CI jobs for the exact minimum and latest allowed releases.
+- [x] Document compatibility, local evaluation/widening, contribution, and release gates; update README, CHANGELOG, AGENTS, and scaffold state.
 
 ## Preservation Boundaries
-- Keep browser PKCE S256, callback state matching, raw-code rejection, pinned discovery/token/JWKS, nonce, and ES256 ID-token validation unchanged.
-- Keep current client ID, ordered eight scopes, proxy headers/routing, authenticated catalog exactness, and refresh-token rotation/preservation.
-- Never write/delete/revoke `~/.grok/auth.json`; pi writes its credential only after a selected login succeeds.
-- Never trust response-provided device/token endpoints, arbitrary `*.x.ai` endpoints, or upstream error text.
-- Do not attempt a live device flow without explicit user interaction in this pane.
+- Preserve runtime behavior from issues #63-#67, including OAuth routing, proxy headers, catalog exactness, OIDC/state security, and device authorization.
+- Do not migrate the test framework, implement issue #68, modernize the placeholder publish workflow, or upgrade unrelated dependencies.
+- Never use `--legacy-peer-deps` or `--force` for positive compatibility validation; `--force` is permitted only in an isolated negative test proving npm emits a peer warning before runtime.
 
 ## Validation Contract
-- [x] Changed-file LSP diagnostics.
-- [x] `node --unhandled-rejections=strict scripts/verify-device-auth.js`.
-- [x] Final `NODE_OPTIONS=--unhandled-rejections=strict npm test` after review fixes.
-- [x] `npm run typecheck`.
-- [x] `git diff --check`.
-- [x] Final `npm pack --dry-run --json` inspection (45 intended files; required runtime/tests/docs present; no scaffold, credentials, caches, or subagent artifacts).
-- [x] Independent correctness/security/timing/test/docs/package review completed; accepted fixes applied.
-- [x] Focused re-review reported `CLEAN`; final full validation passed.
+- [x] Changed-file LSP diagnostics (no errors/warnings; CommonJS/jiti hints only).
+- [x] `npm test` and `npm run typecheck`.
+- [x] Exact packed compatibility runs at both checked-in boundaries with requested/resolved version reporting.
+- [x] Policy/range, registry drift, packed manifest, and unsupported lower/upper peer checks.
+- [x] `npm pack --dry-run --json`, `git diff --check`, and workflow/schema inspection.
+- [x] Independent dependency, CI, correctness, and docs reviews; accepted fixes applied and focused re-review reported CLEAN.
 
 ## Delivery
-- [x] Committed reviewed implementation as `9968f3b` on `feature/issue-66-device-code-auth`.
-- [x] Pushed the feature branch to origin.
-- [x] Opened unmerged PR #75 against `main`, closing #66: https://github.com/BlockedPath/pi-xai-oauth/pull/75
+- [ ] Commit reviewed changes.
+- [ ] Push `feature/issue-69-pi-peer-range`.
+- [ ] Open an unmerged PR against `main` closing #69.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,40 +1,35 @@
 # Execution Progress
 
-**Project:** pi-xai-oauth Issue #66 device-code authentication
-**Branch:** feature/issue-66-device-code-auth
-**Started:** 2026-07-16
+**Project:** pi-xai-oauth Issue #69 bounded Pi peer compatibility
+**Branch:** feature/issue-69-pi-peer-range
+**Started:** 2026-07-17
 
 ## Research and Baseline
-- [x] Confirmed clean requested branch at current `origin/main` merge commit `13187a7` containing PRs #70/#71/#72/#73.
-- [x] Read AGENTS.md, complete issue #66, merged PR summaries, provider/setup/OAuth/OIDC/auth/catalog code, all verification scripts, README, changelog, and scaffold state.
-- [x] Read pi's complete custom-provider OAuth/device-code documentation, linked examples, callback types, TUI login wiring, persistence, cancellation, and built-in device pollers.
-- [x] Read the pinned official Grok authentication guide plus device/config/flow source at commit `b189869...`.
-- [x] Baseline LSP diagnostics, `npm test`, and `npm run typecheck` pass.
-- [x] Completed parallel official-protocol, local-code, and pi-runtime research plus independent planner/oracle review.
+- [x] Confirmed clean requested branch at current `origin/main` merge commit `665c036` containing PRs #70/#71/#72/#73/#75.
+- [x] Read AGENTS.md, complete issue #69 (no comments), package/lock metadata, all current workflows and verification scripts, README, CHANGELOG, CONTRIBUTING, and scaffold state.
+- [x] Read Pi's complete package, extension, and custom-provider docs plus linked extension/provider/dependency examples.
+- [x] Read official npm peer/lock/`npm ci` guidance, node-semver pre-1.0 caret behavior, and SemVer major-zero policy through delegated primary-source research.
+- [x] Audited compatibility history: 1.2.4 adapted to Pi 0.79.8's Responses guard; 1.3.2 adapted to Pi 0.80's export move; 1.3.3 adapted to the 0.80 extension-loader alias; historical commit `eb3a700` proposed `>=0.80.3 <0.81.0` but did not land on main.
+- [x] Confirmed both Pi packages publish aligned releases through 0.80.7 and no 0.81 release currently exists.
 
-## Accepted Design
-- Browser remains first/default; device is explicit and recommended via text only for WSL/SSH/container/non-TTY contexts.
-- Device and token POSTs are pinned; requests use the current client ID/scopes and truthful package attribution.
-- Device polling sleeps first, honors interval plus cumulative `slow_down`, uses fixed secret-safe errors, supports AbortSignal, and stops at `min(expires_in, 15 minutes)`.
-- Device ID tokens are ignored; successful access/refresh credentials use the existing converter, catalog refresh, refresh rotation, and pi persistence.
-- No live device flow will be attempted without explicit user interaction.
+## Current Findings
+- Baseline wildcard peers overclaimed support; caret dev ranges and the old lock silently tested only resolved 0.80.6.
+- A test-only hard-coded nested Pi dependency path failed clean exact-version installs regardless of API compatibility. It now resolves the public OAuth export from the same Pi dependency context as coding-agent `AuthStorage`, including npm 11 nested layouts.
+- Pi 0.80.1 is the selected real minimum: it is the first published 0.80 release, provides the required compat/loader contract, and passes the full packed tests/typecheck. Pi 0.80.7 is the exact latest allowed/tested endpoint; `<0.81.0` remains the safe upper bound.
 
 ## Implementation
-- [x] Added pinned device constants and a focused module with bounded JSON/schema/URL validation, secret-safe fixed errors, initial-wait polling, cumulative slow-down, expiry cap, request bounds, late-result rejection, and AbortSignal races.
-- [x] Added browser-first pi-native method selection, advisory WSL/SSH/container/headless labels, device UI callback, ignored device ID tokens, and shared credential/catalog completion.
-- [x] Added `verify-device-auth.js` deterministic clock/fetch/sleep coverage for request shape, contexts, UI, cadence, success, denial, expiry, HTTP/schema failures, redaction, cancellation, post-login handoff, and refresh rotation/preservation.
-- [x] Extended the browser integration regression to select browser explicitly and prove device UI is not invoked.
-- [x] Updated README, CHANGELOG, setup copy, AGENTS, and scaffold policy/context.
+- [x] Added central compatibility policy and aligned `>=0.80.1 <0.81.0` peer plus exact 0.80.7 development/lock metadata.
+- [x] Added plain-Node range/drift/pack/unsupported-install verifiers and exact packed matrix runner.
+- [x] Added PR/main CI matrix generated from checked-in exact policy endpoints.
+- [x] Added compatibility, widening, contribution/release, AGENTS, changelog, and scaffold documentation.
 
 ## Review and Validation
-- [x] Initial changed-file LSP diagnostics, strict focused/full tests, typecheck, diff check, and 45-file package inspection pass; JS files retain only pre-existing CommonJS/jiti hints.
-- [x] Four independent correctness, OAuth security/privacy, polling timing/cancellation, and tests/docs/package reviews completed.
-- [x] Accepted fixes: exact pi `Login cancelled` sentinel; incremental 64 KiB stream bound/cancellation; ignore `verification_uri_complete` and reject opaque-code reflection in base URI; observe promises before abort checks; expiry classification; hung request/body/timer and strict race tests; registered-provider catalog and real AuthStorage persistence/nonreplacement tests; corrected setup/docs/scaffold copy.
-- [x] Focused independent re-review verified listener cleanup and encoded/delimiter URI rejection and reported `CLEAN`.
-- [x] Final strict focused/full tests, TypeScript, diff check, changed-source LSP diagnostics, and 45-file npm package inspection pass.
-- [x] No live device flow was attempted; deterministic mocks plus registered-provider and real pi AuthStorage integration supplied validation without touching credentials.
+- [x] Exact 0.80.1/0.80.7 packed runs passed with requested/resolved pair reporting under the initial local resolver.
+- [x] Policy/range, registry drift, packed manifest, unsupported lower/upper diagnostics, full tests, typecheck, LSP hints, diff check, and YAML parse passed before independent review.
+- [x] Four independent dependency, CI, correctness, and docs reviews completed; accepted blockers cover npm 11 nested OAuth module identity, candidate-mode policy validation, unreleased README wording, release-gate ordering, and scaffold accuracy.
+- [x] Re-ran exact 0.80.1 and 0.80.7 packed boundaries under pinned npm 11.6.2; both reported the requested/resolved pair and passed full tests/typecheck.
+- [x] Final `npm test`, `npm run typecheck`, `npm run compatibility:check`, 49-file dry-run package inspection, LSP diagnostics, workflow YAML/schema checks, and `git diff --check` passed.
+- [x] Three focused independent re-reviewers validated npm 11 module identity, candidate mode, CI/script behavior, and docs/scaffold fixes; all reported `CLEAN`.
 
 ## Delivery
-- [x] Committed reviewed implementation as `9968f3b` (`Add xAI device-code authentication`).
-- [x] Pushed `feature/issue-66-device-code-auth` to origin.
-- [x] Opened unmerged PR #75 against `main`, closing #66: https://github.com/BlockedPath/pi-xai-oauth/pull/75
+- [ ] Commit, push, and open an unmerged PR against main closing #69.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -32,4 +32,5 @@
 - [x] Three focused independent re-reviewers validated npm 11 module identity, candidate mode, CI/script behavior, and docs/scaffold fixes; all reported `CLEAN`.
 
 ## Delivery
-- [ ] Commit, push, and open an unmerged PR against main closing #69.
+- [x] Committed the reviewed implementation as `4ec249e` (`fix: bound and test Pi peer compatibility`).
+- [x] Pushed `feature/issue-69-pi-peer-range` and opened unmerged PR #77 against main, closing #69: https://github.com/BlockedPath/pi-xai-oauth/pull/77

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,11 @@ Core flow: `bin/setup.js` → `pi install` → bounded catalog selection in `ext
 ## Key Commands (Exact, Copy-Paste Ready)
 - Install / setup: `node bin/setup.js` or `npm run setup`
 - Install as pi extension: `pi install npm:pi-xai-oauth`
-- Run TypeScript: `npx tsc --noEmit` (validate)
-- Git: Always work on feature branches. Current branch for this work: `feature/issue-66-device-code-auth`
+- Run TypeScript: `npm run typecheck` (validate)
+- Verify Pi policy/package metadata: `npm run compatibility:check`
+- Verify exact packed Pi boundaries: `npm run compatibility:boundaries`
+- Evaluate an unadvertised Pi candidate: `node scripts/run-compatibility-matrix.js X.Y.Z --candidate`
+- Git: Always work on feature branches. Current branch for this work: `feature/issue-69-pi-peer-range`
 
 ## Architecture & Boundaries (MUST / MUST NOT)
 **MUST:**
@@ -27,6 +30,9 @@ Core flow: `bin/setup.js` → `pi install` → bounded catalog selection in `ext
 - Treat successful catalog responses as exact entitlement state; additions appear and removals disappear
 - Keep the normalized token-free catalog cache atomic and apply the documented TTL/stale/fallback policy
 - Preserve known model metadata and compatibility behavior without advertising models absent from the authenticated catalog
+- Keep both Pi peers aligned to the checked-in bounded range in `compatibility/pi-versions.json`
+- Install/report exact Pi matrix versions from a clean packed package; never reuse the repository lockfile for boundary jobs
+- Keep normal Pi dev dependencies exact at the policy's latest tested release and review candidate releases before widening support
 
 **MUST NOT:**
 - Hardcode API keys (use OAuth only)
@@ -59,6 +65,13 @@ pi-xai-oauth/
 │       ├── responses.ts  # xAI request/stream helpers
 │       ├── routing.ts    # Credential-aware Responses/Images endpoint routing
 │       └── tools/        # Custom xAI tools + Cursor/Grok CLI shims
+├── compatibility/
+│   └── pi-versions.json # Peer range plus exact minimum/latest matrix policy
+├── scripts/
+│   ├── verify-compatibility.js # Policy/range/registry/pack/unsupported-peer checks
+│   └── run-compatibility-matrix.js # Clean packed exact-version test/typecheck runner
+├── .github/workflows/
+│   └── ci.yml           # PR/main policy and exact Pi boundary matrix
 ├── package.json
 ├── tsconfig.json
 ├── README.md
@@ -87,10 +100,12 @@ Start any task by reading:
 - Never retain a device-flow ID token without a device-specific validation policy; browser ID tokens keep nonce-bound OIDC validation
 - Reject malformed, hidden, unsupported-backend, secret-bearing, and known API-key-only catalog entries
 - Keep startup catalog network behavior bounded and use pi's credential lock for expired stored-token refresh
+- Keep compatibility verification in the existing plain-Node test style; do not migrate frameworks for issue #69
+- Use strict peer resolution for supported versions; `--force` is allowed only in isolated negative fixtures that assert npm peer warnings
 
 ## Safety Gates
 - Before any file edit: run `git status` and confirm on correct branch
-- Before committing: ensure `npx tsc --noEmit` passes
+- Before committing: ensure `npm test`, `npm run typecheck`, and both exact compatibility boundaries pass
 - For multi-agent work: always use the subagent tool with explicit parallel or chain mode
 - External state lives in `.scaffold/` — update progress.md after every major step
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 - Added authenticated OAuth-visible model discovery from the official CLI proxy `/models-v2` endpoint.
 - Added defensive model normalization plus an atomic, token-free last-known-good cache with a 15-minute fresh TTL, a 5-second bounded refresh, and a 7-day stale-if-transient window.
 - Added fixture-based coverage for catalog additions, removals, empty entitlements, malformed entries, API-key-only filtering, cache freshness, auth/network failures, and curated fallback selection.
+- Added packed-package compatibility validation at exact Pi 0.80.1 and 0.80.7 boundaries, with requested/resolved version reporting, range and registry-drift checks, packed-manifest inspection, and unsupported-peer install diagnostics.
+- Added PR/main CI that derives its exact compatibility matrix from the checked-in Pi version policy instead of reusing the development lockfile version.
 
 ### Changed
 
@@ -23,6 +25,8 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 - Made the authenticated account catalog authoritative for OAuth model additions and removals; known static metadata now enriches returned IDs without advertising unreturned models.
 - Made successful login force-refresh and immediately replace the model catalog, while `/reload` follows the documented cache TTL.
 - Kept browser authorization-code + PKCE as the desktop default while recommending device login in remote/headless selector copy without automatically changing the selected method.
+- Replaced wildcard Pi peers with the aligned, bounded `>=0.80.1 <0.81.0` range and pinned development metadata exactly to the latest tested boundary, 0.80.7.
+- Documented the deliberate candidate-test and review process required before widening support to another pre-1.0 Pi line.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,12 +47,44 @@ cd pi-xai-oauth
 # Install dependencies
 npm install
 
-# Run TypeScript check
-npx tsc --noEmit
+# Run the complete verification suite and TypeScript check
+npm test
+npm run typecheck
+
+# Verify compatibility policy, package metadata, and unsupported peers
+npm run compatibility:check
+
+# Verify the exact minimum/latest Pi boundaries from a clean packed package
+npm run compatibility:boundaries
 
 # Test the CLI
 node bin/setup.js --help
 ```
+
+## Pi Compatibility and Release Changes
+
+The compatibility contract lives in `compatibility/pi-versions.json`. Both Pi peer ranges must remain aligned, normal development dependencies must be exact at the policy's `latest` release, and CI derives its two exact matrix cells from that policy.
+
+To evaluate a future Pi release without advertising it prematurely:
+
+```bash
+node scripts/run-compatibility-matrix.js X.Y.Z --candidate
+```
+
+This changes metadata only inside a temporary extracted tarball. For a patch inside the allowed line, update the policy `latest`, both exact Pi dev dependencies, and `package-lock.json` only after the candidate passes. For a new pre-1.0 minor, keep the existing upper bound during evaluation and widen it only after the exact candidate passes the full packed tests/typecheck and review. If the minimum changes, test the immediately previous published release as unsupported and document the support break.
+
+Every dependency/compatibility PR and release must run:
+
+```bash
+npm test
+npm run typecheck
+npm run compatibility:check
+npm run compatibility:boundaries
+npm pack --dry-run --json
+git diff --check
+```
+
+Do not use `--legacy-peer-deps` or `--force` for supported-version validation. The verifier uses `--force` only inside temporary negative fixtures to prove npm emits peer warnings for unsupported hosts.
 
 ## Style Guidelines
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This package adds xAI's **account-specific OAuth model catalog** to pi, with **G
 
 > **Latest release:** `pi-xai-oauth` **1.3.5** keeps the highlighted `/xai-tools` row in place after toggling, so multiple tools can be configured without repeatedly navigating from the top. Version 1.3.4 made every network-backed xAI helper an explicit, session-scoped opt-in through `/xai-tools`, including paid image generation, and made disabled tools fail before OAuth credential lookup or network access. Existing npm installs should run `pi update npm:pi-xai-oauth`; local checkout installs should keep only one copy with `pi remove npm:pi-xai-oauth && pi install .`.
 >
-> **Compatibility note:** 1.2.4+ supports pi 0.79.8+'s OpenAI Responses API guard for Grok/xAI streaming.
+> **Compatibility note for the current checkout / next release:** aligned `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` versions `>=0.80.1 <0.81.0` are supported. The exact tested boundaries are 0.80.1 and 0.80.7. Published 1.3.5 predates this bounded peer metadata.
 
 See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and fix history.
 
@@ -50,6 +50,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and
 - [Changelog](CHANGELOG.md)
 - [How It Works](#how-it-works)
 - [Installation](#installation)
+- [Pi Compatibility](#pi-compatibility)
 - [Authentication](#authentication)
 - [Usage](#usage)
   - [Switching Models](#switching-models)
@@ -153,6 +154,23 @@ Then optionally configure it as default:
 > ```
 >
 > Use the exact package spec/path shown by `pi list` when removing duplicates.
+
+---
+
+## Pi Compatibility
+
+Both Pi runtime peers use the same bounded range:
+
+```text
+@earendil-works/pi-ai:            >=0.80.1 <0.81.0
+@earendil-works/pi-coding-agent:  >=0.80.1 <0.81.0
+```
+
+The lower boundary is **0.80.1**, the first published Pi 0.80 release. It provides the `@earendil-works/pi-ai/compat` transport used by this extension and the matching Pi 0.80 extension-loader contract. The packed package's complete test and typecheck suites run against exact 0.80.1 in CI. The other matrix boundary is exact **0.80.7**, the latest release inside the allowed line when this policy was reviewed.
+
+The exclusive `<0.81.0` upper bound is deliberate. Pi is pre-1.0, so a new minor line may contain breaking API or loader changes; this project does not claim support until that line passes the packed compatibility suite. npm therefore reports a peer-resolution warning or error during installation for older releases such as 0.79.10 and for the untested 0.81 line, rather than allowing a later runtime loader failure.
+
+Older `pi-xai-oauth` 1.2.4 builds supported Pi 0.79.8's then-current Responses guard. Current code uses the Pi 0.80 compat dispatcher after the 1.3.2 export migration and 1.3.3 loader-resolution fix, so that historical statement is not the current minimum.
 
 ---
 
@@ -612,7 +630,7 @@ pi update npm:pi-xai-oauth
 
 This pulls the latest version from npm and updates your installed extension.
 
-pi 0.79.8+ enforces an OpenAI Responses API guard. `pi-xai-oauth` 1.2.4+ handles that guard for Grok/xAI streaming; 1.3.3 fixes Responses transport resolution under pi 0.80's extension loader and includes Grok 4.5 as the default model. Version 1.3.4 makes all network-backed xAI helpers explicit opt-ins through `/xai-tools`, and **1.3.5** preserves the highlighted row while tools are toggled. If you installed the published npm package, update with the command above. If you are testing a local checkout instead, reinstall the checkout:
+The current checkout and next release require aligned Pi runtime packages in `>=0.80.1 <0.81.0`; published 1.3.5 predates the bounded metadata. Version 1.3.3 fixed Responses transport resolution under Pi 0.80's extension loader and includes Grok 4.5 as the default model. Version 1.3.4 makes all network-backed xAI helpers explicit opt-ins through `/xai-tools`, and **1.3.5** preserves the highlighted row while tools are toggled. If you installed the published npm package, update with the command above. If you are testing a local checkout instead, reinstall the checkout:
 
 ```bash
 pi remove npm:pi-xai-oauth && pi install .
@@ -678,6 +696,12 @@ npm run typecheck
 # Run verification tests
 npm test
 
+# Verify source/lock/range/registry/packed metadata and unsupported peers
+npm run compatibility:check
+
+# Repack, install, report, test, and typecheck both exact Pi boundaries
+npm run compatibility:boundaries
+
 # Install local version in pi
 pi install .
 
@@ -739,11 +763,16 @@ pi-xai-oauth/
 │       └── tools/            # Custom xAI tools + Cursor/Grok CLI shims
 ├── bin/
 │   └── setup.js              # One-command setup (npx pi-xai-oauth)
+├── compatibility/
+│   └── pi-versions.json      # Peer range plus exact minimum/latest CI policy
 ├── scripts/
+│   ├── run-compatibility-matrix.js # Clean packed exact-version test/typecheck runner
+│   ├── verify-compatibility.js # Range/lock/registry/pack/unsupported-peer checks
 │   ├── verify-device-auth.js # Deterministic device protocol/timing/cancellation tests
 │   ├── verify-catalog.js     # Catalog normalization/cache tests
 │   ├── verify-extension.js   # Provider/OAuth/transport integration tests
 │   └── verify-setup.js       # Installer/settings tests
+├── .github/workflows/ci.yml  # PR/main policy and exact Pi boundary matrix
 ├── .scaffold/                # Persistent agent state (plan, progress, etc.)
 ├── AGENTS.md                 # AI agent operations manual
 ├── package.json
@@ -751,11 +780,28 @@ pi-xai-oauth/
 └── README.md
 ```
 
-### Publishing
+### Compatibility updates and publishing
+
+`compatibility/pi-versions.json` is the single policy source for the peer range and exact CI endpoints. Normal development stays pinned exactly to the checked-in `latest` release; the minimum is tested only in a clean extracted tarball so the repository lock cannot mask version drift.
+
+When a new Pi patch appears inside the current range:
+
+1. Review both Pi package release notes.
+2. Evaluate it without changing the published claim: `node scripts/run-compatibility-matrix.js X.Y.Z --candidate`.
+3. If it passes, update `latest`, both exact Pi dev dependencies, and the lockfile together.
+4. Run `npm run compatibility:check` and `npm run compatibility:boundaries`, then record the result in CHANGELOG.
+
+For a new pre-1.0 minor line, keep the existing upper bound while running the candidate command. Widen the upper bound only after both Pi packages at that exact release pass the packed tests/typecheck and independent review. If raising the minimum, move the older sentinel to the immediately previous published release and document the support break. Never widen based only on Dependabot, typecheck, or a lockfile refresh.
+
+Before publishing, first bump `package.json` and `package-lock.json` together and finalize CHANGELOG. Then validate the exact release tree:
 
 ```bash
-# Bump version in package.json
-# Then:
+npm test
+npm run typecheck
+npm run compatibility:check
+npm run compatibility:boundaries
+npm pack --dry-run --json
+git diff --check
 npm publish
 
 # Users update with:

--- a/compatibility/pi-versions.json
+++ b/compatibility/pi-versions.json
@@ -1,0 +1,13 @@
+{
+  "packages": [
+    "@earendil-works/pi-ai",
+    "@earendil-works/pi-coding-agent"
+  ],
+  "peerRange": ">=0.80.1 <0.81.0",
+  "minimum": "0.80.1",
+  "latest": "0.80.7",
+  "unsupported": {
+    "older": "0.79.10",
+    "upper": "0.81.0"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,15 +12,15 @@
         "pi-xai-oauth": "bin/setup.js"
       },
       "devDependencies": {
-        "@earendil-works/pi-ai": "^0.80.3",
-        "@earendil-works/pi-coding-agent": "^0.80.3",
+        "@earendil-works/pi-ai": "0.80.7",
+        "@earendil-works/pi-coding-agent": "0.80.7",
         "@types/node": "^26.0.0",
         "jiti": "^2.7.0",
         "typescript": "^7.0.2"
       },
       "peerDependencies": {
-        "@earendil-works/pi-ai": "*",
-        "@earendil-works/pi-coding-agent": "*"
+        "@earendil-works/pi-ai": ">=0.80.1 <0.81.0",
+        "@earendil-works/pi-coding-agent": ">=0.80.1 <0.81.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -485,10 +485,26 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.80.7",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.7.tgz",
+      "integrity": "sha512-EFjyAuoz2kn24sR9Q5A86sZCG6mD+nz58DCsA2I2wxgmS50cF1tSLCBOZaHKI5U9Y3pJs4BefeK3LRkB5TdJag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.80.7",
+        "ignore": "7.0.5",
+        "typebox": "1.1.38",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
-      "integrity": "sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA==",
+      "version": "0.80.7",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.7.tgz",
+      "integrity": "sha512-8RLKLwe5TFM9kKFMNu/lTzveduq4GxZbnlG6ba8FAhLeb5wJP4zbj1eBumKBRvggpFQnW5R/Vo2a8zTlHsV9SQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -512,16 +528,15 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.6.tgz",
-      "integrity": "sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g==",
+      "version": "0.80.7",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.7.tgz",
+      "integrity": "sha512-mxq3IClhdgmCrYiKuzKehs4QKCVJgKmlA70nUEzsgeNsGdxriT7o5sKQTCcxzVJkzDRMcHD/8tAP4/eGrV4gKQ==",
       "dev": true,
-      "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.6",
-        "@earendil-works/pi-ai": "^0.80.3",
-        "@earendil-works/pi-tui": "^0.80.6",
+        "@earendil-works/pi-agent-core": "^0.80.7",
+        "@earendil-works/pi-ai": "^0.80.7",
+        "@earendil-works/pi-tui": "^0.80.7",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -546,546 +561,6 @@
       },
       "optionalDependencies": {
         "@mariozechner/clipboard": "0.3.9"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
-      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-crypto/supports-web-crypto": "^5.2.0",
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.1048.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
-      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/credential-provider-node": "^3.972.42",
-        "@aws-sdk/eventstream-handler-node": "^3.972.16",
-        "@aws-sdk/middleware-eventstream": "^3.972.12",
-        "@aws-sdk/middleware-websocket": "^3.972.19",
-        "@aws-sdk/token-providers": "3.1048.0",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/node-http-handler": "^4.7.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
-      "version": "3.974.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
-      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.24",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.2",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
-      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
-      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/node-http-handler": "^4.7.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
-      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/credential-provider-env": "^3.972.37",
-        "@aws-sdk/credential-provider-http": "^3.972.39",
-        "@aws-sdk/credential-provider-login": "^3.972.41",
-        "@aws-sdk/credential-provider-process": "^3.972.37",
-        "@aws-sdk/credential-provider-sso": "^3.972.41",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
-      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
-      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.37",
-        "@aws-sdk/credential-provider-http": "^3.972.39",
-        "@aws-sdk/credential-provider-ini": "^3.972.41",
-        "@aws-sdk/credential-provider-process": "^3.972.37",
-        "@aws-sdk/credential-provider-sso": "^3.972.41",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
-      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
-      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/token-providers": "3.1048.0",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
-      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
-      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
-      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
-      "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
-      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/node-http-handler": "^4.7.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
-      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1048.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
-      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
-      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
-      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@nodable/entities": "2.1.0",
-        "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.7.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
-      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.6.tgz",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.3",
-        "ignore": "7.0.5",
-        "typebox": "1.1.38",
-        "yaml": "2.9.0"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": "0.91.1",
-        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
-        "@opentelemetry/api": "1.9.0",
-        "@smithy/node-http-handler": "4.7.3",
-        "http-proxy-agent": "7.0.2",
-        "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
-        "partial-json": "0.1.7",
-        "typebox": "1.1.38"
-      },
-      "bin": {
-        "pi-ai": "./dist/cli.js"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "1.6.0",
-        "marked": "18.0.5"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
-      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-auth-library": "^10.3.0",
-        "p-retry": "^4.6.2",
-        "protobufjs": "^7.5.4",
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.2"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
@@ -1293,281 +768,12 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
-      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
-      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
       "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
-      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
-      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
-      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
-      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
-      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
-      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
       "version": "4.0.4",
@@ -1578,44 +784,6 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
-      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
       "version": "5.0.6",
@@ -1629,13 +797,6 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
       "version": "5.6.2",
@@ -1665,34 +826,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
@@ -1701,142 +834,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.7",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
-      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
-      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
-      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
@@ -1855,34 +852,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
-      "version": "10.6.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
-      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.1.4",
-        "gcp-metadata": "8.1.2",
-        "google-logging-utils": "1.1.3",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
@@ -1915,114 +884,12 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bignumber.js": "^9.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
-      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
       "version": "11.4.0",
@@ -2032,19 +899,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
-      "version": "18.0.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
-      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 20"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
@@ -2071,119 +925,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/retry": "0.12.0",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
-      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
@@ -2235,61 +976,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.1",
-        "@protobufjs/fetch": "^1.1.1",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.1",
-        "@types/node": ">=13.7.0",
-        "long": "^5.3.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
@@ -2333,40 +1019,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
@@ -2375,23 +1027,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
@@ -2410,78 +1045,18 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+    "node_modules/@earendil-works/pi-tui": {
+      "version": "0.80.7",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.7.tgz",
+      "integrity": "sha512-1B2++fLZfgI3XMzW2BTpuDuam2uyHnUUEmsOvi5R0Ne9RAt59WjFV0G8ozX6l1Xafa9P5Y3eT4aDtRr/v/CUTA==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
       },
       "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "dev": true,
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@google/genai": {
@@ -3321,6 +1896,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/google-auth-library": {
       "version": "10.6.2",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
@@ -3375,6 +1963,16 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/jiti": {
@@ -3440,6 +2038,19 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -3724,6 +2335,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,12 @@
   "scripts": {
     "scaffold": "node bin/setup.js --scaffold",
     "setup": "node bin/setup.js",
-    "test": "node scripts/verify-device-auth.js && node scripts/verify-catalog.js && node scripts/verify-extension.js && node scripts/verify-setup.js",
-    "typecheck": "npx tsc --noEmit"
+    "test": "node scripts/verify-compatibility.js policy && node scripts/verify-device-auth.js && node scripts/verify-catalog.js && node scripts/verify-extension.js && node scripts/verify-setup.js",
+    "typecheck": "tsc --noEmit",
+    "compatibility:check": "node scripts/verify-compatibility.js all",
+    "compatibility:min": "node scripts/run-compatibility-matrix.js minimum",
+    "compatibility:latest": "node scripts/run-compatibility-matrix.js latest",
+    "compatibility:boundaries": "npm run compatibility:min && npm run compatibility:latest"
   },
   "pi": {
     "extensions": [
@@ -33,12 +37,12 @@
     "image": "https://raw.githubusercontent.com/BlockedPath/pi-xai-oauth/main/preview.jpeg"
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-ai": ">=0.80.1 <0.81.0",
+    "@earendil-works/pi-coding-agent": ">=0.80.1 <0.81.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "^0.80.3",
-    "@earendil-works/pi-coding-agent": "^0.80.3",
+    "@earendil-works/pi-ai": "0.80.7",
+    "@earendil-works/pi-coding-agent": "0.80.7",
     "@types/node": "^26.0.0",
     "jiti": "^2.7.0",
     "typescript": "^7.0.2"

--- a/scripts/run-compatibility-matrix.js
+++ b/scripts/run-compatibility-matrix.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+const assert = require("assert");
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..");
+const policy = JSON.parse(
+  fs.readFileSync(path.join(repoRoot, "compatibility", "pi-versions.json"), "utf8"),
+);
+
+function run(command, args, options = {}) {
+  const printable = `${command} ${args.join(" ")}`;
+  console.log(`\n> ${printable}`);
+  const env = { ...process.env, ...options.env };
+  delete env.npm_config_allow_scripts;
+  delete env.NPM_CONFIG_ALLOW_SCRIPTS;
+  const result = spawnSync(command, args, {
+    cwd: options.cwd || repoRoot,
+    encoding: "utf8",
+    env,
+    stdio: options.capture ? "pipe" : "inherit",
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    if (options.capture) process.stderr.write(`${result.stdout || ""}${result.stderr || ""}`);
+    throw new Error(`${printable} failed with exit ${result.status}`);
+  }
+  return result;
+}
+
+function resolveRequestedVersion(value) {
+  if (value === "minimum") return policy.minimum;
+  if (value === "latest") return policy.latest;
+  assert.match(value || "", /^\d+\.\d+\.\d+$/, "Pass minimum, latest, or an exact Pi version");
+  return value;
+}
+
+function installedVersion(packageRoot, packageName) {
+  return JSON.parse(
+    fs.readFileSync(path.join(packageRoot, "node_modules", ...packageName.split("/"), "package.json"), "utf8"),
+  ).version;
+}
+
+function main() {
+  const requested = resolveRequestedVersion(process.argv[2]);
+  const candidate = process.argv.includes("--candidate");
+  const endpoints = new Set([policy.minimum, policy.latest]);
+  if (!candidate) {
+    assert.ok(
+      endpoints.has(requested),
+      `${requested} is not a checked-in matrix endpoint; use --candidate for a temporary future-release evaluation`,
+    );
+  }
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `pi-xai-oauth-compat-${requested}-`));
+  const packDirectory = path.join(root, "packed");
+  const extractDirectory = path.join(root, "workspace");
+  fs.mkdirSync(packDirectory, { recursive: true });
+  fs.mkdirSync(extractDirectory, { recursive: true });
+
+  try {
+    const packResult = run("npm", ["pack", "--json", "--pack-destination", packDirectory], {
+      capture: true,
+    });
+    const parsedPack = JSON.parse(packResult.stdout);
+    const packEntries = Array.isArray(parsedPack) ? parsedPack : Object.values(parsedPack);
+    assert.strictEqual(packEntries.length, 1, "npm pack must produce exactly one tarball");
+    const tarballPath = path.join(packDirectory, packEntries[0].filename);
+    run("tar", ["-xzf", tarballPath, "-C", extractDirectory]);
+
+    const packageRoot = path.join(extractDirectory, "package");
+    const manifestPath = path.join(packageRoot, "package.json");
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+    for (const packageName of policy.packages) {
+      manifest.devDependencies[packageName] = requested;
+      if (candidate) manifest.peerDependencies[packageName] = requested;
+    }
+    fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+    fs.rmSync(path.join(packageRoot, "package-lock.json"), { force: true });
+    fs.rmSync(path.join(packageRoot, "node_modules"), { recursive: true, force: true });
+
+    console.log(
+      `\nPi compatibility ${candidate ? "candidate" : "boundary"}: requested-ai=${requested} requested-agent=${requested}`,
+    );
+    run(
+      "npm",
+      [
+        "install",
+        "--strict-peer-deps",
+        "--ignore-scripts",
+        "--no-audit",
+        "--no-fund",
+        "--package-lock=false",
+      ],
+      { cwd: packageRoot },
+    );
+
+    const resolvedAi = installedVersion(packageRoot, policy.packages[0]);
+    const resolvedAgent = installedVersion(packageRoot, policy.packages[1]);
+    console.log(`Pi compatibility resolved: ai=${resolvedAi} agent=${resolvedAgent}`);
+    assert.strictEqual(resolvedAi, requested, `Resolved ${policy.packages[0]} drifted from the requested version`);
+    assert.strictEqual(resolvedAgent, requested, `Resolved ${policy.packages[1]} drifted from the requested version`);
+
+    run("npm", ["ls", ...policy.packages, "--depth=0"], { cwd: packageRoot });
+    const matrixEnv = {
+      PI_COMPAT_MATRIX_VERSION: requested,
+      ...(candidate ? { PI_COMPAT_CANDIDATE_PEER_VERSION: requested } : {}),
+    };
+    run("npm", ["test"], { cwd: packageRoot, env: matrixEnv });
+    run("npm", ["run", "typecheck"], { cwd: packageRoot, env: matrixEnv });
+    console.log(`\nPi compatibility ${requested}: ok`);
+  } finally {
+    if (process.env.KEEP_PI_COMPAT_TEMP === "1") {
+      console.log(`Compatibility workspace retained at ${root}`);
+    } else {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }
+}
+
+main();

--- a/scripts/verify-compatibility.js
+++ b/scripts/verify-compatibility.js
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+
+const assert = require("assert");
+const { execFileSync, spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..");
+const policyPath = path.join(repoRoot, "compatibility", "pi-versions.json");
+const packagePath = path.join(repoRoot, "package.json");
+const lockPath = path.join(repoRoot, "package-lock.json");
+const workflowPath = path.join(repoRoot, ".github", "workflows", "ci.yml");
+const policy = JSON.parse(fs.readFileSync(policyPath, "utf8"));
+
+function parseVersion(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  assert.ok(match, `Expected an exact stable semantic version, received ${JSON.stringify(version)}`);
+  return match.slice(1).map(Number);
+}
+
+function compareVersions(left, right) {
+  const a = parseVersion(left);
+  const b = parseVersion(right);
+  for (let index = 0; index < a.length; index++) {
+    if (a[index] !== b[index]) return a[index] < b[index] ? -1 : 1;
+  }
+  return 0;
+}
+
+function parsePeerRange(range) {
+  const match = /^>=(\d+\.\d+\.\d+) <(\d+\.\d+\.\d+)$/.exec(range);
+  assert.ok(match, `Peer range must use the explicit ">=minimum <next-line" policy form: ${range}`);
+  return { minimum: match[1], upper: match[2] };
+}
+
+function satisfiesPeerRange(version, range = policy.peerRange) {
+  const bounds = parsePeerRange(range);
+  return compareVersions(version, bounds.minimum) >= 0 && compareVersions(version, bounds.upper) < 0;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function run(command, args, options = {}) {
+  const env = { ...process.env, ...options.env };
+  delete env.npm_config_allow_scripts;
+  delete env.NPM_CONFIG_ALLOW_SCRIPTS;
+  const result = spawnSync(command, args, {
+    cwd: options.cwd || repoRoot,
+    encoding: "utf8",
+    env,
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  if (options.expectFailure) {
+    assert.notStrictEqual(result.status, 0, `${command} ${args.join(" ")} unexpectedly succeeded`);
+  } else if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} failed with exit ${result.status}\n${result.stdout || ""}${result.stderr || ""}`,
+    );
+  }
+  return result;
+}
+
+function assertPeerDiagnostics(output, version) {
+  assert.match(output, /ERESOLVE|peer dependency|Conflicting peer dependency/i);
+  assert.ok(
+    policy.packages.some((packageName) => output.includes(packageName)),
+    `Expected npm peer diagnostics to name a Pi peer for ${version}`,
+  );
+  assert.ok(
+    output.includes(policy.peerRange) || output.includes(policy.peerRange.replace(" ", "")),
+    `Expected npm peer diagnostics to include ${policy.peerRange} for ${version}`,
+  );
+}
+
+function verifyPolicy() {
+  assert.deepStrictEqual(policy.packages, [
+    "@earendil-works/pi-ai",
+    "@earendil-works/pi-coding-agent",
+  ]);
+
+  const manifest = readJson(packagePath);
+  const expectedDevelopmentVersion = process.env.PI_COMPAT_MATRIX_VERSION || policy.latest;
+  const expectedPeerRange = process.env.PI_COMPAT_CANDIDATE_PEER_VERSION || policy.peerRange;
+  const ranges = policy.packages.map((packageName) => manifest.peerDependencies?.[packageName]);
+  assert.ok(ranges.every((range) => range === expectedPeerRange), "Pi peer ranges must match the active compatibility policy");
+  assert.strictEqual(new Set(ranges).size, 1, "Pi peer ranges must remain aligned");
+
+  const bounds = parsePeerRange(policy.peerRange);
+  assert.strictEqual(bounds.minimum, policy.minimum, "Peer lower bound must match policy.minimum");
+  assert.strictEqual(bounds.upper, policy.unsupported.upper, "Upper sentinel must be the peer range's immediate excluded line");
+  assert.ok(satisfiesPeerRange(policy.minimum), "Minimum release must satisfy the peer range");
+  assert.ok(satisfiesPeerRange(policy.latest), "Latest matrix release must satisfy the peer range");
+  assert.ok(!satisfiesPeerRange(policy.unsupported.older), "Older unsupported release must not satisfy the peer range");
+  assert.ok(!satisfiesPeerRange(policy.unsupported.upper), "Upper breaking-line release must not satisfy the peer range");
+  assert.ok(compareVersions(policy.minimum, policy.latest) <= 0, "Minimum must not exceed latest");
+
+  for (const packageName of policy.packages) {
+    assert.strictEqual(
+      manifest.devDependencies?.[packageName],
+      expectedDevelopmentVersion,
+      `${packageName} development metadata must be exact at ${expectedDevelopmentVersion}`,
+    );
+  }
+
+  if (!process.env.PI_COMPAT_MATRIX_VERSION) {
+    const lock = readJson(lockPath);
+    const lockRoot = lock.packages?.[""];
+    assert.ok(lockRoot, "package-lock.json must contain root package metadata");
+    for (const packageName of policy.packages) {
+      assert.strictEqual(lockRoot.peerDependencies?.[packageName], policy.peerRange);
+      assert.strictEqual(lockRoot.devDependencies?.[packageName], policy.latest);
+      assert.strictEqual(
+        lock.packages?.[`node_modules/${packageName}`]?.version,
+        policy.latest,
+        `The root lock entry for ${packageName} must resolve the checked-in latest release`,
+      );
+    }
+
+    const workflow = fs.readFileSync(workflowPath, "utf8");
+    assert.match(workflow, /verify-compatibility\.js matrix/);
+    assert.match(workflow, /fromJSON\(needs\.policy\.outputs\.versions\)/);
+    assert.doesNotMatch(
+      workflow,
+      /pi-version:\s*\[\s*["']?\d+\.\d+\.\d+/,
+      "CI must consume matrix endpoints from compatibility/pi-versions.json instead of duplicating them",
+    );
+  }
+
+  console.log(
+    `compatibility policy: peers=${policy.peerRange} minimum=${policy.minimum} latest=${policy.latest}`,
+  );
+}
+
+function registryVersions(packageName) {
+  const output = execFileSync(
+    "npm",
+    ["view", `${packageName}@${policy.peerRange}`, "version", "--json"],
+    { cwd: repoRoot, encoding: "utf8", maxBuffer: 10 * 1024 * 1024 },
+  );
+  const parsed = JSON.parse(output);
+  return (Array.isArray(parsed) ? parsed : [parsed]).filter((version) => typeof version === "string");
+}
+
+function verifyRegistry() {
+  for (const packageName of policy.packages) {
+    const versions = registryVersions(packageName).filter((version) => /^\d+\.\d+\.\d+$/.test(version));
+    assert.ok(versions.includes(policy.minimum), `${packageName}@${policy.minimum} must remain published`);
+    versions.sort(compareVersions);
+    assert.strictEqual(
+      versions.at(-1),
+      policy.latest,
+      `${packageName} has a newer release inside ${policy.peerRange}; review it and deliberately update policy.latest`,
+    );
+  }
+  console.log(`registry policy: latest allowed release is exactly ${policy.latest} for both Pi peers`);
+}
+
+function packProject() {
+  const outputDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "pi-xai-oauth-pack-"));
+  try {
+    const result = run("npm", ["pack", "--json", "--pack-destination", outputDirectory]);
+    const parsed = JSON.parse(result.stdout);
+    const entries = Array.isArray(parsed) ? parsed : Object.values(parsed);
+    assert.strictEqual(entries.length, 1, "npm pack must produce exactly one tarball");
+    return {
+      outputDirectory,
+      tarballPath: path.join(outputDirectory, entries[0].filename),
+      files: entries[0].files.map((entry) => entry.path),
+    };
+  } catch (error) {
+    fs.rmSync(outputDirectory, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function verifyPackedPackage() {
+  const packed = packProject();
+  try {
+    const manifestText = execFileSync("tar", ["-xOf", packed.tarballPath, "package/package.json"], {
+      encoding: "utf8",
+    });
+    const sourceManifest = readJson(packagePath);
+    const packedManifest = JSON.parse(manifestText);
+    assert.strictEqual(packedManifest.name, sourceManifest.name);
+    assert.strictEqual(packedManifest.version, sourceManifest.version);
+    for (const packageName of policy.packages) {
+      assert.strictEqual(packedManifest.peerDependencies?.[packageName], policy.peerRange);
+    }
+
+    const required = [
+      "package.json",
+      "README.md",
+      "CHANGELOG.md",
+      "LICENSE",
+      "compatibility/pi-versions.json",
+      "extensions/xai-oauth.ts",
+      "scripts/verify-compatibility.js",
+      "scripts/run-compatibility-matrix.js",
+    ];
+    for (const file of required) assert.ok(packed.files.includes(file), `Packed package is missing ${file}`);
+
+    const forbidden = ["node_modules/", ".git/", ".scaffold/", ".pi-subagents/", ".env", "auth.json"];
+    for (const file of packed.files) {
+      assert.ok(!forbidden.some((prefix) => file === prefix || file.startsWith(prefix)), `Packed forbidden path: ${file}`);
+    }
+    console.log(`packed manifest: ${packed.files.length} files with peer range ${policy.peerRange}`);
+  } finally {
+    fs.rmSync(packed.outputDirectory, { recursive: true, force: true });
+  }
+}
+
+function writeStubPackage(root, packageName, version) {
+  const slug = packageName.replace(/[^a-z0-9]+/gi, "-").replace(/^-|-$/g, "");
+  const sourceRoot = path.join(root, slug);
+  const packageDirectory = path.join(sourceRoot, "package");
+  const tarballPath = path.join(root, `${slug}-${version}.tgz`);
+  fs.mkdirSync(packageDirectory, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageDirectory, "package.json"),
+    `${JSON.stringify({ name: packageName, version }, null, 2)}\n`,
+  );
+  execFileSync("tar", ["-czf", tarballPath, "-C", sourceRoot, "package"]);
+  return tarballPath;
+}
+
+function writeConsumer(directory, tarballPath, version, stubRoot) {
+  const dependencies = { "pi-xai-oauth": `file:${tarballPath}` };
+  for (const packageName of policy.packages) {
+    dependencies[packageName] = `file:${writeStubPackage(stubRoot, packageName, version)}`;
+  }
+  fs.mkdirSync(directory, { recursive: true });
+  fs.writeFileSync(
+    path.join(directory, "package.json"),
+    `${JSON.stringify({ name: "pi-peer-negative-fixture", private: true, version: "1.0.0", dependencies }, null, 2)}\n`,
+  );
+}
+
+function verifyUnsupportedInstalls() {
+  const packed = packProject();
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-xai-oauth-peer-negative-"));
+  try {
+    for (const version of [policy.unsupported.older, policy.unsupported.upper]) {
+      const strictDirectory = path.join(root, version, "strict");
+      writeConsumer(strictDirectory, packed.tarballPath, version, path.join(root, version, "strict-stubs"));
+      const strict = run(
+        "npm",
+        ["install", "--strict-peer-deps", "--ignore-scripts", "--no-audit", "--no-fund", "--package-lock=false"],
+        { cwd: strictDirectory, expectFailure: true },
+      );
+      assertPeerDiagnostics(`${strict.stdout}\n${strict.stderr}`, version);
+
+      const warningDirectory = path.join(root, version, "warning");
+      writeConsumer(warningDirectory, packed.tarballPath, version, path.join(root, version, "warning-stubs"));
+      const warning = run(
+        "npm",
+        ["install", "--force", "--ignore-scripts", "--no-audit", "--no-fund", "--package-lock=false"],
+        { cwd: warningDirectory },
+      );
+      assertPeerDiagnostics(`${warning.stdout}\n${warning.stderr}`, version);
+      console.log(`unsupported peer ${version}: strict install rejected; forced install emitted a peer warning`);
+    }
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(packed.outputDirectory, { recursive: true, force: true });
+  }
+}
+
+function printMatrix() {
+  process.stdout.write(`${JSON.stringify([policy.minimum, policy.latest])}\n`);
+}
+
+function main() {
+  const command = process.argv[2] || "policy";
+  if (command === "matrix") return printMatrix();
+  if (command === "policy") return verifyPolicy();
+  if (command === "registry") return verifyRegistry();
+  if (command === "pack") return verifyPackedPackage();
+  if (command === "unsupported") return verifyUnsupportedInstalls();
+  if (command === "all") {
+    verifyPolicy();
+    verifyRegistry();
+    verifyPackedPackage();
+    verifyUnsupportedInstalls();
+    return;
+  }
+  throw new Error(`Unknown compatibility verification command: ${command}`);
+}
+
+main();

--- a/scripts/verify-device-auth.js
+++ b/scripts/verify-device-auth.js
@@ -11,20 +11,10 @@ const {
   pollXaiDeviceAuthorization,
   requestXaiDeviceAuthorization,
 } = jiti(path.join(repoRoot, "extensions", "xai", "device-auth.ts"));
+const codingAgentEntry = jiti.resolve("@earendil-works/pi-coding-agent");
+const codingAgentJiti = createJiti(codingAgentEntry, { interopDefault: true });
 const { AuthStorage } = jiti("@earendil-works/pi-coding-agent");
-const { registerOAuthProvider } = jiti(path.join(
-  repoRoot,
-  "node_modules",
-  "@earendil-works",
-  "pi-coding-agent",
-  "node_modules",
-  "@earendil-works",
-  "pi-ai",
-  "dist",
-  "utils",
-  "oauth",
-  "index.js",
-));
+const { registerOAuthProvider } = codingAgentJiti("@earendil-works/pi-ai/oauth");
 const {
   createXaiOAuth,
   detectXaiLoginContext,


### PR DESCRIPTION
## Summary

- replace wildcard Pi peers with the aligned `>=0.80.1 <0.81.0` compatibility contract
- pin normal development/lock metadata exactly to Pi 0.80.7
- add a checked-in policy, registry drift/range/pack/unsupported-peer checks, and clean packed-package boundary runner
- add PR/main CI that installs, reports, tests, and typechecks exact Pi 0.80.1 and 0.80.7 pairs without reusing the repository lockfile Pi version
- document the evidence-backed minimum, safe pre-1.0 upper bound, and deliberate future-release evaluation/widening process

## Minimum rationale

Pi 0.80.1 is the first published 0.80 release for both peer packages and the first line containing the current `@earendil-works/pi-ai/compat` transport plus matching extension-loader contract. The current packed package's complete tests and typecheck pass with both peers installed exactly at 0.80.1. Pi 0.79.10 lacks that compat entry and is now verified as unsupported at npm peer resolution. The `<0.81.0` bound avoids claiming an untested pre-1.0 breaking line.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run compatibility:check`
- clean packed exact Pi 0.80.1 matrix under npm 11.6.2
- clean packed exact Pi 0.80.7 matrix under npm 11.6.2
- candidate-mode validation
- `npm pack --dry-run --json` (49 intended files)
- workflow YAML/schema inspection
- changed-file LSP diagnostics (no errors/warnings)
- `git diff --check`
- independent dependency, CI, correctness, and docs review; accepted fixes applied
- focused re-review: CLEAN from all three reviewers

Closes #69.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes published peer ranges and install/CI gates, so npm may reject previously allowed Pi versions; runtime auth and API paths are untouched.
> 
> **Overview**
> Replaces wildcard `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` peers with a single aligned **`>=0.80.1 <0.81.0`** contract, pins dev/lock metadata to exact **0.80.7**, and adds **`compatibility/pi-versions.json`** as the shared policy for peers, matrix endpoints, and unsupported sentinels.
> 
> Adds **`scripts/verify-compatibility.js`** (policy/lock/workflow drift, registry max inside the range, packed manifest checks, unsupported-peer npm diagnostics) and **`scripts/run-compatibility-matrix.js`** (repack, clean install with strict peers, assert requested/resolved Pi pairs, then `npm test` + typecheck). **`npm test`** now runs the policy check first; new **`compatibility:*`** scripts wrap local validation.
> 
> Introduces **`.github/workflows/ci.yml`**: a **policy** job on PR/main and a **compatibility** matrix job for exact **0.80.1** and **0.80.7** derived from the policy output—not the repo lockfile.
> 
> **`scripts/verify-device-auth.js`** stops using a hard-coded nested `pi-ai` path and resolves OAuth via the same public export as `AuthStorage` (npm 11 nested layouts). README, CHANGELOG, CONTRIBUTING, and AGENTS document widening via **`--candidate`** evaluation. No production OAuth, catalog, or transport behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b145c926593b01954f311c3bd8eb0f5140ae00d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->