### PR TITLE
docs: keep goal and plan workflows out of pi-xai-oauth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 - Added disabled-by-default, session-scoped vision routing for exact authenticated text-only entitlements, with deterministic exact-catalog target selection, a bounded image-only description request, final image-free enforcement, lifecycle invalidation, and `/xai-tools` cost/privacy controls.
 - Added disabled-by-default `xai_image_to_video` with pinned create/status polling, DNS-pinned unauthenticated MP4 download, bounded streamed private storage, and honest remote-job cancellation semantics.
 
+### Changed
+
+- Recorded the package-scope decision to keep provider-neutral goal/plan workflows, autonomous continuation, runtime plan management, and write-restriction policy out of `pi-xai-oauth`; see [ADR 0001](docs/decisions/0001-goal-plan-package-scope.md).
+
 ### Fixed
 
 - Contained the direct Grok-native `read_file`, `search_replace`, and `list_dir` adapters to resolved workspace paths, safely limited missing-leaf creation to contained physical parents, and capped package-owned full text reads at 5,000,000 bytes. `run_terminal_command` remains an unrestricted delegation to pi `bash`, so this is direct-adapter defense-in-depth rather than a filesystem sandbox.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and
 
 - [✨ New: Grok 4.5](#-new-grok-45)
 - [Features](#features)
+- [Package Scope](#package-scope)
 - [Changelog](CHANGELOG.md)
 - [How It Works](#how-it-works)
 - [Installation](#installation)
@@ -87,6 +88,16 @@ See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and
 - **Revision-pinned wire contract** — route-specific headers, truthful package identity, protected request metadata, redirect rejection, and the upstream Grok Build review procedure are documented without impersonating the official client
 
 > **✅ Verified (May 2026)**: All custom xAI tools (`xai_generate_text`, `xai_x_search`, `xai_web_search`, `xai_code_execution`, `xai_critique`, `xai_multi_agent`, `xai_deep_research`, image tools, etc.) have been tested end-to-end after the OAuth + payload repair. The provider now correctly handles mixed-model requests and native xAI tool shapes.
+
+---
+
+## Package Scope
+
+`pi-xai-oauth` owns the xAI-specific integration needed to use entitled Grok models through pi: authentication and credentials, account-specific catalogs, transport and payload behavior, Grok-native compatibility adapters, opt-in network tools, and media integrations. It intentionally does not provide generic `/goal` or `/plan` commands, autonomous continuation, a runtime plan-file protocol, generic task/subagent orchestration, or plan-mode write restriction. See [ADR 0001](docs/decisions/0001-goal-plan-package-scope.md) for the decision and alternatives.
+
+Tool hiding, active-tool filtering, and shell-command filtering are workflow controls, not an enforced read-only boundary. Pi and its extensions run with the user's permissions; strong isolation requires an external sandbox, container, or VM that constrains every tool and extension involved.
+
+The optional [`--scaffold`](#agent-scaffolding) command is separate: it performs one-time generation of `AGENTS.md` and `.scaffold/*` guidance files in the current directory. It is not a runtime workflow controller, an authoritative plan-state protocol, or a security mechanism.
 
 ---
 

--- a/docs/decisions/0001-goal-plan-package-scope.md
+++ b/docs/decisions/0001-goal-plan-package-scope.md
@@ -1,0 +1,115 @@
+# ADR 0001: Keep goal and plan workflows out of `pi-xai-oauth`
+
+- **Status:** Accepted
+- **Date:** 2026-07-16
+- **Last reviewed:** 2026-07-19
+- **Issue:** [#85](https://github.com/BlockedPath/pi-xai-oauth/issues/85)
+- **Decision owners:** `pi-xai-oauth` maintainers
+
+## Context
+
+Grok-style `/goal` and `/plan` workflows can improve agentic coding, but they do not require xAI OAuth, an xAI model entitlement, the Grok CLI proxy, or another provider capability owned by this package. Installing an authentication provider should not silently install an autonomous task controller, an authoritative workspace plan-file protocol, or a write-restriction policy.
+
+This package owns the xAI-specific integration needed to use entitled Grok models through Pi: authentication and credentials, account-specific catalogs, transport and payload behavior, Grok-native compatibility adapters, opt-in network tools, and media integrations. Goal state, plan approval, task continuation, generic subagent orchestration, and sandbox policy are provider-neutral concerns.
+
+This record compares three locations for those workflows:
+
+1. inside `pi-xai-oauth`;
+2. in a separately installed provider-neutral package;
+3. in existing provider-neutral Pi extensions and prompt templates.
+
+The decision was initially researched against Pi 0.80.7 and was revalidated against this repository's current tested boundary, Pi 0.80.10. Third-party packages named below are examples to evaluate, not endorsements or permanent compatibility claims.
+
+## Decision
+
+**Do not implement generic `/goal` or `/plan` commands, runtime plan-file management, autonomous continuation, generic task/subagent orchestration, or plan-mode write restriction in `pi-xai-oauth`.** This is a decisive no-go for this package.
+
+Users should first evaluate Pi's prompt templates and official reference extensions or separately installed provider-neutral packages. Examples include:
+
+- [`@narumitw/pi-goal`](https://www.npmjs.com/package/@narumitw/pi-goal) for goal lifecycle and continuation;
+- [`@plannotator/pi-extension`](https://www.npmjs.com/package/@plannotator/pi-extension) for plan authoring and human review;
+- [`@mjasnikovs/pi-task`](https://www.npmjs.com/package/@mjasnikovs/pi-task) for spec/task orchestration;
+- [`pi-subagents`](https://www.npmjs.com/package/pi-subagents) or Pi's [subagent reference example](https://github.com/earendil-works/pi/tree/v0.80.10/packages/coding-agent/examples/extensions/subagent) for delegated work;
+- Pi [prompt templates](https://github.com/earendil-works/pi/blob/v0.80.10/packages/coding-agent/docs/prompt-templates.md) for lightweight, stateless planning prompts.
+
+These candidates must be assessed against the user's workflow and threat model. A package that changes active tools or filters shell strings is not thereby a read-only sandbox.
+
+If existing extensions cannot satisfy a concrete requirement, any new implementation must be proposed as a separate provider-neutral Pi package with its own issue tracker, release cycle, security statement, compatibility policy, and tests. No implementation follow-up is opened from #85 because implementation in this repository is not approved.
+
+## Options considered
+
+| Option | Fit | Security and failure isolation | Maintenance | Decision |
+| --- | --- | --- | --- | --- |
+| Add workflows to `pi-xai-oauth` | Poor. The behavior is not xAI-specific. | Worst. Every OAuth install would load autonomous control and tool-policy code in the same privileged Pi process. | A second state machine permanently coupled to the provider compatibility matrix. | **Rejected.** |
+| Create a separate provider-neutral package | Acceptable only for a proven unmet need and explicit installation. | Better package and release isolation, but still not an OS security boundary. | Its own state, persistence, UI, security policy, releases, and cross-provider tests. | **Deferred, not approved.** |
+| Reuse existing generic extensions/templates | Best current fit. Pi already exposes the required generic primitives and reference implementations. | Users choose the package and threat model explicitly. Strong isolation still requires an external boundary. | No runtime or compatibility burden in this repository. | **Chosen first.** |
+
+## Relevant Pi APIs and ecosystem
+
+Pi 0.80.10 already exposes provider-neutral primitives for a workflow package:
+
+- Commands, tools, flags, and shortcuts: `registerCommand`, `registerTool`, `registerFlag`, and `registerShortcut`.
+- Prompt and tool control: `input`, `before_agent_start`, `context`, `sendMessage`, `sendUserMessage`, `getActiveTools`, `setActiveTools`, and `getAllTools`.
+- Completion state: the distinct `agent_end`, `agent_settled`, and `turn_end` events, plus `ctx.isIdle()` and pending-message checks. `ctx.waitForIdle()` is available to user-invoked command contexts rather than every lifecycle handler.
+- Cancellation: optional tool `AbortSignal` and `ctx.signal`, `ctx.abort()`, event-specific cancellation results or signals, generation guards when no signal is available, and `session_shutdown` cleanup.
+- Persistence and recovery: extension-owned entries through `appendEntry`, read-only session-manager access, and `session_start`, `session_before_switch`, `session_before_fork`, `session_before_compact`, `session_compact`, `session_before_tree`, `session_tree`, and `session_shutdown` events.
+- Composition: package prompt templates, skills, extensions, and the in-process `pi.events` bus.
+
+The authoritative inventory is Pi's [extension documentation](https://github.com/earendil-works/pi/blob/v0.80.10/packages/coding-agent/docs/extensions.md), [session format](https://github.com/earendil-works/pi/blob/v0.80.10/packages/coding-agent/docs/session-format.md), [package format](https://github.com/earendil-works/pi/blob/v0.80.10/packages/coding-agent/docs/packages.md), and official [plan-mode](https://github.com/earendil-works/pi/tree/v0.80.10/packages/coding-agent/examples/extensions/plan-mode), [todo](https://github.com/earendil-works/pi/blob/v0.80.10/packages/coding-agent/examples/extensions/todo.ts), and [subagent](https://github.com/earendil-works/pi/tree/v0.80.10/packages/coding-agent/examples/extensions/subagent) examples.
+
+The official plan-mode example is API guidance, not a security boundary. Pi's [security model](https://github.com/earendil-works/pi/blob/v0.80.10/packages/coding-agent/docs/security.md) states that Pi and extensions run with the user's permissions and that real isolation must come from an operating-system, container, or VM boundary.
+
+## Requirements for any separate proposal
+
+A future provider-neutral proposal would need to address all of the following before implementation:
+
+### State, concurrency, and recovery
+
+- Keep goal, phase, approval, progress, and continuation state owned by the current Pi session, with versioned persisted transitions that can be rebuilt after resume or branch navigation.
+- Treat in-memory controller and UI state as disposable caches and prevent a new session from inheriting another session's active goal implicitly.
+- Use revision or generation guards so delayed completions, calls, and continuations from replaced or cancelled work become stale no-ops.
+- Keep optional human-readable plan files non-authoritative. If sessions share one, use atomic replacement and explicit conflict detection rather than last-writer-wins.
+- Propagate cancellation through model calls, fetches, timers, child processes, and nested agents; make shutdown cleanup idempotent.
+- Pause ambiguous in-flight side effects for recovery instead of automatically repeating commands whose completion is unknown.
+- Keep credentials, authenticated headers, and provider internals out of workflow state and plan files.
+
+### Security model
+
+Hiding `edit` and `write`, filtering shell strings, or changing Pi's active-tool list is insufficient to enforce read-only behavior. A same-process extension cannot provide that guarantee because shell and child processes, third-party and MCP tools, other extensions, remote services, and privileged extension code can all produce side effects outside a registered tool call.
+
+This repository provides a concrete example: Grok-native `run_terminal_command` delegates to Pi's `bash` tool and may access paths outside the workspace. The direct file adapters' containment checks are defense in depth, not a complete filesystem sandbox.
+
+A future package must therefore document one of two honest modes:
+
+1. **Advisory planning:** best-effort prompts, tool filtering, and per-command approval, explicitly labeled as workflow behavior rather than a security guarantee.
+2. **Enforced read-only planning:** the planning agent and every tool run behind an independently enforced sandbox, container, VM, or equivalent boundary with a read-only workspace, minimal credentials, and restricted network access.
+
+`pi-xai-oauth` will implement neither mode because neither belongs to provider authentication or routing.
+
+### Provider and test scope
+
+Goal and plan behavior must work equivalently with xAI and non-xAI models. Model-specific prompt tuning may be an adapter, but provider identity cannot own the command namespace, persistence format, transitions, cancellation semantics, or security policy.
+
+A separate implementation would require focused coverage for state transitions, stale generations, resume and branch navigation, concurrent file conflicts, crash recovery, cancellation at await boundaries, descendant cleanup, built-in/extension/MCP/shell side effects, and equivalent behavior with xAI and at least one non-xAI provider. It would also need its own package compatibility and release policy.
+
+An exception can be reconsidered only for a small capability that requires xAI OAuth or entitlement state and cannot be represented through a provider-neutral interface. No requirement identified in #85 meets that test.
+
+## Consequences
+
+### Positive
+
+- OAuth installation remains focused and predictable.
+- Provider credentials, catalog state, routing, tools, and media behavior are not coupled to autonomous workflow state.
+- This package does not make a false read-only security claim.
+- Users can compose the provider with the generic workflow that matches their needs.
+- Workflow packages can evolve across providers without forcing an xAI provider release.
+
+### Negative
+
+- `pi-xai-oauth` does not provide a single-install Grok-flavored `/goal` or `/plan` experience.
+- Users who want those workflows must select another package or prompt template.
+- Existing packages differ in persistence, review UI, cancellation, and security posture, so users must evaluate them.
+
+### Scope guard
+
+Future PRs adding generic goal/plan commands, runtime plan files, autonomous continuation, write restriction, or generic task/subagent orchestration to this repository should be closed unless this ADR is explicitly superseded by a new decision with evidence of an xAI-specific requirement and a complete security model.


### PR DESCRIPTION
## Summary

- add ADR 0001 comparing in-package, separate provider-neutral package, and existing generic Pi workflow options
- record a decisive no-go for generic `/goal`, `/plan`, runtime plan-file management, autonomous continuation, generic task/subagent orchestration, and in-process write-restriction policy in `pi-xai-oauth`
- revalidate the Pi API and security inventory against the current tested Pi 0.80.10 boundary
- document current package scope, including Grok-native compatibility adapters, opt-in network tools, and media integrations
- keep the patch to durable README, changelog, and ADR documentation; no runtime or `.scaffold` files changed

## Why

Goal and plan orchestration does not depend on xAI OAuth, authenticated model entitlements, xAI routing, or another provider-specific capability. Bundling it into this provider would couple unrelated state machines and could imply a read-only security boundary that Pi explicitly does not provide in-process.

Existing generic extensions and templates are the correct first choice. A separate provider-neutral package remains an option only after a concrete unmet requirement is proven and its state, concurrency, cancellation, recovery, security, compatibility, and test model is defined.

## Validation

- `git diff --check` — pass
- changed Markdown links and README anchors — pass
- referenced Pi 0.80.10 documentation links — pass
- `npm test` — pass (43 files, 474 tests, plus real loader smoke)
- `npm run typecheck` — pass
- clean tracked-tree `npm pack --dry-run --json` — pass; README, CHANGELOG, and ADR included

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only scope and architecture decision; no code paths, auth, or routing behavior change.
> 
> **Overview**
> Documents a **package-scope boundary**: generic `/goal` and `/plan` workflows, autonomous continuation, runtime plan-file management, task/subagent orchestration, and in-process write-restriction policy will **not** ship in `pi-xai-oauth`.
> 
> Adds **[ADR 0001](docs/decisions/0001-goal-plan-package-scope.md)** (closes #85) comparing in-repo implementation, a separate provider-neutral package, and existing Pi extensions/templates; it records a decisive **no-go** for this provider and points users at third-party or Pi-native alternatives. The ADR revalidates Pi **0.80.10** extension APIs and states that tool filtering is advisory, not a sandbox.
> 
> **README** gains a **Package Scope** section (plus TOC link) describing what the package owns versus what it excludes, and clarifies that `--scaffold` is one-time file generation, not runtime workflow control. **CHANGELOG** Unreleased **Changed** notes the decision with a link to the ADR.
> 
> No runtime, test, or scaffold behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc1c8a33e012642f6f72e37229d83c6ed73af872. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->