### PR TITLE
Add bounded xAI subscription usage

### DIFF
--- a/.scaffold/constraints.md
+++ b/.scaffold/constraints.md
@@ -1,30 +1,32 @@
-# Constraints & Safety Rules — Issue #83
+# Constraints & Safety Rules — Issue #82
 
-## Image-edit boundary
+## Identity and credentials
 
-- `xai_edit_image` remains disabled by default and session-scoped through `/xai-tools`.
-- Disabled calls fail before parameter/context reads, credential lookup, filesystem/codecs, fetch, or output writes.
-- Accept one to three byte-validated PNG/JPEG references from workspace-contained regular files or strict canonical data URLs.
-- Reject four references before credential, filesystem, codec, or network access.
-- Reject remote/file URLs, attachment or Files API identifiers, WebP, caller endpoints, and caller output paths.
-- Require a supported aspect ratio for multiple references; validate any supplied singular ratio but omit it from the wire.
-- Pin `/v1/images/edits`, fixed model/count/resolution/response format, redirect rejection, cancellation, timeout, and bounded bodies.
-- Verify exactly one canonical base64 PNG/JPEG output, including decoded byte/pixel/side limits, before atomic 0700/0600 session storage.
-- Never reflect prompts, source paths/data URLs/images, credentials, headers, raw bodies, or lower-layer codec messages.
+- Resolve the OAuth bearer through Pi's existing credential path; never accept API-key provenance for this surface.
+- Obtain `x-userid` only from pinned authenticated `GET https://cli-chat-proxy.grok.com/v1/user`.
+- Keep identity transient within one fetch call. Never persist, cache, log, display, fingerprint, or copy it into catalog/auth state.
+- On any identity transport, auth, redirect, timeout, cancellation, byte, JSON, shape, or validation failure, stop before billing.
+- Never log or reflect bearer tokens, authenticated headers, user identity, raw bodies, or transport exception details.
 
-## Inherited main invariants
+## Billing and parsing
 
-- Preserve exact authenticated catalog membership, schema-2 modality provenance, cache migration, refresh locking, and privacy behavior.
-- Preserve inert final Responses payload canonicalization, canonical runtime model binding, computer-screenshot detection, zero SDK retries, and pre/post-compaction modality enforcement.
-- Preserve centralized route-aware wire headers, reserved-header scrubbing, redirect rejection, safe errors, and generic-affinity suppression.
-- Image editing is independent of the active Responses model's authenticated text/image modality.
-- Preserve OAuth PKCE/state/nonce/OIDC and bounded device authorization behavior.
-- Keep Pi peers at `>=0.80.1 <0.81.0` with exact packed 0.80.1/0.80.10 boundaries.
+- Pin `GET https://cli-chat-proxy.grok.com/v1/billing?format=credits`; never accept a caller/catalog endpoint.
+- Reject redirects; use a 15-second per-request timeout and 64 KiB response limit.
+- Bound JSON depth, node count, array size, object keys, history periods, user ID, labels, timestamps, percentages, billing cycles, and cent values.
+- Treat config fields as optional. Support only observed new fields and documented legacy fallbacks.
+- Billing errors and optional status must never affect chat.
+
+## Status lifecycle
+
+- One-shot `/xai-usage` is explicit and does not enable status.
+- Status is off by default and requires `/xai-usage status on` with an active `xai-auth` model.
+- Status is in-memory/session-only, refreshes only after completed turns, and never more often than once per minute.
+- Clear and disable status on model, provider, account, session start/shutdown, and non-xAI context changes.
 
 ## Delivery
 
-- The issue-83 worktree has one writer; delegated agents are read-only.
-- Base the rebased branch on merged PR #90 at `b0556a8`; preserve safety branch `safety/issue-83-pre-pr90-rebase`.
-- Update scaffold state after major phases.
-- Run focused, strict full, typecheck, coverage, package, loader, and exact boundary validation before publishing.
-- Do not merge PR #91 or make live paid xAI calls.
+- Keep implementation changes in the isolated issue-82 worktree; delegated audits are read-only.
+- Preserve `safety/issue-82-pre-main-rebase` and use exact force-with-lease against the known old remote head.
+- Use locked npm dependencies; use UV instead of pip if Python becomes necessary.
+- Preserve merged wire, modality, image-edit, catalog, OAuth, and Pi 0.80.1/0.80.10 compatibility behavior.
+- Update scaffold after major phases. Push only after full validation and independent review; do not merge PR #89.

--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -1,32 +1,35 @@
-# Shared Agent Context — Issue #83
+# Shared Agent Context — Issue #82
 
-**Branch:** feature/issue-83-image-editing
-**Issue:** https://github.com/BlockedPath/pi-xai-oauth/issues/83
-**Original commits:** `4a61389`, `e31303f`
-**Post-PR-90 baseline:** `b0556a8`
-**Safety branch:** `safety/issue-83-pre-pr90-rebase`
+**Branch:** feature/issue-82-xai-usage
+**Issue:** https://github.com/BlockedPath/pi-xai-oauth/issues/82
+**Upstream pin:** xai-org/grok-build@b189869b7755d2b482969acf6c92da3ecfeffd36
+**Rebase baseline:** `af31e83`
+**Safety branch:** `safety/issue-82-pre-main-rebase`
 
-## Evidence and decisions
+## Approved architecture
 
-- Pinned source: `xai-org/grok-build@b189869b7755d2b482969acf6c92da3ecfeffd36`.
-- Current first-party documentation limits edits to three source images, so the final package contract is one to three.
-- Use Pi's public worker-backed `resizeImage`; add no image dependency.
-- Keep the source-backed 400 KiB pass-through, 768 px compression maximum, 256 px floor, and quality steps inside stricter package-owned byte/pixel budgets.
-- Route both credential provenance tags to the pinned public edit endpoint without adding API-key environment fallback.
-- Persist one verified output under hashed Pi session storage and return only safe metadata.
+Use the existing Pi-resolved OAuth bearer for a pinned authenticated `GET /v1/user`; transiently validate `userId`; only then request pinned `GET /v1/billing?format=credits` with `x-userid`. Fail closed before billing on every identity error. Never persist/cache/log/display identity, authenticated headers, or raw bodies.
 
-## Integration focus
+## Implementation map
 
-- PR #90 is merged exactly as reviewed. Preserve its catalog modality, payload canonicalization, retry, canonical-model, and privacy behavior.
-- Adopt shared direct-JSON header construction and route classification from `wire.ts`; edits remain direct public media requests, never proxy requests.
-- Keep disabled zero-I/O behavior and permit explicitly enabled edits under an authenticated text-only active Responses model.
-- Reapply decoded output side and pixel limits after codec verification and redact all codec/compression failures.
+- `extensions/xai/usage.ts`: bounded JSON transport/parser, safe rendering, `/xai-usage`, and session status controller.
+- `extensions/xai/auth.ts`: pi-model-registry-only OAuth resolver for usage; unrelated active-model API keys and file fallbacks are excluded.
+- `extensions/xai/constants.ts`: pinned URLs and usage limits.
+- `extensions/xai-oauth.ts`: thin account/session/model/turn lifecycle wiring.
+- `tests/fixtures/usage/*.json`: identity plus observed new/legacy credits shapes.
+- `tests/usage/*.test.ts`: parser/bounds, identity-first transport/errors/cancellation, and command/status lifecycle.
 
 ## Validation state
 
-- Rebase started from clean `e31303f` after verifying `origin/main=b0556a8` contains the exact reviewed PR #90 tree.
-- No live xAI request is part of deterministic validation.
+- `/xai-usage` works as an explicit one-shot lookup without enabling background behavior.
+- `/xai-usage status on` requires an active `xai-auth` model, refreshes immediately, then only after completed turns with a one-minute minimum interval.
+- Any model/provider/account/session change disables and clears status. Non-xAI contexts never refresh.
+- New `creditUsagePercent` and `currentPeriod` fields take precedence; legacy `used`/`monthlyLimit` and billing-period timestamps are conservative fallbacks.
+- Missing optional fields are omitted. Unsupported/out-of-range optional fields are ignored; malformed root/history or over-limit structures fail safely.
+- PR #89 has no reviews or review threads; its three conversation comments are bot usage-limit notices.
+- The old policy failure was only the now-obsolete Pi 0.80.7 registry-drift check; merged PR #94 pins and validates 0.80.10.
+- The original clean remote head was `53b8013`; the rebase onto `af31e83` is in progress.
 
 ## Delivery
 
-The original implementation (`4a61389`) and delivery record (`e31303f`) were pushed to unmerged PR #91. The branch is now being rebased and revalidated before its next push: https://github.com/BlockedPath/pi-xai-oauth/pull/91
+Revalidate the cumulative branch against the current merged baseline, complete independent review, and replace the known old remote head with exact force-with-lease. PR #89 remains unmerged: https://github.com/BlockedPath/pi-xai-oauth/pull/89

--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -28,8 +28,16 @@ Use the existing Pi-resolved OAuth bearer for a pinned authenticated `GET /v1/us
 - Missing optional fields are omitted. Unsupported/out-of-range optional fields are ignored; malformed root/history or over-limit structures fail safely.
 - PR #89 has no reviews or review threads; its three conversation comments are bot usage-limit notices.
 - The old policy failure was only the now-obsolete Pi 0.80.7 registry-drift check; merged PR #94 pins and validates 0.80.10.
-- The original clean remote head was `53b8013`; the rebase onto `af31e83` is in progress.
+- The original clean remote head was `53b8013`; it rebased onto `af31e83` as `9792282` plus `4c0f098`.
+- Usage headers now live in the shared wire module, and stalled response bodies are explicitly bounded by cancellation/timeout races.
+- Usage accepts only a resolver token that matches Pi's current stored OAuth credential after refresh, so stored/runtime API keys cannot be relabeled and sent to the CLI proxy.
+- Cosmetic footer refreshes are detached from Pi's awaited turn lifecycle, malformed calendar timestamps are omitted, and unsuccessful bodies are cancelled.
+- Caller/model `x-userid` is scrubbed globally and added only by the protected billing-header contract after bounded `/user` validation.
+- Stored OAuth removal disables status before throttling; account/session resets abort and suppress stale one-shot or footer completions.
+- Focused usage/provider/wire coverage passes 7 files / 74 tests; strict TypeScript, real loader, direct pack contract, and diff check pass.
+- The final cumulative gate passes 37 files / 398 tests, 86.03% statement coverage, the 111-file pack contract, policy checks, and exact Pi 0.80.1/0.80.10 matrices.
+- Independent security and final test re-reviews are clean.
 
 ## Delivery
 
-Revalidate the cumulative branch against the current merged baseline, complete independent review, and replace the known old remote head with exact force-with-lease. PR #89 remains unmerged: https://github.com/BlockedPath/pi-xai-oauth/pull/89
+Complete the full cumulative validation and independent reviews, then replace the known old remote head with exact force-with-lease. PR #89 remains unmerged: https://github.com/BlockedPath/pi-xai-oauth/pull/89

--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -40,4 +40,4 @@ Use the existing Pi-resolved OAuth bearer for a pinned authenticated `GET /v1/us
 
 ## Delivery
 
-Complete the full cumulative validation and independent reviews, then replace the known old remote head with exact force-with-lease. PR #89 remains unmerged: https://github.com/BlockedPath/pi-xai-oauth/pull/89
+The known old remote head was replaced with exact force-with-lease, PR #89's description was refreshed, and fresh policy, Socket, and exact Pi 0.80.1/0.80.10 checks are green. PR #89 remains open and unmerged: https://github.com/BlockedPath/pi-xai-oauth/pull/89

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,30 +1,31 @@
-# Implementation Plan — Issue #83
+# Implementation Plan — Issue #82 xAI usage
 
-**Branch:** feature/issue-83-image-editing
-**Baseline:** `b0556a8`
+**Branch:** feature/issue-82-xai-usage
+**Rebase baseline:** `af31e83`
 
 ## Goal
 
-Finish PR #91 as a disabled-by-default, bounded `xai_edit_image` feature integrated with merged PR #90 transport, modality, and privacy guarantees.
+Add an explicit `/xai-usage` command and an off-by-default session status without weakening credential or privacy boundaries around the unofficial revision-pinned xAI billing surface.
 
 ## Phases
 
-1. [x] Verify PR #90 merged exactly as reviewed and create a safety branch for `e31303f`.
-2. [x] Rebase the two PR #91 commits onto `b0556a8` and semantically synthesize conflicts.
-3. [x] Change the reference contract to one to three and tighten cheap aspect-ratio validation.
-4. [x] Integrate shared direct-JSON headers and route classification without weakening bounded edit response handling.
-5. [x] Enforce decoded output side/pixel limits and redact codec/compression failures.
-6. [x] Preserve disabled zero-I/O and text-only Responses-model independence with focused regressions.
-7. [x] Synthesize cumulative docs/scaffold content and remove stale counts, versions, and one-to-four claims.
-8. [x] Run focused, typecheck, strict full, coverage, package, loader, and exact Pi boundary validation.
-9. [x] Complete range-diff/invariant review and independent final reviews.
-10. [x] Push the rebased branch with lease, refresh PR #91, and verify all checks without merging.
+1. [x] Confirm the clean feature branch; read issue #82, provider/auth/command/event code, tests, docs, and the approved scout/architect handoff.
+2. [x] Verify the exact upstream `/user` and `/billing?format=credits` contracts at `xai-org/grok-build@b189869b7755d2b482969acf6c92da3ecfeffd36`.
+3. [x] Implement pinned sequential identity and billing requests with the same Pi-resolved OAuth bearer and fail closed before billing on every identity failure.
+4. [x] Bound redirects, per-request timeout, response bytes, JSON complexity, array/object/history counts, IDs, timestamps, percentages, and credit values; expose only redacted errors.
+5. [x] Register `/xai-usage` plus explicit `status on|off`; keep status session-only, minimum-interval event-driven, non-xAI suppressed, and cleared on model/account/session changes.
+6. [x] Add observed new/legacy JSON fixtures and focused parser, transport, cancellation, redaction, command, and lifecycle tests.
+7. [x] Document the unofficial revision pin, privacy boundary, command syntax, refresh policy, and limits in README, CHANGELOG, and AGENTS.
+8. [x] Create `safety/issue-82-pre-main-rebase` and rebase the clean PR branch onto merged `main` after PRs #90, #91, #92, and #94.
+9. [ ] Audit the automatic code merge against current wire, modality, credential, and lifecycle contracts; address findings.
+10. [ ] Run focused, strict full, typecheck, coverage, package, loader, and exact Pi 0.80.1/0.80.10 boundary validation.
+11. [ ] Complete independent final review, force-push with exact lease, and verify fresh PR checks without merging.
 
 ## Validation contract
 
-- Four references and invalid singular ratios fail before credentials, filesystem, codec, or network I/O.
-- Both credential provenance tags use the exact pinned direct edit URL and protected direct-media headers.
-- Exactly one bounded verified output is atomically persisted with private permissions.
-- No prompt, source reference, credential, raw body, or codec/server detail is reflected.
-- PR #90 catalog, payload, modality, routing, retry, and privacy behavior remains intact.
-- Pi peers and exact 0.80.1/0.80.10 boundaries remain unchanged.
+- Identity lookup must succeed and yield a bounded header-safe user ID before billing is requested.
+- Usage accepts only Pi-managed OAuth-session credentials; unrelated API keys and file fallbacks are excluded.
+- Redirects, timeouts, bodies, JSON complexity, history, labels, timestamps, numeric ranges, and errors stay bounded.
+- Identity, credentials, authenticated headers, raw bodies, and transport details are never cached, persisted, logged, displayed, or reflected.
+- Optional status remains off by default, session-only, xAI-only, event-driven, and cleared on account/model/session changes.
+- Current wire, catalog, image-edit, modality, OAuth, and exact Pi boundary behavior remains intact.

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -19,7 +19,7 @@ Add an explicit `/xai-usage` command and an off-by-default session status withou
 8. [x] Create `safety/issue-82-pre-main-rebase` and rebase the clean PR branch onto merged `main` after PRs #90, #91, #92, and #94.
 9. [x] Audit the automatic code merge against current wire, modality, credential, and lifecycle contracts; address findings.
 10. [x] Run focused, strict full, typecheck, coverage, package, loader, and exact Pi 0.80.1/0.80.10 boundary validation.
-11. [ ] Complete independent final review, force-push with exact lease, and verify fresh PR checks without merging.
+11. [x] Complete independent final review, force-push with exact lease, and verify fresh PR checks without merging.
 
 ## Validation contract
 

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -17,8 +17,8 @@ Add an explicit `/xai-usage` command and an off-by-default session status withou
 6. [x] Add observed new/legacy JSON fixtures and focused parser, transport, cancellation, redaction, command, and lifecycle tests.
 7. [x] Document the unofficial revision pin, privacy boundary, command syntax, refresh policy, and limits in README, CHANGELOG, and AGENTS.
 8. [x] Create `safety/issue-82-pre-main-rebase` and rebase the clean PR branch onto merged `main` after PRs #90, #91, #92, and #94.
-9. [ ] Audit the automatic code merge against current wire, modality, credential, and lifecycle contracts; address findings.
-10. [ ] Run focused, strict full, typecheck, coverage, package, loader, and exact Pi 0.80.1/0.80.10 boundary validation.
+9. [x] Audit the automatic code merge against current wire, modality, credential, and lifecycle contracts; address findings.
+10. [x] Run focused, strict full, typecheck, coverage, package, loader, and exact Pi 0.80.1/0.80.10 boundary validation.
 11. [ ] Complete independent final review, force-push with exact lease, and verify fresh PR checks without merging.
 
 ## Validation contract

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -19,13 +19,22 @@
 - [x] Preserved the original reviewed implementation/docs commits (`d7ccd17`, `53b8013`) and open PR #89 on `safety/issue-82-pre-main-rebase`.
 - [x] Fetched `origin/main=af31e83`, verified the worktree was clean at remote head `53b8013`, and created `safety/issue-82-pre-main-rebase`.
 - [x] Started the semantic rebase onto current merged main while preserving #90/#91/#92/#94 behavior.
+- [x] Completed the rebase as `9792282` plus `4c0f098` with no unresolved markers or diff-check errors.
+- [x] Centralized the exact usage proxy-header contract in `wire.ts`.
+- [x] Bounded stalled response bodies with explicit abort races and deterministic cancellation/timeout coverage.
+- [x] Required the Pi-resolved bearer to match the current stored OAuth access token after refresh, rejecting stored and runtime API-key provenance.
+- [x] Detached cosmetic status refresh from Pi's awaited `turn_end` path, made calendar timestamp validation strict, and cancelled non-success bodies.
+- [x] Reserved `x-userid` across shared wire scrubbing and documented its single transient billing-only exception.
+- [x] Aborted/suppressed stale one-shot and footer completions on reset; stored OAuth removal now disables status before throttling.
+- [x] Added actual provider lifecycle, file-fallback rejection, parser node/key/timestamp, invalid UTF-8, loader-command, and pack-production regressions.
+- [x] Passed the post-finding focused usage/provider/wire suites (7 files / 74 tests), strict TypeScript, real loader, direct pack contract, and diff check.
+- [x] Passed the final cumulative gate: `npm test` (37 files / 398 tests), strict TypeScript, real loader, coverage, policy, 111-file pack contract, and exact Pi 0.80.1/0.80.10 boundaries.
+- [x] Measured final V8 coverage at 86.03% statements, 79.27% branches, 86.09% functions, and 89.88% lines.
+- [x] Passed independent security re-review of OAuth removal, stale one-shot suppression, billing-only identity handling, and caller `x-userid` scrubbing.
+- [x] Passed independent final test review after adding real exact-boundary registry coverage, version-adaptive strict OAuth provenance, non-blocking hostile-stream cancellation, and a due/stalled turn lifecycle regression.
 
 ## In progress
 
-- [ ] Finish conflict resolution and audit the automatically merged production/test code.
-- [ ] Address actionable functional/security/test findings.
-- [ ] Run focused, strict full, typecheck, coverage, package, loader, policy, and exact boundary validation.
-- [ ] Complete independent final review and range-diff/invariant review.
 - [ ] Force-push with exact lease, refresh PR #89 if needed, and verify fresh checks without merging.
 
 ## Residual

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -32,10 +32,12 @@
 - [x] Measured final V8 coverage at 86.03% statements, 79.27% branches, 86.09% functions, and 89.88% lines.
 - [x] Passed independent security re-review of OAuth removal, stale one-shot suppression, billing-only identity handling, and caller `x-userid` scrubbing.
 - [x] Passed independent final test review after adding real exact-boundary registry coverage, version-adaptive strict OAuth provenance, non-blocking hostile-stream cancellation, and a due/stalled turn lifecycle regression.
+- [x] Replaced the known old PR head with exact force-with-lease and refreshed PR #89's description.
+- [x] Verified fresh GitHub policy, Socket, and exact Pi 0.80.1/0.80.10 compatibility checks are green.
 
-## In progress
+## Delivery
 
-- [ ] Force-push with exact lease, refresh PR #89 if needed, and verify fresh checks without merging.
+- [x] Kept PR #89 open and unmerged for maintainer approval: https://github.com/BlockedPath/pi-xai-oauth/pull/89
 
 ## Residual
 

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -16,6 +16,7 @@
 - [x] Tightened usage credential resolution to pi's managed xAI model registry only and added a regression proving an unrelated active-model API key is never sent to xAI.
 - [x] Confirmed PR #89 has no reviews or review threads; its comments are bot usage-limit notices.
 - [x] Confirmed the old policy failure was obsolete Pi 0.80.7 registry drift already fixed by merged PR #94.
+- [x] Preserved the original reviewed implementation/docs commits (`d7ccd17`, `53b8013`) and open PR #89 on `safety/issue-82-pre-main-rebase`.
 - [x] Fetched `origin/main=af31e83`, verified the worktree was clean at remote head `53b8013`, and created `safety/issue-82-pre-main-rebase`.
 - [x] Started the semantic rebase onto current merged main while preserving #90/#91/#92/#94 behavior.
 

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,45 +1,33 @@
-# Execution Progress — Issue #83
+# Execution Progress — Issue #82
 
-**Branch:** feature/issue-83-image-editing
-**Baseline:** `b0556a8`
+**Branch:** feature/issue-82-xai-usage
+**Current baseline:** `af31e83`
 
 ## Completed
 
-- [x] Confirmed PR #90 merged as `b0556a8` and contains exact reviewed head `fe0b95f`.
-- [x] Confirmed the issue-83 worktree and remote branch were clean at `e31303f`.
-- [x] Created `safety/issue-83-pre-pr90-rebase`.
-- [x] Started rebasing the original implementation/docs commits onto merged main.
-- [x] Preserved the original bounded media implementation, focused tests, and disabled-by-default tool lifecycle for semantic integration.
-- [x] Completed the rebase as `316884d` plus `f3e0fd8` on merged baseline `b0556a8`.
-- [x] Enforced one to three references and cheap validation of every supplied aspect ratio.
-- [x] Added shared protected direct-media headers and edit-route error classification without proxy metadata.
-- [x] Reapplied decoded output limits, redacted codec/compression failures, and hardened body/output cancellation.
-- [x] Added regressions for four-reference zero-I/O rejection, both credential provenance tags, stalled bodies, request-ID filtering, decoded dimensions, and text-only active models.
-- [x] Passed the primary and cumulative focused image-edit/media/provider/tool suites plus strict TypeScript.
-- [x] Passed the strict full suite, real loader smoke, and V8 coverage above every configured floor.
-- [x] Passed policy/registry, packed-manifest, unsupported-peer, and package dry-run checks.
-- [x] Passed clean packed test/loader/typecheck matrices with exact Pi 0.80.1 and 0.80.10.
-- [x] Applied security review feedback so disabled tools prove explicit opt-in before reading active-model context, with a throwing-getter regression.
-- [x] Replaced a false-positive cancellation test with deterministic cleanup checks after temporary write and final rename, and added POSIX FIFO rejection coverage.
-- [x] Completed the old-vs-rebased range diff and verified protected PR #90/OAuth/catalog/package-policy files were not replaced.
-- [x] Functional, security/privacy, and test/validation re-reviews returned CLEAN after their accepted fixes.
-- [x] Confirmed PR #91 has no review submissions or unresolved review threads; its only comments are review-bot usage-limit notices.
+- [x] Confirmed the branch was clean and based on `origin/main`; installed locked dependencies with `npm ci`.
+- [x] Read issue #82 and the relevant provider, credential, command, event, fixture, test, documentation, and package-boundary code.
+- [x] Verified upstream billing and `/user` identity behavior at the exact issue revision.
+- [x] Added the pinned identity-first usage transport with OAuth-only provenance, required proxy metadata, fail-closed sequencing, redirect rejection, cancellation, safe errors, and no identity/raw-body retention.
+- [x] Added bounded new/legacy usage parsing and conservative command/footer renderers.
+- [x] Registered `/xai-usage` with one-shot display plus explicit `status on|off`; status is session-scoped, rate-bounded, event-driven, non-xAI suppressed, and reset on model/account/session changes.
+- [x] Added three JSON fixtures and focused parser, transport, timeout, cancellation, redaction, command, status, and provider-registration coverage.
+- [x] Updated README, CHANGELOG, AGENTS, and all issue scaffold files.
+- [x] Tightened usage credential resolution to pi's managed xAI model registry only and added a regression proving an unrelated active-model API key is never sent to xAI.
+- [x] Confirmed PR #89 has no reviews or review threads; its comments are bot usage-limit notices.
+- [x] Confirmed the old policy failure was obsolete Pi 0.80.7 registry drift already fixed by merged PR #94.
+- [x] Fetched `origin/main=af31e83`, verified the worktree was clean at remote head `53b8013`, and created `safety/issue-82-pre-main-rebase`.
+- [x] Started the semantic rebase onto current merged main while preserving #90/#91/#92/#94 behavior.
 
 ## In progress
 
-- [x] Committed the final reviewed implementation as `b29c119` (`fix: finalize bounded image editing`).
-- [x] Replaced the known pre-rebase remote head with an exact force-with-lease and refreshed PR #91's description.
-- [x] Verified fresh GitHub policy, Socket, and exact Pi 0.80.1/0.80.10 checks are green.
-- [x] Kept PR #91 open and unmerged for maintainer approval.
-
-## Delivery
-
-- Apply the one-to-three, shared-header, decoded-output-limit, redaction, and modality-independence changes from the final handoff.
-- Run the complete post-rebase validation and independent review contract.
-- Original implementation commit `4a61389` and delivery record `e31303f` were pushed to unmerged PR #91 before this rebase.
-- PR #91 remains open and must not be merged until the rebased branch passes the full gate: https://github.com/BlockedPath/pi-xai-oauth/pull/91
+- [ ] Finish conflict resolution and audit the automatically merged production/test code.
+- [ ] Address actionable functional/security/test findings.
+- [ ] Run focused, strict full, typecheck, coverage, package, loader, policy, and exact boundary validation.
+- [ ] Complete independent final review and range-diff/invariant review.
+- [ ] Force-push with exact lease, refresh PR #89 if needed, and verify fresh checks without merging.
 
 ## Residual
 
 - No live xAI request or interactive OAuth flow is part of this offline gate.
-- Parent-directory replacement remains a documented trusted-parent filesystem assumption.
+- The usage API is unofficial and revision-pinned; upstream drift requires deliberate review.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 ## Project Overview
 pi-xai-oauth is a pi-package that registers the xAI OAuth provider (`xai-auth`) and the authenticated account's OAuth-visible Grok model catalog for the pi coding agent framework, with Grok 4.5 as the curated offline fallback.
 
-Core flow: `bin/setup.js` → `pi install` → bounded catalog selection in `extensions/xai/catalog.ts` → provider registration in `extensions/xai-oauth.ts` → browser PKCE or bounded device authorization in `extensions/xai/oauth.ts` / `extensions/xai/device-auth.ts` → pinned browser OIDC/JWKS validation in `extensions/xai/oidc.ts` → streaming via xAI API helpers in `extensions/xai/responses.ts`.
+Core flow: `bin/setup.js` → `pi install` → bounded catalog selection in `extensions/xai/catalog.ts` → provider registration in `extensions/xai-oauth.ts` → browser PKCE or bounded device authorization in `extensions/xai/oauth.ts` / `extensions/xai/device-auth.ts` → pinned browser OIDC/JWKS validation in `extensions/xai/oidc.ts` → streaming via xAI API helpers in `extensions/xai/responses.ts`; explicit revision-pinned subscription usage lives in `extensions/xai/usage.ts`.
 
 ## Key Commands (Exact, Copy-Paste Ready)
 - Install / setup: `node bin/setup.js` or `npm run setup`
@@ -18,7 +18,7 @@ Core flow: `bin/setup.js` → `pi install` → bounded catalog selection in `ext
 - Verify Pi policy/package metadata: `npm run compatibility:check`
 - Verify exact packed Pi boundaries: `npm run compatibility:boundaries`
 - Evaluate an unadvertised Pi candidate: `node scripts/run-compatibility-matrix.js X.Y.Z --candidate`
-- Git: Always work on feature branches. Current branch for this work: `feature/issue-83-image-editing`
+- Git: Always work on feature branches and confirm the active branch before edits.
 
 ## Architecture & Boundaries (MUST / MUST NOT)
 **MUST:**
@@ -37,6 +37,8 @@ Core flow: `bin/setup.js` → `pi install` → bounded catalog selection in `ext
 - Keep both Pi peers aligned to the checked-in bounded range in `compatibility/pi-versions.json`
 - Install/report exact Pi matrix versions from a clean packed package; never reuse the repository lockfile for boundary jobs
 - Keep normal Pi dev dependencies exact at the policy's latest tested release and review candidate releases before widening support
+- Resolve `x-userid` transiently from the pinned authenticated CLI-proxy `/user` endpoint before any billing request
+- Keep `/xai-usage` explicit, and keep its optional status off by default, session-scoped, bounded, and inactive outside xAI models
 
 **MUST NOT:**
 - Hardcode API keys (use OAuth only)
@@ -44,6 +46,8 @@ Core flow: `bin/setup.js` → `pi install` → bounded catalog selection in `ext
 - Trust arbitrary `*.x.ai` discovery, device, token, verification, or JWKS endpoints
 - Log or reflect authorization codes, opaque device codes, tokens, PKCE verifiers, state, nonce, device/token response bodies, or authenticated request headers
 - Cache raw `/models-v2` responses, credentials, identity fields, endpoint URLs, or known API-key-only models
+- Persist, cache, log, or display `/user` identity, authenticated usage headers, or raw authenticated usage bodies
+- Send `/billing?format=credits` when the transient authenticated `/user` lookup is missing, malformed, cancelled, oversized, redirected, or unsuccessful
 - Trust catalog-provided endpoints or route non-Responses models through the OAuth provider
 - Delete or revoke existing user credentials during validation
 - Modify core pi-coding-agent internals
@@ -71,6 +75,7 @@ pi-xai-oauth/
 │       ├── wire.ts       # Route-aware headers, scrubbing, identity, safe errors
 │       ├── image-edit.ts # Bounded pinned image-edit orchestration
 │       ├── media/        # Reusable strict media/path/compression/storage primitives
+│       ├── usage.ts      # Explicit bounded identity-first subscription usage command/status
 │       └── tools/        # Custom xAI tools + Cursor/Grok CLI shims
 ├── compatibility/
 │   ├── pi-versions.json # Peer range plus exact minimum/latest matrix policy
@@ -112,6 +117,8 @@ Start any task by reading:
 - Keep caller/model reserved headers scrubbed before appending the route-specific contract; never reflect raw transport error bodies
 - Reject malformed, hidden, unsupported-backend, secret-bearing, and known API-key-only catalog entries
 - Keep startup catalog network behavior bounded and use pi's credential lock for expired stored-token refresh
+- Keep usage redirects, timeouts, response bytes, JSON complexity, history counts, and numeric ranges bounded; redact every usage error
+- Clear optional usage status on model, provider, account, and session changes, and never refresh it for non-xAI models
 - Keep compatibility policy/registry/pack/resolver verification in plain Node; behavior tests use focused Vitest suites
 - Isolate fetch, timers, environment, temp HOME/filesystem, module state, runtime models, credentials, and active-tool registries per test
 - Keep real callback tests sequential with real timers and guaranteed listener cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 - Replaced raw direct-response error reflection with bounded status/route classification and actionable, non-impersonating proxy version-gate guidance.
 - Prevented authenticated text-only entitlements from sending image-bearing Responses payloads, including payload-hook mutations and image-input custom tools, without changing image generation.
 - Canonicalized final Responses payloads before model and modality enforcement, detected computer screenshots, disabled unsafe delegated retries, and hardened wide-payload traversal so custom serializers cannot bypass authenticated text-only policy.
-- Made usage identity resolution fail closed before billing and prevented account identity, authenticated headers, raw response bodies, and transport details from being cached, persisted, logged, or reflected in errors.
+- Made usage credential and identity resolution fail closed before billing, rejected stored/runtime API-key provenance, and prevented account identity, authenticated headers, raw response bodies, and transport details from being cached, persisted, logged, or reflected in errors.
 - Removed the unbound raw authorization-code fallback; pasted browser completions require matching OAuth state, and raw-code users are directed to device login or a complete state-bound redirect URL.
 - Pinned xAI OIDC discovery and JWKS policy and validated fresh-login ID-token ES256 signatures, signing keys, issuer, audience, expiry, and nonce before retaining credentials.
 - Stopped reflecting xAI token endpoint response bodies in authentication errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 - Added focused typed Vitest regressions across provider/catalog routing, browser/device OAuth and OIDC, Responses payloads/streams/errors, images, network-tool lifecycle, custom tools, Cursor shims, and setup/settings.
 - Added the disabled-by-default `xai_edit_image` tool with exact singular/plural Imagine edit payloads, a distinct pinned `/images/edits` route, timeout/cancellation, and redacted errors.
 - Added reusable bounded media primitives for byte-validated PNG/JPEG data URLs and workspace files, source-backed compression, explicit request/response/output budgets, and atomic 0700/0600 Pi-session storage.
+- Added the explicit `/xai-usage` command with pinned authenticated `/user` identity resolution followed by the unofficial revision-pinned `/billing?format=credits` lookup.
+- Added an optional session-only compact usage status that is off by default, refreshes no more than once per minute after completed xAI turns, and clears on model, provider, account, and session changes.
+- Added fixture-based usage parser, transport, cancellation, redaction, command, bounds, and status-lifecycle coverage.
 - Added a small real Pi extension-loader smoke plus V8 text/JSON/LCOV coverage with measured regression floors.
 - Added a browser-first native login-method selector with device authorization for SSH, WSL, containers, remote workspaces/VMs, and human-operated headless sessions.
 - Added pinned, bounded, cancellable RFC 8628 polling with initial wait, server interval plus cumulative `slow_down`, denial/expiry handling, strict secret-safe schema validation, and deterministic timing tests.
@@ -27,6 +30,7 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 
 - Centralized xAI wire headers around pinned routes, truthful `pi-xai-oauth/<version>` attribution, package-controlled proxy versioning, and shared OAuth form metadata.
 - Migrated the normalized model cache to schema 2 while safely retaining schema-1 membership and rederiving legacy input as known/default rather than authenticated evidence.
+- Bounded the unofficial usage transport to pinned endpoints, rejected redirects, 15-second request timeouts, 64 KiB bodies, bounded JSON complexity/history, and conservative numeric/timestamp ranges.
 - Replaced the shared-state monolithic behavior verifiers with isolated per-domain suites and closure-local fixtures; production runtime behavior is unchanged.
 - Made the repository CI job run the full unit suite once under coverage and the loader smoke separately; packed compatibility jobs rerun unit, loader, and TypeScript checks at each exact Pi boundary.
 - Centralized xAI endpoint selection around explicit OAuth-session versus API-key credential provenance instead of model IDs.
@@ -50,6 +54,7 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 - Replaced raw direct-response error reflection with bounded status/route classification and actionable, non-impersonating proxy version-gate guidance.
 - Prevented authenticated text-only entitlements from sending image-bearing Responses payloads, including payload-hook mutations and image-input custom tools, without changing image generation.
 - Canonicalized final Responses payloads before model and modality enforcement, detected computer screenshots, disabled unsafe delegated retries, and hardened wide-payload traversal so custom serializers cannot bypass authenticated text-only policy.
+- Made usage identity resolution fail closed before billing and prevented account identity, authenticated headers, raw response bodies, and transport details from being cached, persisted, logged, or reflected in errors.
 - Removed the unbound raw authorization-code fallback; pasted browser completions require matching OAuth state, and raw-code users are directed to device login or a complete state-bound redirect URL.
 - Pinned xAI OIDC discovery and JWKS policy and validated fresh-login ID-token ES256 signatures, signing keys, issuer, audience, expiry, and nonce before retaining credentials.
 - Stopped reflecting xAI token endpoint response bodies in authentication errors.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and
 - **Grok 4.5 fast mode** — same model with `low` reasoning effort (`/think low` or `grok-4.5:low`); not a separate model ID
 - **Long-context metadata when entitled** — known Grok 4.3 behavior is preserved when xAI returns it, with authenticated limits taking precedence
 - **Authenticated model catalog** — fetches the OAuth-visible `/models-v2` list from the official CLI proxy, so additions and removals track the signed-in account
+- **Explicit subscription usage** — `/xai-usage` performs a bounded, identity-first lookup against the revision-pinned unofficial Grok billing surface without retaining account identity
 - **Coding models when entitled** — Grok Build, Composer, and other models appear only when xAI includes them in the account catalog
 - **Reasoning support** — parses supplied reasoning capability and thinking levels while preserving known model compatibility
 - **Bounded last-known-good cache** — avoids routine startup delay and falls back safely when discovery is offline or unavailable
@@ -236,6 +237,28 @@ Or use a specific model:
 ```bash
 pi --model grok-4.5 "Write a poem about Rust"
 ```
+
+### Subscription usage (unofficial)
+
+Run an explicit one-shot usage lookup from pi:
+
+```text
+/xai-usage
+```
+
+The command displays only validated fields that xAI actually returned, such as included usage percentage, legacy included-credit totals, current reset time, on-demand usage/cap, prepaid balance, and bounded history count. Missing optional fields stay omitted.
+
+The billing surface is **not a stable public xAI API**. This implementation is pinned to [`xai-org/grok-build@b189869`](https://github.com/xai-org/grok-build/blob/b189869b7755d2b482969acf6c92da3ecfeffd36/crates/codegen/xai-grok-shell/src/extensions/billing.rs): it first makes authenticated `GET /v1/user`, uses the returned validated `userId` only for the immediately following `GET /v1/billing?format=credits`, then discards it. Account identity, bearer/authenticated headers, and raw response bodies are never logged, displayed, cached, or persisted. If identity cannot be resolved safely, billing is not requested.
+
+The compact footer status is off by default and requires a separate per-session opt-in while an `xai-auth` model is active:
+
+```text
+/xai-usage status
+/xai-usage status on
+/xai-usage status off
+```
+
+Enabling status performs one immediate lookup. Later refreshes are event-driven after completed turns and occur no more than once per minute. The status disables and clears on model, provider, account, or session changes; it never refreshes for non-xAI models. Status failures clear silently and never interfere with chat. Every request rejects redirects, has a 15-second timeout, reads at most 64 KiB, and applies bounded JSON depth, collection counts, history length, and numeric ranges.
 
 ### Switching Models
 
@@ -526,6 +549,8 @@ Opt-in research using the active xAI model plus native web and X search tools. E
 | List packages | `pi list` |
 | Set default model | `/model grok-4.5` (in TUI) |
 | Set thinking level | `/think high` (in TUI) |
+| Show subscription usage | `/xai-usage` (unofficial, explicit request) |
+| Manage optional usage status | `/xai-usage status on\|off` (off by default) |
 | Manage outbound xAI tools | `/xai-tools` (in TUI) |
 | Recreate extension/catalog state | `/reload` (respects the 15-minute cache TTL) |
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and
 - [Pi Compatibility](#pi-compatibility)
 - [Authentication](#authentication)
 - [Usage](#usage)
+  - [Subscription usage (unofficial)](#subscription-usage-unofficial)
   - [Switching Models](#switching-models)
   - [Reasoning / Thinking Levels](#reasoning--thinking-levels)
 - [Custom Tools](#custom-tools)
@@ -248,7 +249,7 @@ Run an explicit one-shot usage lookup from pi:
 
 The command displays only validated fields that xAI actually returned, such as included usage percentage, legacy included-credit totals, current reset time, on-demand usage/cap, prepaid balance, and bounded history count. Missing optional fields stay omitted.
 
-The billing surface is **not a stable public xAI API**. This implementation is pinned to [`xai-org/grok-build@b189869`](https://github.com/xai-org/grok-build/blob/b189869b7755d2b482969acf6c92da3ecfeffd36/crates/codegen/xai-grok-shell/src/extensions/billing.rs): it first makes authenticated `GET /v1/user`, uses the returned validated `userId` only for the immediately following `GET /v1/billing?format=credits`, then discards it. Account identity, bearer/authenticated headers, and raw response bodies are never logged, displayed, cached, or persisted. If identity cannot be resolved safely, billing is not requested.
+The billing surface is **not a stable public xAI API**. This implementation is pinned to [`xai-org/grok-build@b189869`](https://github.com/xai-org/grok-build/blob/b189869b7755d2b482969acf6c92da3ecfeffd36/crates/codegen/xai-grok-shell/src/extensions/billing.rs): it first makes authenticated `GET /v1/user`, uses the returned validated `userId` only for the immediately following `GET /v1/billing?format=credits`, then discards it. The command requires a current Pi-stored OAuth credential and rejects stored or runtime `--api-key` provenance. Account identity, bearer/authenticated headers, and raw response bodies are never logged, displayed, cached, or persisted. If identity cannot be resolved safely, billing is not requested.
 
 The compact footer status is off by default and requires a separate per-session opt-in while an `xai-auth` model is active:
 
@@ -258,7 +259,7 @@ The compact footer status is off by default and requires a separate per-session 
 /xai-usage status off
 ```
 
-Enabling status performs one immediate lookup. Later refreshes are event-driven after completed turns and occur no more than once per minute. The status disables and clears on model, provider, account, or session changes; it never refreshes for non-xAI models. Status failures clear silently and never interfere with chat. Every request rejects redirects, has a 15-second timeout, reads at most 64 KiB, and applies bounded JSON depth, collection counts, history length, and numeric ranges.
+Enabling status performs one immediate lookup. Later refreshes are event-driven after completed turns and occur no more than once per minute. The status disables and clears on model, provider, login, or session changes and on the next extension-handled event after stored OAuth removal; it never refreshes for non-xAI models. Status failures clear silently and never interfere with chat. Every request rejects redirects, has a 15-second timeout, reads at most 64 KiB, and applies bounded JSON depth, collection counts, history length, and numeric ranges.
 
 ### Switching Models
 

--- a/compatibility/grok-build-wire-protocol.md
+++ b/compatibility/grok-build-wire-protocol.md
@@ -15,6 +15,7 @@ Pinned source starting points:
 - [Default auth, client, version, and User-Agent headers](https://github.com/xai-org/grok-build/blob/b189869b7755d2b482969acf6c92da3ecfeffd36/crates/codegen/xai-grok-sampler/src/client.rs#L399-L496)
 - [Proxy-specific injected headers](https://github.com/xai-org/grok-build/blob/b189869b7755d2b482969acf6c92da3ecfeffd36/crates/codegen/xai-grok-shell/src/agent/mvp_agent/mod.rs#L1148-L1190)
 - [Responses defaults and dispatch](https://github.com/xai-org/grok-build/blob/b189869b7755d2b482969acf6c92da3ecfeffd36/crates/codegen/xai-grok-sampler/src/client.rs#L1081-L1160)
+- [Subscription billing structures and handler](https://github.com/xai-org/grok-build/blob/b189869b7755d2b482969acf6c92da3ecfeffd36/crates/codegen/xai-grok-shell/src/extensions/billing.rs#L1-L288)
 
 The upstream sampler posts paths relative to a configured base URL. That does not authorize this package to accept caller-, model-, or catalog-provided origins. The endpoint policy below remains pinned in source.
 
@@ -42,6 +43,8 @@ All listed headers are internally owned. Caller/model headers are scrubbed case-
 | Browser/device/refresh token | `https://auth.x.ai/oauth2/token` | JSON accept, form content type, truthful User-Agent, client version/surface | No CLI-proxy headers; no response-body reflection |
 | OIDC discovery/JWKS | Pinned issuer discovery and JWKS URLs | JSON accept, redirect rejection, issuer/algorithm/key validation | No bearer, caller endpoint, or proxy metadata |
 | OAuth model catalog | `https://cli-chat-proxy.grok.com/v1/models-v2` | Bearer, JSON accept, truthful identity/version/User-Agent, token-auth, authenticate-response, client mode | No conversation, request, model, session, agent, turn, user, or deployment IDs |
+| OAuth account identity | `https://cli-chat-proxy.grok.com/v1/user` | Pi-stored OAuth bearer, token-auth, client version/mode, redirect rejection, 15-second timeout, 64 KiB response bound | No `x-userid`, API-key provenance, caller endpoint, or caller/model headers |
+| OAuth subscription usage | `https://cli-chat-proxy.grok.com/v1/billing?format=credits` | Same verified OAuth bearer plus the immediately preceding bounded `/user` result as transient `x-userid`; redirect/timeout/body/JSON bounds | No cached/persisted identity, API-key provenance, caller endpoint, or other identity/affinity IDs |
 | OAuth streaming Responses | `https://cli-chat-proxy.grok.com/v1/responses` | Bearer, JSON content, `Accept: text/event-stream`, truthful identity/version/User-Agent, proxy auth, client mode, conversation/request/model/session metadata, redirect rejection | No unsupported identity IDs, generic SDK affinity IDs, or caller route |
 | OAuth direct Responses | `https://cli-chat-proxy.grok.com/v1/responses` | Same proxy metadata with `Accept: application/json` and redirect rejection | No SSE accept, unsupported identity IDs, or generic SDK affinity IDs |
 | API-key direct Responses | `https://api.x.ai/v1/responses` | Bearer, JSON accept/content, truthful User-Agent, redirect rejection | No CLI-proxy metadata or generic SDK affinity IDs |
@@ -49,13 +52,14 @@ All listed headers are internally owned. Caller/model headers are scrubbed case-
 
 ### Header classification
 
-- Always internally owned: `Authorization`, `Accept`, `Content-Type`, `User-Agent`, every `x-grok-*` header, `X-XAI-Token-Auth`, and `x-authenticateresponse`.
+- Always internally owned: `Authorization`, `Accept`, `Content-Type`, `User-Agent`, every `x-grok-*` header, `X-XAI-Token-Auth`, `x-authenticateresponse`, and `x-userid`.
 - Proxy-route authentication: `X-XAI-Token-Auth: xai-grok-cli` and `x-authenticateresponse: authenticate-response`.
 - Truthful attribution/gating: `x-grok-client-identifier`, `x-grok-client-version`, and `User-Agent`.
 - Route mode: `x-grok-client-mode`, resolved as `interactive` only for a text TTY and `headless` for print/JSON/RPC/non-TTY operation.
 - Streaming only: `Accept: text/event-stream`.
+- Usage billing only: `x-userid`, accepted only from the bounded authenticated `/user` response and never from caller/model headers.
 - Affinity/routing metadata: conversation, request, model override, and session IDs on OAuth Responses only.
-- Unsupported: agent, turn, deployment, and user IDs. Unknown caller-supplied `x-grok-*` names are rejected. Generic delegate affinity headers (`session_id`, `x-client-request-id`, and `x-session-id`) are suppressed so only the reviewed xAI conversation/request/session fields leave the process.
+- Unsupported outside the pinned billing request: agent, turn, deployment, and user IDs. Unknown caller-supplied `x-grok-*` names are rejected. Generic delegate affinity headers (`session_id`, `x-client-request-id`, and `x-session-id`) are suppressed so only the reviewed xAI conversation/request/session fields leave the process.
 
 ## ID ownership
 
@@ -66,11 +70,12 @@ All listed headers are internally owned. Caller/model headers are scrubbed case-
 - `x-grok-model-override` comes only from the normalized selected/requested model ID.
 - `x-grok-agent-id` is omitted because upstream treats it as a persistent runtime/machine identity and Pi does not provide an equivalent consented value.
 - `x-grok-turn-idx` is omitted because Pi does not expose one authoritative value through all streaming and direct helper paths.
-- Deployment and user IDs are never derived from OAuth credentials, identity tokens, catalog bodies, or local machine state.
+- Subscription usage obtains `x-userid` only from the pinned authenticated `/user` lookup, uses it once for the immediately following billing request, and discards it.
+- Deployment and other user IDs are never derived from OAuth credentials, identity tokens, catalog bodies, or local machine state.
 
 ## Privacy and failure policy
 
-The header sanitizer removes authorization, accept/content type, User-Agent, proxy auth, generic SDK affinity IDs, and every caller-provided `x-grok-*` value before adding the approved route contract. This prevents client impersonation and privacy-sensitive ID injection while preserving unrelated non-reserved headers. Responses and media POSTs reject redirects before fetch can replay request bodies or metadata to another origin.
+The header sanitizer removes authorization, accept/content type, User-Agent, proxy auth, `x-userid`, generic SDK affinity IDs, and every caller-provided `x-grok-*` value before adding the approved route contract. This prevents client impersonation and privacy-sensitive ID injection while preserving unrelated non-reserved headers. The usage module alone adds its transient validated `x-userid` to the pinned billing GET. Responses, media POSTs, and usage GETs reject redirects before fetch can replay request bodies or metadata to another origin.
 
 Unsuccessful direct HTTP responses are read through a 16 KiB bound for classification only. Raw response bodies, request headers, credentials, and request bodies are never included in the thrown/displayed message. Errors preserve HTTP status and route classification. Proxy version-gate signals return stable update/report guidance and the last reviewed revision; they do not recommend copying an official Grok version.
 
@@ -106,12 +111,12 @@ Issue #78 does not change payload include handling, conversation persistence, ty
    ```
 
 3. Reclassify every changed header as internally required, route-specific, streaming-only, affinity, optional attribution, or unsupported. Trace where upstream values originate; do not assume the sampler generates IDs it only forwards.
-4. Re-audit `extensions/xai/constants.ts`, `routing.ts`, `wire.ts`, `responses.ts`, `catalog.ts`, `oauth.ts`, and `device-auth.ts`. Preserve pinned origins unless a separate security review explicitly changes them.
+4. Re-audit `extensions/xai/constants.ts`, `routing.ts`, `wire.ts`, `responses.ts`, `catalog.ts`, `usage.ts`, `oauth.ts`, and `device-auth.ts`. Preserve pinned origins unless a separate security review explicitly changes them.
 5. Update the reviewed revision and this matrix only after request-shape/privacy tests cover the new behavior.
 6. Run:
 
    ```bash
-   npm run test:unit -- tests/responses/routing.test.ts tests/catalog/cache.test.ts tests/oauth/browser-login.test.ts tests/oauth/refresh.test.ts tests/oauth/device-initiation.test.ts tests/oauth/device-polling.test.ts
+   npm run test:unit -- tests/responses/routing.test.ts tests/catalog/cache.test.ts tests/usage tests/oauth/browser-login.test.ts tests/oauth/refresh.test.ts tests/oauth/device-initiation.test.ts tests/oauth/device-polling.test.ts
    npm run typecheck
    npm test
    npm run compatibility:boundaries

--- a/extensions/xai-oauth.ts
+++ b/extensions/xai-oauth.ts
@@ -8,6 +8,7 @@ import { createXaiOAuth } from "./xai/oauth";
 import { streamSimpleXaiResponses } from "./xai/responses";
 import { resolveXaiRoute } from "./xai/routing";
 import { registerXaiTools, syncXaiToolsForModel } from "./xai/tools";
+import { registerXaiUsage } from "./xai/usage";
 
 /** Register the xAI OAuth provider and its authenticated model catalog. */
 export default async function (pi: ExtensionAPI) {
@@ -20,6 +21,7 @@ export default async function (pi: ExtensionAPI) {
   let activeLoginRefreshes = 0;
   let refreshAbortController: AbortController | undefined;
   let oauth: ReturnType<typeof createXaiOAuth>;
+  const xaiUsage = registerXaiUsage(pi);
 
   const providerModels = (models: readonly XaiCatalogModel[]) =>
     models.map(({ apiBackend: _apiBackend, inputProvenance: _inputProvenance, ...model }) => model);
@@ -86,6 +88,9 @@ export default async function (pi: ExtensionAPI) {
   oauth = createXaiOAuth({
     getExistingCredentials: getGrokAuthCredentials,
     onLoginCredentials: async (credentials: OAuthCredentials, callbacks: OAuthLoginCallbacks) => {
+      // A successful login can replace the account. Drop any prior session
+      // usage display before performing other authenticated work.
+      xaiUsage.reset();
       const loginGeneration = ++loginCatalogGeneration;
       activeLoginRefreshes++;
       try {
@@ -171,10 +176,12 @@ export default async function (pi: ExtensionAPI) {
     // Active-tool accessors belong to the ExtensionAPI (`pi`), while models
     // and pi-managed credentials are supplied by the event/context payload.
     (pi as any).on("session_start", async (_event: any, ctx: any) => {
+      xaiUsage.reset(ctx);
       await refreshDeferredCatalog(ctx);
       syncXaiToolsForModel(pi, ctx?.model, { resetNetworkTools: true });
     });
     (pi as any).on("input", async (_event: any, ctx: any) => {
+      xaiUsage.clearIfInactive(ctx);
       await refreshDeferredCatalog(ctx);
       const activeModel = ctx?.model;
       const entitled =
@@ -198,10 +205,14 @@ export default async function (pi: ExtensionAPI) {
       );
       return { action: "handled" };
     });
-    (pi as any).on("model_select", (event: any, ctx: any) =>
-      syncXaiToolsForModel(pi, event?.model ?? ctx?.model),
-    );
+    (pi as any).on("model_select", (event: any, ctx: any) => {
+      // Model changes invalidate the account/model association of a compact
+      // usage display. Require an explicit opt-in again.
+      xaiUsage.reset(ctx);
+      return syncXaiToolsForModel(pi, event?.model ?? ctx?.model);
+    });
     (pi as any).on("before_agent_start", async (_event: any, ctx: any) => {
+      xaiUsage.clearIfInactive(ctx);
       await refreshDeferredCatalog(ctx);
       let activeModel = ctx?.model;
       const entitled =
@@ -227,6 +238,12 @@ export default async function (pi: ExtensionAPI) {
         }
       }
       return syncXaiToolsForModel(pi, activeModel);
+    });
+    (pi as any).on("turn_end", async (_event: any, ctx: any) => {
+      await xaiUsage.refreshStatus(ctx);
+    });
+    (pi as any).on("session_shutdown", (_event: any, ctx: any) => {
+      xaiUsage.reset(ctx);
     });
   }
 }

--- a/extensions/xai-oauth.ts
+++ b/extensions/xai-oauth.ts
@@ -239,8 +239,10 @@ export default async function (pi: ExtensionAPI) {
       }
       return syncXaiToolsForModel(pi, activeModel);
     });
-    (pi as any).on("turn_end", async (_event: any, ctx: any) => {
-      await xaiUsage.refreshStatus(ctx);
+    (pi as any).on("turn_end", (_event: any, ctx: any) => {
+      // Footer usage is cosmetic. Never delay pi's awaited turn lifecycle on
+      // credential resolution or two bounded network requests.
+      void xaiUsage.refreshStatus(ctx).catch(() => undefined);
     });
     (pi as any).on("session_shutdown", (_event: any, ctx: any) => {
       xaiUsage.reset(ctx);

--- a/extensions/xai/auth.ts
+++ b/extensions/xai/auth.ts
@@ -140,25 +140,33 @@ export function getStartupXaiCatalogAuth(now = Date.now()): StartupXaiCatalogAut
   return { credential: null, needsRegistryRefresh, credentialChangedAt };
 }
 
-/** Resolve a tagged xAI OAuth credential from pi context or reusable Grok CLI credentials. */
-export async function resolveXaiCredential(ctx: any): Promise<XaiCredential | null> {
-  if (typeof ctx?.modelRegistry?.find === "function" && typeof ctx?.modelRegistry?.getApiKeyAndHeaders === "function") {
-    const candidateIds = [
-      ctx?.model?.provider === XAI_PROVIDER_ID ? ctx.model.id : undefined,
-      DEFAULT_XAI_MODEL,
-      ...getXaiRuntimeModels().map((model) => model.id),
-    ].filter((id, index, values): id is string => typeof id === "string" && !!id && values.indexOf(id) === index);
-    for (const modelId of candidateIds) {
-      const registryModel = ctx.modelRegistry.find(XAI_PROVIDER_ID, modelId);
-      if (!registryModel) continue;
-      const auth = await ctx.modelRegistry.getApiKeyAndHeaders(registryModel);
-      if (auth?.ok && auth.apiKey) return { kind: "oauth-session", token: auth.apiKey };
-      const authorization = auth?.ok && typeof auth.headers?.Authorization === "string" ? auth.headers.Authorization : "";
-      if (authorization.toLowerCase().startsWith("bearer ")) {
-        return { kind: "oauth-session", token: authorization.slice("bearer ".length) };
-      }
+/** Resolve an xAI OAuth credential exclusively through pi's managed model registry. */
+export async function resolvePiManagedXaiCredential(ctx: any): Promise<XaiCredential | null> {
+  if (typeof ctx?.modelRegistry?.find !== "function" || typeof ctx?.modelRegistry?.getApiKeyAndHeaders !== "function") {
+    return null;
+  }
+  const candidateIds = [
+    ctx?.model?.provider === XAI_PROVIDER_ID ? ctx.model.id : undefined,
+    DEFAULT_XAI_MODEL,
+    ...getXaiRuntimeModels().map((model) => model.id),
+  ].filter((id, index, values): id is string => typeof id === "string" && !!id && values.indexOf(id) === index);
+  for (const modelId of candidateIds) {
+    const registryModel = ctx.modelRegistry.find(XAI_PROVIDER_ID, modelId);
+    if (!registryModel) continue;
+    const auth = await ctx.modelRegistry.getApiKeyAndHeaders(registryModel);
+    if (auth?.ok && auth.apiKey) return { kind: "oauth-session", token: auth.apiKey };
+    const authorization = auth?.ok && typeof auth.headers?.Authorization === "string" ? auth.headers.Authorization : "";
+    if (authorization.toLowerCase().startsWith("bearer ")) {
+      return { kind: "oauth-session", token: authorization.slice("bearer ".length) };
     }
   }
+  return null;
+}
+
+/** Resolve a tagged xAI OAuth credential from pi context or reusable Grok CLI credentials. */
+export async function resolveXaiCredential(ctx: any): Promise<XaiCredential | null> {
+  const managedCredential = await resolvePiManagedXaiCredential(ctx);
+  if (managedCredential) return managedCredential;
   if (ctx?.apiKey) return { kind: "oauth-session", token: ctx.apiKey };
 
   const credentials = getGrokAuthCredentials();

--- a/extensions/xai/auth.ts
+++ b/extensions/xai/auth.ts
@@ -140,27 +140,138 @@ export function getStartupXaiCatalogAuth(now = Date.now()): StartupXaiCatalogAut
   return { credential: null, needsRegistryRefresh, credentialChangedAt };
 }
 
-/** Resolve an xAI OAuth credential exclusively through pi's managed model registry. */
+function xaiRegistryCandidateIds(ctx: any): string[] {
+  return [
+    ctx?.model?.provider === XAI_PROVIDER_ID ? ctx.model.id : undefined,
+    DEFAULT_XAI_MODEL,
+    ...getXaiRuntimeModels().map((model) => model.id),
+  ].filter(
+    (id, index, values): id is string =>
+      typeof id === "string" && !!id && values.indexOf(id) === index,
+  );
+}
+
+function legacyStoredOAuthAccess(registry: any): string | null | undefined {
+  if (typeof registry?.authStorage?.get !== "function") return undefined;
+  try {
+    const stored = registry.authStorage.get(XAI_PROVIDER_ID);
+    return stored?.type === "oauth"
+      && typeof stored.access === "string"
+      && stored.access
+      ? stored.access
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function hasRuntimeApiKeyOverride(registry: any): boolean {
+  if (typeof registry?.getProviderAuthStatus !== "function") return false;
+  try {
+    return registry.getProviderAuthStatus(XAI_PROVIDER_ID)?.source === "runtime";
+  } catch {
+    return true;
+  }
+}
+
+function registryModelUsesOAuth(registry: any, model: any): boolean {
+  try {
+    if (registry.isUsingOAuth(model) !== true) return false;
+    const legacyAccess = legacyStoredOAuthAccess(registry);
+    if (legacyAccess !== undefined) return legacyAccess !== null;
+    if (typeof registry.getProviderAuthStatus !== "function") return false;
+    const status = registry.getProviderAuthStatus(XAI_PROVIDER_ID);
+    return status?.configured === true && status.source === "stored";
+  } catch {
+    return false;
+  }
+}
+
+function credentialFromResolvedAuth(auth: any): XaiCredential | null {
+  if (auth?.ok && typeof auth.apiKey === "string" && auth.apiKey) {
+    return { kind: "oauth-session", token: auth.apiKey };
+  }
+  const authorization =
+    auth?.ok && typeof auth.headers?.Authorization === "string"
+      ? auth.headers.Authorization
+      : "";
+  return authorization.toLowerCase().startsWith("bearer ")
+    ? { kind: "oauth-session", token: authorization.slice("bearer ".length) }
+    : null;
+}
+
+/** Resolve a tagged xAI credential through pi's managed model registry. */
 export async function resolvePiManagedXaiCredential(ctx: any): Promise<XaiCredential | null> {
   if (typeof ctx?.modelRegistry?.find !== "function" || typeof ctx?.modelRegistry?.getApiKeyAndHeaders !== "function") {
     return null;
   }
-  const candidateIds = [
-    ctx?.model?.provider === XAI_PROVIDER_ID ? ctx.model.id : undefined,
-    DEFAULT_XAI_MODEL,
-    ...getXaiRuntimeModels().map((model) => model.id),
-  ].filter((id, index, values): id is string => typeof id === "string" && !!id && values.indexOf(id) === index);
-  for (const modelId of candidateIds) {
+  for (const modelId of xaiRegistryCandidateIds(ctx)) {
     const registryModel = ctx.modelRegistry.find(XAI_PROVIDER_ID, modelId);
     if (!registryModel) continue;
     const auth = await ctx.modelRegistry.getApiKeyAndHeaders(registryModel);
-    if (auth?.ok && auth.apiKey) return { kind: "oauth-session", token: auth.apiKey };
-    const authorization = auth?.ok && typeof auth.headers?.Authorization === "string" ? auth.headers.Authorization : "";
-    if (authorization.toLowerCase().startsWith("bearer ")) {
-      return { kind: "oauth-session", token: authorization.slice("bearer ".length) };
+    const credential = credentialFromResolvedAuth(auth);
+    if (credential) return credential;
+  }
+  return null;
+}
+
+/**
+ * Resolve only a Pi-stored xAI OAuth bearer, rejecting API-key credentials and
+ * runtime API-key overrides even when Pi's generic request resolver returns one.
+ */
+export async function resolvePiManagedXaiOAuthCredential(ctx: any): Promise<XaiCredential | null> {
+  const registry = ctx?.modelRegistry;
+  if (
+    typeof registry?.find !== "function"
+    || typeof registry?.getApiKeyAndHeaders !== "function"
+    || typeof registry?.isUsingOAuth !== "function"
+  ) {
+    return null;
+  }
+  const legacyAccessBefore = legacyStoredOAuthAccess(registry);
+  if (legacyAccessBefore === null || hasRuntimeApiKeyOverride(registry)) {
+    return null;
+  }
+  for (const modelId of xaiRegistryCandidateIds(ctx)) {
+    const registryModel = registry.find(XAI_PROVIDER_ID, modelId);
+    if (!registryModel || !registryModelUsesOAuth(registry, registryModel)) continue;
+    const credential = credentialFromResolvedAuth(
+      await registry.getApiKeyAndHeaders(registryModel),
+    );
+    const legacyAccessAfter = legacyStoredOAuthAccess(registry);
+    if (
+      credential
+      && !hasRuntimeApiKeyOverride(registry)
+      && registryModelUsesOAuth(registry, registryModel)
+      && legacyAccessAfter !== null
+      && (legacyAccessAfter === undefined || credential.token === legacyAccessAfter)
+    ) {
+      return credential;
     }
   }
   return null;
+}
+
+/**
+ * Return whether Pi currently identifies an xAI registry model as stored OAuth.
+ *
+ * This uses the public registry facade available across Pi 0.80.1–0.80.10.
+ */
+export function hasPiManagedXaiOAuth(ctx: any): boolean {
+  const registry = ctx?.modelRegistry;
+  if (
+    typeof registry?.find !== "function"
+    || typeof registry?.isUsingOAuth !== "function"
+    || hasRuntimeApiKeyOverride(registry)
+  ) {
+    return false;
+  }
+  const legacyAccess = legacyStoredOAuthAccess(registry);
+  if (legacyAccess === null) return false;
+  return xaiRegistryCandidateIds(ctx).some((modelId) => {
+    const registryModel = registry.find(XAI_PROVIDER_ID, modelId);
+    return !!registryModel && registryModelUsesOAuth(registry, registryModel);
+  });
 }
 
 /** Resolve a tagged xAI OAuth credential from pi context or reusable Grok CLI credentials. */

--- a/extensions/xai/constants.ts
+++ b/extensions/xai/constants.ts
@@ -29,6 +29,8 @@ export const XAI_CLI_BASE_URL = "https://cli-chat-proxy.grok.com/v1";
 export const XAI_RESPONSES_URL = "https://api.x.ai/v1/responses";
 export const XAI_CLI_RESPONSES_URL = "https://cli-chat-proxy.grok.com/v1/responses";
 export const XAI_CLI_MODELS_URL = "https://cli-chat-proxy.grok.com/v1/models-v2";
+export const XAI_CLI_USER_URL = "https://cli-chat-proxy.grok.com/v1/user";
+export const XAI_CLI_BILLING_URL = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
 export const XAI_IMAGES_GENERATIONS_URL = "https://api.x.ai/v1/images/generations";
 export const XAI_IMAGES_EDITS_URL = "https://api.x.ai/v1/images/edits";
 
@@ -37,6 +39,15 @@ export const XAI_MODEL_CATALOG_FRESH_TTL_MS = 15 * 60 * 1000;
 export const XAI_MODEL_CATALOG_MAX_STALE_MS = 7 * 24 * 60 * 60 * 1000;
 export const XAI_MODEL_CATALOG_TIMEOUT_MS = 5 * 1000;
 export const XAI_MODEL_CATALOG_MAX_BYTES = 1024 * 1024;
+
+export const XAI_USAGE_TIMEOUT_MS = 15 * 1000;
+export const XAI_USAGE_MAX_RESPONSE_BYTES = 64 * 1024;
+export const XAI_USAGE_MAX_JSON_DEPTH = 12;
+export const XAI_USAGE_MAX_JSON_ARRAY_ITEMS = 64;
+export const XAI_USAGE_MAX_JSON_OBJECT_KEYS = 64;
+export const XAI_USAGE_MAX_JSON_NODES = 2048;
+export const XAI_USAGE_MAX_HISTORY_PERIODS = 24;
+export const XAI_USAGE_STATUS_MIN_REFRESH_MS = 60 * 1000;
 
 export const XAI_CLIENT_IDENTIFIER = packageMetadata.name;
 export const XAI_PACKAGE_VERSION = packageMetadata.version;

--- a/extensions/xai/usage.ts
+++ b/extensions/xai/usage.ts
@@ -1,0 +1,633 @@
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+  ExtensionContext,
+  ExtensionUIContext,
+} from "@earendil-works/pi-coding-agent";
+import { resolvePiManagedXaiCredential } from "./auth";
+import {
+  XAI_CLIENT_VERSION,
+  XAI_CLI_BILLING_URL,
+  XAI_CLI_USER_URL,
+  XAI_PROVIDER_ID,
+  XAI_USAGE_MAX_HISTORY_PERIODS,
+  XAI_USAGE_MAX_JSON_ARRAY_ITEMS,
+  XAI_USAGE_MAX_JSON_DEPTH,
+  XAI_USAGE_MAX_JSON_NODES,
+  XAI_USAGE_MAX_JSON_OBJECT_KEYS,
+  XAI_USAGE_MAX_RESPONSE_BYTES,
+  XAI_USAGE_STATUS_MIN_REFRESH_MS,
+  XAI_USAGE_TIMEOUT_MS,
+} from "./constants";
+import { resolveXaiClientMode } from "./models";
+import type { XaiCredential } from "./routing";
+
+const XAI_USAGE_STATUS_KEY = "xai-usage";
+const XAI_USAGE_COMMAND_HELP = "Usage: /xai-usage [status [on|off]]";
+const MAX_USER_ID_LENGTH = 256;
+const MAX_LABEL_LENGTH = 80;
+const MAX_TIMESTAMP_LENGTH = 64;
+const MAX_CENTS = 1_000_000_000_000;
+const MIN_BILLING_YEAR = 2000;
+const MAX_BILLING_YEAR = 2200;
+const USER_ID_PATTERN = /^[\x21-\x7e]+$/;
+const RFC3339_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+export interface XaiUsagePeriod {
+  type?: string;
+  start?: string;
+  end?: string;
+}
+
+export interface XaiUsageHistoryPeriod {
+  period?: XaiUsagePeriod;
+  billingCycle?: { year: number; month: number };
+  includedUsedCents?: number;
+  onDemandUsedCents?: number;
+  totalUsedCents?: number;
+}
+
+export interface XaiUsageSnapshot {
+  creditUsagePercent?: number;
+  currentPeriod?: XaiUsagePeriod;
+  monthlyLimitCents?: number;
+  usedCents?: number;
+  onDemandCapCents?: number;
+  onDemandUsedCents?: number;
+  prepaidBalanceCents?: number;
+  isUnifiedBillingUser?: boolean;
+  onDemandEnabled?: boolean;
+  subscriptionTier?: string;
+  history: XaiUsageHistoryPeriod[];
+}
+
+type XaiUsageErrorCode =
+  | "auth"
+  | "cancelled"
+  | "http"
+  | "invalid"
+  | "oversize"
+  | "timeout"
+  | "transport";
+
+/** A user-safe usage failure that never includes response bodies, credentials, or identity. */
+export class XaiUsageError extends Error {
+  readonly code: XaiUsageErrorCode;
+  readonly status?: number;
+
+  constructor(code: XaiUsageErrorCode, message: string, status?: number) {
+    super(message);
+    this.name = "XaiUsageError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+interface JsonBudget {
+  nodes: number;
+}
+
+function objectValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function assertBoundedJson(value: unknown, depth = 0, budget: JsonBudget = { nodes: 0 }): void {
+  if (depth > XAI_USAGE_MAX_JSON_DEPTH || ++budget.nodes > XAI_USAGE_MAX_JSON_NODES) {
+    throw new XaiUsageError("invalid", "xAI usage returned an over-complex response.");
+  }
+  if (Array.isArray(value)) {
+    if (value.length > XAI_USAGE_MAX_JSON_ARRAY_ITEMS) {
+      throw new XaiUsageError("invalid", "xAI usage returned too many response entries.");
+    }
+    for (const item of value) assertBoundedJson(item, depth + 1, budget);
+    return;
+  }
+  const obj = objectValue(value);
+  if (!obj) return;
+  const values = Object.values(obj);
+  if (values.length > XAI_USAGE_MAX_JSON_OBJECT_KEYS) {
+    throw new XaiUsageError("invalid", "xAI usage returned too many response fields.");
+  }
+  for (const item of values) assertBoundedJson(item, depth + 1, budget);
+}
+
+function boundedLabel(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const label = value.trim();
+  return label && label.length <= MAX_LABEL_LENGTH && !/[\u0000-\u001f\u007f]/.test(label)
+    ? label
+    : undefined;
+}
+
+function boundedTimestamp(value: unknown): string | undefined {
+  if (
+    typeof value !== "string"
+    || value.length > MAX_TIMESTAMP_LENGTH
+    || !RFC3339_PATTERN.test(value)
+    || !Number.isFinite(Date.parse(value))
+  ) return undefined;
+  return value;
+}
+
+function boundedPercent(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 100
+    ? value
+    : undefined;
+}
+
+function boundedCents(value: unknown): number | undefined {
+  const wrapper = objectValue(value);
+  if (!wrapper) return undefined;
+  const cents = wrapper.val === undefined ? 0 : wrapper.val;
+  return typeof cents === "number"
+    && Number.isSafeInteger(cents)
+    && cents >= 0
+    && cents <= MAX_CENTS
+    ? cents
+    : undefined;
+}
+
+function usagePeriod(value: unknown): XaiUsagePeriod | undefined {
+  const obj = objectValue(value);
+  if (!obj) return undefined;
+  const result: XaiUsagePeriod = {};
+  const type = boundedLabel(obj.type);
+  const start = boundedTimestamp(obj.start);
+  const end = boundedTimestamp(obj.end);
+  if (type) result.type = type;
+  if (start) result.start = start;
+  if (end) result.end = end;
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function billingCycle(value: unknown): { year: number; month: number } | undefined {
+  const obj = objectValue(value);
+  if (!obj) return undefined;
+  const { year, month } = obj;
+  return Number.isSafeInteger(year)
+    && Number.isSafeInteger(month)
+    && (year as number) >= MIN_BILLING_YEAR
+    && (year as number) <= MAX_BILLING_YEAR
+    && (month as number) >= 1
+    && (month as number) <= 12
+    ? { year: year as number, month: month as number }
+    : undefined;
+}
+
+function historyPeriod(value: unknown): XaiUsageHistoryPeriod | undefined {
+  const obj = objectValue(value);
+  if (!obj) return undefined;
+  const result: XaiUsageHistoryPeriod = {};
+  const period = usagePeriod(obj.period);
+  const cycle = billingCycle(obj.billingCycle);
+  const included = boundedCents(obj.includedUsed);
+  const onDemand = boundedCents(obj.onDemandUsed);
+  const total = boundedCents(obj.totalUsed);
+  if (period) result.period = period;
+  if (cycle) result.billingCycle = cycle;
+  if (included !== undefined) result.includedUsedCents = included;
+  if (onDemand !== undefined) result.onDemandUsedCents = onDemand;
+  if (total !== undefined) result.totalUsedCents = total;
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+/** Extract a transient header-safe user ID from the authenticated `/user` response. */
+export function parseXaiUserId(value: unknown): string {
+  assertBoundedJson(value);
+  const userId = objectValue(value)?.userId;
+  if (
+    typeof userId !== "string"
+    || !userId
+    || userId.length > MAX_USER_ID_LENGTH
+    || !USER_ID_PATTERN.test(userId)
+  ) {
+    throw new XaiUsageError(
+      "invalid",
+      "xAI account identity could not be verified; billing was not requested.",
+    );
+  }
+  return userId;
+}
+
+/** Parse the bounded observed credits response without retaining its raw representation. */
+export function parseXaiUsage(value: unknown): XaiUsageSnapshot {
+  assertBoundedJson(value);
+  const root = objectValue(value);
+  if (!root) throw new XaiUsageError("invalid", "xAI usage returned an invalid response.");
+  if (root.config !== undefined && root.config !== null && !objectValue(root.config)) {
+    throw new XaiUsageError("invalid", "xAI usage returned an invalid response.");
+  }
+  const config = objectValue(root.config);
+  const snapshot: XaiUsageSnapshot = { history: [] };
+  if (typeof root.onDemandEnabled === "boolean") snapshot.onDemandEnabled = root.onDemandEnabled;
+  const tier = boundedLabel(root.subscriptionTier);
+  if (tier) snapshot.subscriptionTier = tier;
+  if (!config) return snapshot;
+
+  const history = config.history;
+  if (history !== undefined && !Array.isArray(history)) {
+    throw new XaiUsageError("invalid", "xAI usage returned invalid billing history.");
+  }
+  if (Array.isArray(history) && history.length > XAI_USAGE_MAX_HISTORY_PERIODS) {
+    throw new XaiUsageError("invalid", "xAI usage returned too many billing periods.");
+  }
+
+  const percent = boundedPercent(config.creditUsagePercent);
+  const currentPeriod = usagePeriod(config.currentPeriod);
+  const monthlyLimit = boundedCents(config.monthlyLimit);
+  const used = boundedCents(config.used);
+  const onDemandCap = boundedCents(config.onDemandCap);
+  const onDemandUsed = boundedCents(config.onDemandUsed);
+  const prepaid = boundedCents(config.prepaidBalance);
+  if (percent !== undefined) snapshot.creditUsagePercent = percent;
+  if (currentPeriod) snapshot.currentPeriod = currentPeriod;
+  if (monthlyLimit !== undefined) snapshot.monthlyLimitCents = monthlyLimit;
+  if (used !== undefined) snapshot.usedCents = used;
+  if (onDemandCap !== undefined) snapshot.onDemandCapCents = onDemandCap;
+  if (onDemandUsed !== undefined) snapshot.onDemandUsedCents = onDemandUsed;
+  if (prepaid !== undefined) snapshot.prepaidBalanceCents = prepaid;
+  if (typeof config.isUnifiedBillingUser === "boolean") {
+    snapshot.isUnifiedBillingUser = config.isUnifiedBillingUser;
+  }
+  const fallbackStart = boundedTimestamp(config.billingPeriodStart);
+  const fallbackEnd = boundedTimestamp(config.billingPeriodEnd);
+  if (!snapshot.currentPeriod && (fallbackStart || fallbackEnd)) {
+    snapshot.currentPeriod = {
+      ...(fallbackStart ? { start: fallbackStart } : {}),
+      ...(fallbackEnd ? { end: fallbackEnd } : {}),
+    };
+  }
+  if (Array.isArray(history)) {
+    snapshot.history = history
+      .map(historyPeriod)
+      .filter((entry): entry is XaiUsageHistoryPeriod => entry !== undefined);
+  }
+  return snapshot;
+}
+
+async function readBoundedBody(response: Response, signal: AbortSignal): Promise<string> {
+  if (!response.body) return "";
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let bytes = 0;
+  let text = "";
+  try {
+    while (true) {
+      if (signal.aborted) throw signal.reason;
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytes += value.byteLength;
+      if (bytes > XAI_USAGE_MAX_RESPONSE_BYTES) {
+        void reader.cancel().catch(() => undefined);
+        throw new XaiUsageError("oversize", "xAI usage returned an oversized response.");
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    return text + decoder.decode();
+  } catch (error) {
+    if (error instanceof XaiUsageError) throw error;
+    throw new XaiUsageError("invalid", "xAI usage returned an invalid response body.");
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function httpError(status: number): XaiUsageError {
+  if (status === 401 || status === 403) {
+    return new XaiUsageError(
+      "auth",
+      "xAI authentication was rejected. Run /login xai-auth and try again.",
+      status,
+    );
+  }
+  if (status === 404 || (status >= 300 && status < 400)) {
+    return new XaiUsageError(
+      "http",
+      "The pinned xAI usage contract is unavailable.",
+      status,
+    );
+  }
+  if (status === 429) {
+    return new XaiUsageError("http", "xAI usage is rate limited. Try again later.", status);
+  }
+  return new XaiUsageError("http", `xAI usage request failed with status ${status}.`, status);
+}
+
+async function requestBoundedJson(
+  url: string,
+  credential: XaiCredential,
+  headers: Record<string, string>,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  if (credential.kind !== "oauth-session" || !credential.token) {
+    throw new XaiUsageError("auth", "xAI OAuth credentials are required. Run /login xai-auth first.");
+  }
+  const controller = new AbortController();
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, XAI_USAGE_TIMEOUT_MS);
+  const forwardAbort = () => controller.abort();
+  signal?.addEventListener("abort", forwardAbort, { once: true });
+  if (signal?.aborted) controller.abort();
+
+  try {
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "GET",
+        redirect: "error",
+        signal: controller.signal,
+        headers: {
+          ...headers,
+          Authorization: `Bearer ${credential.token}`,
+          "X-XAI-Token-Auth": "xai-grok-cli",
+          "x-grok-client-version": XAI_CLIENT_VERSION,
+          "x-grok-client-mode": resolveXaiClientMode(),
+        },
+      });
+    } catch {
+      if (signal?.aborted) throw new XaiUsageError("cancelled", "xAI usage request was cancelled.");
+      if (timedOut) throw new XaiUsageError("timeout", "xAI usage request timed out.");
+      throw new XaiUsageError("transport", "xAI usage request failed.");
+    }
+    if (!response.ok) throw httpError(response.status);
+    let body: string;
+    try {
+      body = await readBoundedBody(response, controller.signal);
+    } catch (error) {
+      if (signal?.aborted) throw new XaiUsageError("cancelled", "xAI usage request was cancelled.");
+      if (timedOut) throw new XaiUsageError("timeout", "xAI usage request timed out.");
+      if (error instanceof XaiUsageError) throw error;
+      throw new XaiUsageError("transport", "xAI usage request failed.");
+    }
+    try {
+      return JSON.parse(body);
+    } catch {
+      throw new XaiUsageError("invalid", "xAI usage returned malformed JSON.");
+    }
+  } finally {
+    clearTimeout(timeout);
+    signal?.removeEventListener("abort", forwardAbort);
+  }
+}
+
+/** Fetch identity and billing sequentially using one transient Pi-resolved bearer. */
+export async function fetchXaiUsage(
+  credential: XaiCredential,
+  signal?: AbortSignal,
+): Promise<XaiUsageSnapshot> {
+  const identity = await requestBoundedJson(XAI_CLI_USER_URL, credential, {}, signal);
+  const userId = parseXaiUserId(identity);
+  const billing = await requestBoundedJson(
+    XAI_CLI_BILLING_URL,
+    credential,
+    { "x-userid": userId },
+    signal,
+  );
+  return parseXaiUsage(billing);
+}
+
+function formatPercent(value: number): string {
+  return `${Number(value.toFixed(1))}%`;
+}
+
+function formatCents(value: number): string {
+  return `$${(value / 100).toFixed(2)}`;
+}
+
+function effectivePercent(usage: XaiUsageSnapshot): number | undefined {
+  if (usage.creditUsagePercent !== undefined) return usage.creditUsagePercent;
+  if (
+    usage.usedCents !== undefined
+    && usage.monthlyLimitCents !== undefined
+    && usage.monthlyLimitCents > 0
+  ) {
+    return Math.min(100, (usage.usedCents / usage.monthlyLimitCents) * 100);
+  }
+  return undefined;
+}
+
+/** Render only validated usage fields for the explicit command. */
+export function renderXaiUsage(usage: XaiUsageSnapshot): string {
+  const lines = ["xAI usage (unofficial, revision-pinned):"];
+  const percent = effectivePercent(usage);
+  if (usage.subscriptionTier) lines.push(`Subscription: ${usage.subscriptionTier}`);
+  if (percent !== undefined) lines.push(`Included usage: ${formatPercent(percent)}`);
+  if (usage.usedCents !== undefined || usage.monthlyLimitCents !== undefined) {
+    lines.push(
+      `Included credits: ${usage.usedCents !== undefined ? `${formatCents(usage.usedCents)} used` : "usage unavailable"}`
+      + `${usage.monthlyLimitCents !== undefined ? ` of ${formatCents(usage.monthlyLimitCents)}` : ""}`,
+    );
+  }
+  if (usage.currentPeriod?.start) lines.push(`Period start: ${usage.currentPeriod.start}`);
+  if (usage.currentPeriod?.end) lines.push(`Reset: ${usage.currentPeriod.end}`);
+  if (usage.onDemandUsedCents !== undefined || usage.onDemandCapCents !== undefined) {
+    lines.push(
+      `On-demand credits: ${usage.onDemandUsedCents !== undefined ? `${formatCents(usage.onDemandUsedCents)} used` : "usage unavailable"}`
+      + `${usage.onDemandCapCents !== undefined ? ` of ${formatCents(usage.onDemandCapCents)}` : ""}`,
+    );
+  }
+  if (usage.prepaidBalanceCents !== undefined) {
+    lines.push(`Prepaid balance: ${formatCents(usage.prepaidBalanceCents)}`);
+  }
+  if (usage.onDemandEnabled !== undefined) {
+    lines.push(`On-demand billing: ${usage.onDemandEnabled ? "enabled" : "disabled"}`);
+  }
+  if (usage.isUnifiedBillingUser !== undefined) {
+    lines.push(`Usage pool: ${usage.isUnifiedBillingUser ? "unified" : "standard"}`);
+  }
+  if (usage.history.length > 0) lines.push(`Validated history periods: ${usage.history.length}`);
+  if (lines.length === 1) lines.push("No supported usage fields were returned.");
+  return lines.join("\n");
+}
+
+/** Render a compact footer value without account identity. */
+export function renderXaiUsageStatus(usage: XaiUsageSnapshot): string {
+  const percent = effectivePercent(usage);
+  const parts = [
+    percent !== undefined
+      ? `${formatPercent(percent)} used`
+      : usage.usedCents !== undefined && usage.monthlyLimitCents !== undefined
+        ? `${formatCents(usage.usedCents)}/${formatCents(usage.monthlyLimitCents)}`
+        : usage.prepaidBalanceCents !== undefined
+          ? `${formatCents(usage.prepaidBalanceCents)} prepaid`
+          : "usage available",
+  ];
+  if (usage.currentPeriod?.end) parts.push(`reset ${usage.currentPeriod.end.slice(0, 10)}`);
+  return `xAI ${parts.join(" · ")}`;
+}
+
+export interface XaiUsageFeature {
+  reset(ctx?: ExtensionContext): void;
+  clearIfInactive(ctx: ExtensionContext): void;
+  refreshStatus(ctx: ExtensionContext): Promise<void>;
+}
+
+interface XaiUsageDependencies {
+  resolveCredential: typeof resolvePiManagedXaiCredential;
+  fetchUsage: typeof fetchXaiUsage;
+  now: () => number;
+  minimumRefreshMs: number;
+}
+
+function safeUsageError(error: unknown): XaiUsageError {
+  return error instanceof XaiUsageError
+    ? error
+    : new XaiUsageError("transport", "xAI usage request failed.");
+}
+
+/** Register `/xai-usage` and return its session-scoped status lifecycle. */
+export function registerXaiUsage(
+  pi: ExtensionAPI,
+  overrides: Partial<XaiUsageDependencies> = {},
+): XaiUsageFeature {
+  const dependencies: XaiUsageDependencies = {
+    resolveCredential: overrides.resolveCredential ?? resolvePiManagedXaiCredential,
+    fetchUsage: overrides.fetchUsage ?? fetchXaiUsage,
+    now: overrides.now ?? Date.now,
+    minimumRefreshMs: overrides.minimumRefreshMs ?? XAI_USAGE_STATUS_MIN_REFRESH_MS,
+  };
+  let statusEnabled = false;
+  let lastRefreshAt = 0;
+  let generation = 0;
+  let lastUi: ExtensionUIContext | undefined;
+  let statusController: AbortController | undefined;
+  let refreshPromise: Promise<{ ok: boolean; error?: XaiUsageError }> | undefined;
+
+  const clear = (ctx?: ExtensionContext) => {
+    const ui = ctx?.ui ?? lastUi;
+    try {
+      ui?.setStatus(XAI_USAGE_STATUS_KEY, undefined);
+    } catch {
+      // Status is cosmetic and must never affect chat or account changes.
+    }
+    lastUi = ctx?.ui;
+  };
+
+  const reset = (ctx?: ExtensionContext) => {
+    statusEnabled = false;
+    lastRefreshAt = 0;
+    generation++;
+    statusController?.abort();
+    statusController = undefined;
+    refreshPromise = undefined;
+    clear(ctx);
+  };
+
+  const resolveUsage = async (ctx: ExtensionContext, signal?: AbortSignal) => {
+    let credential: XaiCredential | null;
+    try {
+      credential = await dependencies.resolveCredential(ctx);
+    } catch {
+      throw new XaiUsageError("auth", "xAI OAuth credentials could not be resolved. Run /login xai-auth first.");
+    }
+    if (!credential) {
+      throw new XaiUsageError("auth", "xAI OAuth credentials are required. Run /login xai-auth first.");
+    }
+    return dependencies.fetchUsage(credential, signal);
+  };
+
+  const updateStatus = async (
+    ctx: ExtensionContext,
+    force: boolean,
+  ): Promise<{ ok: boolean; error?: XaiUsageError }> => {
+    lastUi = ctx.ui;
+    if (!statusEnabled || ctx.model?.provider !== XAI_PROVIDER_ID) {
+      reset(ctx);
+      return { ok: false };
+    }
+    const now = dependencies.now();
+    if (!force && lastRefreshAt > 0 && now - lastRefreshAt < dependencies.minimumRefreshMs) {
+      return { ok: true };
+    }
+    if (refreshPromise) return refreshPromise;
+    lastRefreshAt = now;
+    const refreshGeneration = generation;
+    const controller = new AbortController();
+    statusController = controller;
+    const pending = (async () => {
+      try {
+        const usage = await resolveUsage(ctx, controller.signal);
+        if (
+          refreshGeneration === generation
+          && statusEnabled
+          && ctx.model?.provider === XAI_PROVIDER_ID
+          && !controller.signal.aborted
+        ) {
+          ctx.ui.setStatus(XAI_USAGE_STATUS_KEY, renderXaiUsageStatus(usage));
+        }
+        return { ok: true };
+      } catch (error) {
+        if (refreshGeneration === generation) clear(ctx);
+        return { ok: false, error: safeUsageError(error) };
+      } finally {
+        if (statusController === controller) statusController = undefined;
+      }
+    })();
+    refreshPromise = pending;
+    try {
+      return await pending;
+    } finally {
+      if (refreshPromise === pending) refreshPromise = undefined;
+    }
+  };
+
+  pi.registerCommand("xai-usage", {
+    description: "Show xAI subscription usage or manage the optional session status",
+    handler: async (args: string, ctx: ExtensionCommandContext) => {
+      const parts = args.trim().split(/\s+/).filter(Boolean).map((part) => part.toLowerCase());
+      if (parts.length === 0) {
+        try {
+          const usage = await resolveUsage(ctx, ctx.signal);
+          ctx.ui.notify(renderXaiUsage(usage), "info");
+        } catch (error) {
+          ctx.ui.notify(safeUsageError(error).message, "error");
+        }
+        return;
+      }
+      if (parts[0] !== "status" || parts.length > 2 || (parts[1] && !["on", "off"].includes(parts[1]))) {
+        ctx.ui.notify(XAI_USAGE_COMMAND_HELP, "error");
+        return;
+      }
+      if (!parts[1]) {
+        ctx.ui.notify(`xAI usage status is ${statusEnabled ? "on" : "off"} for this session.`, "info");
+        return;
+      }
+      if (parts[1] === "off") {
+        reset(ctx);
+        ctx.ui.notify("xAI usage status is off for this session.", "info");
+        return;
+      }
+      if (ctx.model?.provider !== XAI_PROVIDER_ID) {
+        reset(ctx);
+        ctx.ui.notify("Select an xAI/Grok model before enabling xAI usage status.", "error");
+        return;
+      }
+      reset(ctx);
+      statusEnabled = true;
+      lastRefreshAt = 0;
+      const result = await updateStatus(ctx, true);
+      if (result.ok) {
+        ctx.ui.notify("xAI usage status is on for this session.", "info");
+      } else {
+        reset(ctx);
+        ctx.ui.notify(result.error?.message ?? "xAI usage status could not be refreshed.", "error");
+      }
+    },
+  });
+
+  return {
+    reset,
+    clearIfInactive(ctx) {
+      if (ctx.model?.provider !== XAI_PROVIDER_ID) reset(ctx);
+    },
+    async refreshStatus(ctx) {
+      if (!statusEnabled) return;
+      await updateStatus(ctx, false);
+    },
+  };
+}

--- a/extensions/xai/usage.ts
+++ b/extensions/xai/usage.ts
@@ -4,9 +4,11 @@ import type {
   ExtensionContext,
   ExtensionUIContext,
 } from "@earendil-works/pi-coding-agent";
-import { resolvePiManagedXaiCredential } from "./auth";
 import {
-  XAI_CLIENT_VERSION,
+  hasPiManagedXaiOAuth,
+  resolvePiManagedXaiOAuthCredential,
+} from "./auth";
+import {
   XAI_CLI_BILLING_URL,
   XAI_CLI_USER_URL,
   XAI_PROVIDER_ID,
@@ -19,8 +21,8 @@ import {
   XAI_USAGE_STATUS_MIN_REFRESH_MS,
   XAI_USAGE_TIMEOUT_MS,
 } from "./constants";
-import { resolveXaiClientMode } from "./models";
 import type { XaiCredential } from "./routing";
+import { xaiUsageHeaders } from "./wire";
 
 const XAI_USAGE_STATUS_KEY = "xai-usage";
 const XAI_USAGE_COMMAND_HELP = "Usage: /xai-usage [status [on|off]]";
@@ -31,7 +33,8 @@ const MAX_CENTS = 1_000_000_000_000;
 const MIN_BILLING_YEAR = 2000;
 const MAX_BILLING_YEAR = 2200;
 const USER_ID_PATTERN = /^[\x21-\x7e]+$/;
-const RFC3339_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+const RFC3339_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|([+-])(\d{2}):(\d{2}))$/;
 
 export interface XaiUsagePeriod {
   type?: string;
@@ -122,12 +125,58 @@ function boundedLabel(value: unknown): string | undefined {
 }
 
 function boundedTimestamp(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.length > MAX_TIMESTAMP_LENGTH) return undefined;
+  const match = value.match(RFC3339_PATTERN);
+  if (!match) return undefined;
+  const [
+    ,
+    yearText,
+    monthText,
+    dayText,
+    hourText,
+    minuteText,
+    secondText,
+    ,
+    offsetHourText,
+    offsetMinuteText,
+  ] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+  const offsetHour = offsetHourText === undefined ? 0 : Number(offsetHourText);
+  const offsetMinute = offsetMinuteText === undefined ? 0 : Number(offsetMinuteText);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [
+    31,
+    leapYear ? 29 : 28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31,
+  ];
   if (
-    typeof value !== "string"
-    || value.length > MAX_TIMESTAMP_LENGTH
-    || !RFC3339_PATTERN.test(value)
+    month < 1
+    || month > 12
+    || day < 1
+    || day > daysInMonth[month - 1]
+    || hour > 23
+    || minute > 59
+    || second > 59
+    || offsetHour > 23
+    || offsetMinute > 59
     || !Number.isFinite(Date.parse(value))
-  ) return undefined;
+  ) {
+    return undefined;
+  }
   return value;
 }
 
@@ -273,14 +322,28 @@ async function readBoundedBody(response: Response, signal: AbortSignal): Promise
   const decoder = new TextDecoder("utf-8", { fatal: true });
   let bytes = 0;
   let text = "";
+  const abortError = () => new DOMException("The operation was cancelled.", "AbortError");
+  let rejectOnAbort: ((reason: unknown) => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    rejectOnAbort = reject;
+  });
+  const onAbort = () => rejectOnAbort?.(signal.reason ?? abortError());
+  const cancelReader = () => {
+    try {
+      void reader.cancel().catch(() => undefined);
+    } catch {
+      // Cancellation is best-effort cleanup and must never extend the request bound.
+    }
+  };
+  signal.addEventListener("abort", onAbort, { once: true });
   try {
+    if (signal.aborted) throw signal.reason ?? abortError();
     while (true) {
-      if (signal.aborted) throw signal.reason;
-      const { done, value } = await reader.read();
+      const { done, value } = await Promise.race([reader.read(), aborted]);
       if (done) break;
       bytes += value.byteLength;
       if (bytes > XAI_USAGE_MAX_RESPONSE_BYTES) {
-        void reader.cancel().catch(() => undefined);
+        cancelReader();
         throw new XaiUsageError("oversize", "xAI usage returned an oversized response.");
       }
       text += decoder.decode(value, { stream: true });
@@ -290,7 +353,13 @@ async function readBoundedBody(response: Response, signal: AbortSignal): Promise
     if (error instanceof XaiUsageError) throw error;
     throw new XaiUsageError("invalid", "xAI usage returned an invalid response body.");
   } finally {
-    reader.releaseLock();
+    signal.removeEventListener("abort", onAbort);
+    if (signal.aborted) cancelReader();
+    try {
+      reader.releaseLock();
+    } catch {
+      // A hostile pending read may retain the lock; request completion stays bounded.
+    }
   }
 }
 
@@ -318,7 +387,7 @@ function httpError(status: number): XaiUsageError {
 async function requestBoundedJson(
   url: string,
   credential: XaiCredential,
-  headers: Record<string, string>,
+  userId?: string,
   signal?: AbortSignal,
 ): Promise<unknown> {
   if (credential.kind !== "oauth-session" || !credential.token) {
@@ -341,20 +410,17 @@ async function requestBoundedJson(
         method: "GET",
         redirect: "error",
         signal: controller.signal,
-        headers: {
-          ...headers,
-          Authorization: `Bearer ${credential.token}`,
-          "X-XAI-Token-Auth": "xai-grok-cli",
-          "x-grok-client-version": XAI_CLIENT_VERSION,
-          "x-grok-client-mode": resolveXaiClientMode(),
-        },
+        headers: xaiUsageHeaders(credential.token, userId),
       });
     } catch {
       if (signal?.aborted) throw new XaiUsageError("cancelled", "xAI usage request was cancelled.");
       if (timedOut) throw new XaiUsageError("timeout", "xAI usage request timed out.");
       throw new XaiUsageError("transport", "xAI usage request failed.");
     }
-    if (!response.ok) throw httpError(response.status);
+    if (!response.ok) {
+      void response.body?.cancel().catch(() => undefined);
+      throw httpError(response.status);
+    }
     let body: string;
     try {
       body = await readBoundedBody(response, controller.signal);
@@ -380,12 +446,12 @@ export async function fetchXaiUsage(
   credential: XaiCredential,
   signal?: AbortSignal,
 ): Promise<XaiUsageSnapshot> {
-  const identity = await requestBoundedJson(XAI_CLI_USER_URL, credential, {}, signal);
+  const identity = await requestBoundedJson(XAI_CLI_USER_URL, credential, undefined, signal);
   const userId = parseXaiUserId(identity);
   const billing = await requestBoundedJson(
     XAI_CLI_BILLING_URL,
     credential,
-    { "x-userid": userId },
+    userId,
     signal,
   );
   return parseXaiUsage(billing);
@@ -468,7 +534,7 @@ export interface XaiUsageFeature {
 }
 
 interface XaiUsageDependencies {
-  resolveCredential: typeof resolvePiManagedXaiCredential;
+  resolveCredential: typeof resolvePiManagedXaiOAuthCredential;
   fetchUsage: typeof fetchXaiUsage;
   now: () => number;
   minimumRefreshMs: number;
@@ -486,7 +552,7 @@ export function registerXaiUsage(
   overrides: Partial<XaiUsageDependencies> = {},
 ): XaiUsageFeature {
   const dependencies: XaiUsageDependencies = {
-    resolveCredential: overrides.resolveCredential ?? resolvePiManagedXaiCredential,
+    resolveCredential: overrides.resolveCredential ?? resolvePiManagedXaiOAuthCredential,
     fetchUsage: overrides.fetchUsage ?? fetchXaiUsage,
     now: overrides.now ?? Date.now,
     minimumRefreshMs: overrides.minimumRefreshMs ?? XAI_USAGE_STATUS_MIN_REFRESH_MS,
@@ -496,6 +562,8 @@ export function registerXaiUsage(
   let generation = 0;
   let lastUi: ExtensionUIContext | undefined;
   let statusController: AbortController | undefined;
+  let oneShotController: AbortController | undefined;
+  let oneShotGeneration = 0;
   let refreshPromise: Promise<{ ok: boolean; error?: XaiUsageError }> | undefined;
 
   const clear = (ctx?: ExtensionContext) => {
@@ -512,8 +580,11 @@ export function registerXaiUsage(
     statusEnabled = false;
     lastRefreshAt = 0;
     generation++;
+    oneShotGeneration++;
     statusController?.abort();
+    oneShotController?.abort();
     statusController = undefined;
+    oneShotController = undefined;
     refreshPromise = undefined;
     clear(ctx);
   };
@@ -536,7 +607,11 @@ export function registerXaiUsage(
     force: boolean,
   ): Promise<{ ok: boolean; error?: XaiUsageError }> => {
     lastUi = ctx.ui;
-    if (!statusEnabled || ctx.model?.provider !== XAI_PROVIDER_ID) {
+    if (
+      !statusEnabled
+      || ctx.model?.provider !== XAI_PROVIDER_ID
+      || !hasPiManagedXaiOAuth(ctx)
+    ) {
       reset(ctx);
       return { ok: false };
     }
@@ -562,8 +637,12 @@ export function registerXaiUsage(
         }
         return { ok: true };
       } catch (error) {
-        if (refreshGeneration === generation) clear(ctx);
-        return { ok: false, error: safeUsageError(error) };
+        const safeError = safeUsageError(error);
+        if (refreshGeneration === generation) {
+          if (safeError.code === "auth") reset(ctx);
+          else clear(ctx);
+        }
+        return { ok: false, error: safeError };
       } finally {
         if (statusController === controller) statusController = undefined;
       }
@@ -581,11 +660,32 @@ export function registerXaiUsage(
     handler: async (args: string, ctx: ExtensionCommandContext) => {
       const parts = args.trim().split(/\s+/).filter(Boolean).map((part) => part.toLowerCase());
       if (parts.length === 0) {
+        oneShotController?.abort();
+        const controller = new AbortController();
+        oneShotController = controller;
+        const requestGeneration = ++oneShotGeneration;
+        const sessionGeneration = generation;
+        const forwardAbort = () => controller.abort();
+        ctx.signal?.addEventListener("abort", forwardAbort, { once: true });
+        if (ctx.signal?.aborted) controller.abort();
         try {
-          const usage = await resolveUsage(ctx, ctx.signal);
-          ctx.ui.notify(renderXaiUsage(usage), "info");
+          const usage = await resolveUsage(ctx, controller.signal);
+          if (
+            requestGeneration === oneShotGeneration
+            && sessionGeneration === generation
+          ) {
+            ctx.ui.notify(renderXaiUsage(usage), "info");
+          }
         } catch (error) {
-          ctx.ui.notify(safeUsageError(error).message, "error");
+          if (
+            requestGeneration === oneShotGeneration
+            && sessionGeneration === generation
+          ) {
+            ctx.ui.notify(safeUsageError(error).message, "error");
+          }
+        } finally {
+          ctx.signal?.removeEventListener("abort", forwardAbort);
+          if (oneShotController === controller) oneShotController = undefined;
         }
         return;
       }
@@ -594,6 +694,7 @@ export function registerXaiUsage(
         return;
       }
       if (!parts[1]) {
+        if (statusEnabled && !hasPiManagedXaiOAuth(ctx)) reset(ctx);
         ctx.ui.notify(`xAI usage status is ${statusEnabled ? "on" : "off"} for this session.`, "info");
         return;
       }
@@ -623,7 +724,12 @@ export function registerXaiUsage(
   return {
     reset,
     clearIfInactive(ctx) {
-      if (ctx.model?.provider !== XAI_PROVIDER_ID) reset(ctx);
+      if (
+        ctx.model?.provider !== XAI_PROVIDER_ID
+        || !hasPiManagedXaiOAuth(ctx)
+      ) {
+        reset(ctx);
+      }
     },
     async refreshStatus(ctx) {
       if (!statusEnabled) return;

--- a/extensions/xai/wire.ts
+++ b/extensions/xai/wire.ts
@@ -20,6 +20,7 @@ const RESERVED_HEADER_NAMES = new Set([
   "x-authenticateresponse",
   "x-client-request-id",
   "x-session-id",
+  "x-userid",
   "x-xai-token-auth",
 ]);
 const APPROVED_PROXY_HEADER_NAMES = new Set([
@@ -138,6 +139,21 @@ export function xaiCatalogHeaders(
     "x-grok-client-identifier": XAI_CLIENT_IDENTIFIER,
     "x-grok-client-version": XAI_PROXY_CLIENT_VERSION,
     "x-grok-client-mode": clientMode,
+  };
+}
+
+/** Build the exact authenticated CLI-proxy header contract for usage GET requests. */
+export function xaiUsageHeaders(
+  accessToken: string,
+  userId?: string,
+  clientMode: XaiClientMode = resolveXaiClientMode(),
+): Record<string, string> {
+  return {
+    Authorization: `Bearer ${accessToken}`,
+    "X-XAI-Token-Auth": "xai-grok-cli",
+    "x-grok-client-version": XAI_PROXY_CLIENT_VERSION,
+    "x-grok-client-mode": clientMode,
+    ...(userId ? { "x-userid": userId } : {}),
   };
 }
 

--- a/scripts/verify-compatibility.js
+++ b/scripts/verify-compatibility.js
@@ -206,6 +206,7 @@ function verifyPackedPackage() {
       "LICENSE",
       "compatibility/pi-versions.json",
       "extensions/xai-oauth.ts",
+      "extensions/xai/usage.ts",
       "scripts/verify-compatibility.js",
       "scripts/run-compatibility-matrix.js",
       "scripts/verify-extension-loader.mjs",

--- a/scripts/verify-extension-loader.mjs
+++ b/scripts/verify-extension-loader.mjs
@@ -25,6 +25,7 @@ try {
   assert.ok(loaded.tools.has("xai_edit_image"), "bounded xAI image-edit tool should be registered");
   assert.ok(loaded.tools.has("Grep"), "representative Cursor shim should be registered");
   assert.ok(loaded.commands.has("xai-tools"), "/xai-tools should be registered");
+  assert.ok(loaded.commands.has("xai-usage"), "/xai-usage should be registered");
   assert.equal(runtime.pendingProviderRegistrations.length, 1, "one provider should be queued");
   const provider = runtime.pendingProviderRegistrations[0];
   assert.equal(provider.name, "xai-auth");

--- a/tests/fixtures/usage/credits-legacy.json
+++ b/tests/fixtures/usage/credits-legacy.json
@@ -1,0 +1,18 @@
+{
+  "config": {
+    "monthlyLimit": { "val": 2000 },
+    "used": { "val": 500 },
+    "onDemandCap": { "val": 500 },
+    "onDemandUsed": {},
+    "billingPeriodStart": "2026-07-01T00:00:00Z",
+    "billingPeriodEnd": "2026-08-01T00:00:00Z",
+    "history": [
+      {
+        "billingCycle": { "year": 2026, "month": 6 },
+        "includedUsed": { "val": 1800 },
+        "onDemandUsed": {},
+        "totalUsed": { "val": 1800 }
+      }
+    ]
+  }
+}

--- a/tests/fixtures/usage/credits-new.json
+++ b/tests/fixtures/usage/credits-new.json
@@ -1,0 +1,26 @@
+{
+  "config": {
+    "creditUsagePercent": 42.5,
+    "currentPeriod": {
+      "type": "USAGE_PERIOD_TYPE_WEEKLY",
+      "start": "2026-07-13T00:00:00Z",
+      "end": "2026-07-20T00:00:00Z"
+    },
+    "onDemandCap": { "val": 5000 },
+    "onDemandUsed": { "val": 300 },
+    "prepaidBalance": { "val": 1250 },
+    "isUnifiedBillingUser": true,
+    "history": [
+      {
+        "period": {
+          "type": "USAGE_PERIOD_TYPE_WEEKLY",
+          "start": "2026-07-06T00:00:00Z",
+          "end": "2026-07-13T00:00:00Z"
+        },
+        "onDemandUsed": { "val": 120 }
+      }
+    ]
+  },
+  "onDemandEnabled": true,
+  "subscriptionTier": "SuperGrok"
+}

--- a/tests/fixtures/usage/identity.json
+++ b/tests/fixtures/usage/identity.json
@@ -1,0 +1,3 @@
+{
+  "userId": "user-fixture-82"
+}

--- a/tests/provider/credentials.test.ts
+++ b/tests/provider/credentials.test.ts
@@ -1,10 +1,12 @@
 import { access, mkdir, writeFile } from "node:fs/promises";
+import * as PiCodingAgent from "@earendil-works/pi-coding-agent";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getGrokAuthCredentials,
   getStartupXaiCatalogAuth,
   resolveXaiCredential,
+  resolvePiManagedXaiOAuthCredential,
 } from "../../extensions/xai/auth";
 import {
   CURATED_FALLBACK_MODELS,
@@ -13,6 +15,85 @@ import {
 import { createTempDir } from "../fixtures/temp";
 import { TEST_MODEL } from "../fixtures/models";
 let temp: Awaited<ReturnType<typeof createTempDir>>;
+
+const boundaryProviderConfig = {
+  name: "xAI boundary fixture",
+  baseUrl: "https://example.invalid/v1",
+  api: "openai-responses",
+  authHeader: true,
+  oauth: {
+    name: "xAI boundary fixture",
+    async login() {
+      throw new Error("not used");
+    },
+    async refreshToken(credentials: any) {
+      return credentials;
+    },
+    getApiKey(credentials: any) {
+      return credentials.access;
+    },
+  },
+  models: [{
+    id: TEST_MODEL.id,
+    name: TEST_MODEL.name,
+    api: "openai-responses",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1_000,
+    maxTokens: 100,
+  }],
+};
+
+async function realBoundaryRegistry(initialCredential: any) {
+  const codingAgent = PiCodingAgent as any;
+  if (codingAgent.ModelRuntime) {
+    let stored = initialCredential;
+    const credentialStore = {
+      async read(providerId: string) {
+        return providerId === "xai-auth" ? stored : undefined;
+      },
+      async list() {
+        return stored
+          ? [{ providerId: "xai-auth", type: stored.type }]
+          : [];
+      },
+      async modify(_providerId: string, update: (current: any) => Promise<any>) {
+        const next = await update(stored);
+        if (next !== undefined) stored = next;
+        return stored;
+      },
+      async delete() {
+        stored = undefined;
+      },
+    };
+    const runtime = await codingAgent.ModelRuntime.create({
+      credentials: credentialStore,
+      modelsPath: null,
+      allowModelNetwork: false,
+    });
+    const registry = new codingAgent.ModelRegistry(runtime);
+    registry.registerProvider("xai-auth", boundaryProviderConfig);
+    await runtime.refresh({ allowNetwork: false });
+    return {
+      registry,
+      setRuntimeApiKey: (key: string) => runtime.setRuntimeApiKey("xai-auth", key),
+    };
+  }
+
+  const authStorage = codingAgent.AuthStorage.inMemory({
+    "xai-auth": initialCredential,
+  });
+  const registry = codingAgent.ModelRegistry.inMemory(authStorage);
+  registry.registerProvider("xai-auth", boundaryProviderConfig);
+  return {
+    registry,
+    async setRuntimeApiKey(key: string) {
+      authStorage.setRuntimeApiKey("xai-auth", key);
+    },
+  };
+}
+
 beforeEach(async () => {
   temp = await createTempDir("pi-xai-auth-");
   vi.stubEnv("HOME", temp.path);
@@ -115,5 +196,143 @@ describe("credential resolution", () => {
       kind: "oauth-session",
       token: "header-token",
     });
+  });
+  it("accepts only a bearer that matches Pi's current stored OAuth credential", async () => {
+    let stored = {
+      type: "oauth",
+      access: "expired-access",
+      refresh: "refresh",
+      expires: 1,
+    };
+    const credential = await resolvePiManagedXaiOAuthCredential({
+      model: TEST_MODEL,
+      modelRegistry: {
+        authStorage: {
+          get: () => stored,
+        },
+        find: () => TEST_MODEL,
+        isUsingOAuth: () => true,
+        getApiKeyAndHeaders: async () => {
+          stored = { ...stored, access: "refreshed-access", expires: Date.now() + 60_000 };
+          return { ok: true, apiKey: "refreshed-access" };
+        },
+      },
+    });
+    expect(credential).toEqual({
+      kind: "oauth-session",
+      token: "refreshed-access",
+    });
+  });
+  it("rejects stored and runtime API-key provenance for the usage surface", async () => {
+    const getApiKeyAndHeaders = vi.fn(async () => ({
+      ok: true,
+      apiKey: "RUNTIME_API_KEY",
+    }));
+    const storedApiKey = await resolvePiManagedXaiOAuthCredential({
+      model: TEST_MODEL,
+      modelRegistry: {
+        authStorage: {
+          get: () => ({ type: "api_key", key: "STORED_API_KEY" }),
+        },
+        find: () => TEST_MODEL,
+        isUsingOAuth: () => false,
+        getApiKeyAndHeaders,
+      },
+    });
+    expect(storedApiKey).toBeNull();
+    expect(getApiKeyAndHeaders).not.toHaveBeenCalled();
+
+    const runtimeOverride = await resolvePiManagedXaiOAuthCredential({
+      model: TEST_MODEL,
+      modelRegistry: {
+        authStorage: {
+          get: () => ({
+            type: "oauth",
+            access: "stored-oauth-access",
+            refresh: "refresh",
+            expires: Date.now() + 60_000,
+          }),
+        },
+        find: () => TEST_MODEL,
+        isUsingOAuth: () => true,
+        getApiKeyAndHeaders,
+      },
+    });
+    expect(runtimeOverride).toBeNull();
+    expect(getApiKeyAndHeaders).toHaveBeenCalledTimes(1);
+  });
+  it.each([
+    ["runtime override", { configured: true, source: "runtime" }],
+    ["stored OAuth removal", { configured: false }],
+  ])("rejects a modern-registry %s introduced during resolution", async (_label, afterStatus) => {
+    let usingOAuth = true;
+    let status: any = { configured: true, source: "stored" };
+    const credential = await resolvePiManagedXaiOAuthCredential({
+      model: TEST_MODEL,
+      modelRegistry: {
+        find: () => TEST_MODEL,
+        isUsingOAuth: () => usingOAuth,
+        getProviderAuthStatus: () => status,
+        getApiKeyAndHeaders: async () => {
+          usingOAuth = false;
+          status = afterStatus;
+          return { ok: true, apiKey: "STALE_OR_OVERRIDDEN_TOKEN" };
+        },
+      },
+    });
+    expect(credential).toBeNull();
+  });
+  it("does not use a Grok auth file when Pi has no stored OAuth credential", async () => {
+    const path = join(temp.path, ".grok/auth.json");
+    await mkdir(join(path, ".."), { recursive: true });
+    await writeFile(
+      path,
+      JSON.stringify({
+        "https://auth.x.ai::b1a00492-073a-47ea-816f-4c329264a828": {
+          key: "grok-file-access",
+          refresh_token: "grok-file-refresh",
+          expires_at: Date.now() + 3600_000,
+        },
+      }),
+    );
+    await expect(resolvePiManagedXaiOAuthCredential({
+      model: TEST_MODEL,
+      modelRegistry: {
+        authStorage: { get: () => undefined },
+        find: () => TEST_MODEL,
+        isUsingOAuth: () => false,
+        getApiKeyAndHeaders: vi.fn(),
+      },
+    })).resolves.toBeNull();
+  });
+  it("uses the real exact-boundary registry facade and rejects its runtime override", async () => {
+    const boundary = await realBoundaryRegistry({
+      type: "oauth",
+      access: "boundary-oauth-access",
+      refresh: "boundary-refresh",
+      expires: Date.now() + 60_000,
+    });
+    const ctx = {
+      model: TEST_MODEL,
+      modelRegistry: boundary.registry,
+    };
+
+    await expect(resolvePiManagedXaiOAuthCredential(ctx)).resolves.toEqual({
+      kind: "oauth-session",
+      token: "boundary-oauth-access",
+    });
+
+    await boundary.setRuntimeApiKey("BOUNDARY_RUNTIME_API_KEY");
+    await expect(resolvePiManagedXaiOAuthCredential(ctx)).resolves.toBeNull();
+  });
+  it("rejects a stored API key through the real exact-boundary registry facade", async () => {
+    const boundary = await realBoundaryRegistry({
+      type: "api_key",
+      key: "BOUNDARY_STORED_API_KEY",
+    });
+    await expect(resolvePiManagedXaiOAuthCredential({
+      model: TEST_MODEL,
+      modelRegistry: boundary.registry,
+    })).resolves.toBeNull();
   });
 });

--- a/tests/provider/registration.test.ts
+++ b/tests/provider/registration.test.ts
@@ -16,6 +16,7 @@ beforeEach(async () => {
 });
 afterEach(async () => {
   setXaiRuntimeModels(CURATED_FALLBACK_MODELS);
+  vi.restoreAllMocks();
   await temp.cleanup();
 });
 
@@ -51,6 +52,9 @@ describe("provider registration", () => {
         "session_shutdown",
       ]),
     );
+    expect(
+      harness.handlers.get("turn_end")?.({}, { model: TEST_MODEL, ui: {} }),
+    ).toBeUndefined();
   });
   it("registers independently on a second Pi API object", async () => {
     const first = createExtensionHarness();
@@ -60,6 +64,90 @@ describe("provider registration", () => {
     expect(second.tools.size).toBe(first.tools.size);
     expect(second.commands.size).toBe(first.commands.size);
     expect(second.providers.has("xai-auth")).toBe(true);
+  });
+  it("wires usage status through turn, model, session-start, and shutdown events", async () => {
+    let now = 1_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const harness = createExtensionHarness();
+    await extension(harness.api);
+    const notifications: Array<{ message: string; type?: string }> = [];
+    const statuses: Array<{ key: string; text?: string }> = [];
+    let storedCredential: any = {
+      type: "oauth",
+      access: "oauth-access",
+      refresh: "refresh",
+      expires: Date.now() + 60_000,
+    };
+    const ui = {
+      notify(message: string, type?: string) {
+        notifications.push({ message, type });
+      },
+      setStatus(key: string, text: string | undefined) {
+        statuses.push({ key, text });
+      },
+    };
+    const ctx = {
+      model: TEST_MODEL,
+      signal: undefined,
+      ui,
+      modelRegistry: {
+        authStorage: {
+          get: () => storedCredential,
+        },
+        find: () => TEST_MODEL,
+        isUsingOAuth: () => storedCredential?.type === "oauth",
+        getApiKeyAndHeaders: async () => ({
+          ok: true,
+          apiKey: storedCredential?.access,
+        }),
+      },
+    };
+    let stallNext = false;
+    const fetchMock = vi.fn(async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      if (stallNext) {
+        stallNext = false;
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("cancelled", "AbortError")),
+            { once: true },
+          );
+        });
+      }
+      return String(input).endsWith("/user")
+        ? new Response(JSON.stringify({ userId: "user-registration-test" }))
+        : new Response(JSON.stringify({ config: { creditUsagePercent: 25 } }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const usageCommand = harness.commands.get("xai-usage").handler;
+
+    await usageCommand("status on", ctx);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(statuses.at(-1)?.text).toBe("xAI 25% used");
+
+    now += 60_000;
+    stallNext = true;
+    expect(harness.handlers.get("turn_end")?.({}, ctx)).toBeUndefined();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+
+    await harness.handlers.get("model_select")?.({ model: TEST_MODEL }, ctx);
+    expect(statuses.at(-1)).toEqual({ key: "xai-usage", text: undefined });
+    await usageCommand("status", ctx);
+    expect(notifications.at(-1)?.message).toMatch(/status is off/);
+
+    await usageCommand("status on", ctx);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    harness.handlers.get("session_shutdown")?.({}, ctx);
+    expect(statuses.at(-1)).toEqual({ key: "xai-usage", text: undefined });
+
+    await usageCommand("status on", ctx);
+    expect(fetchMock).toHaveBeenCalledTimes(7);
+    await harness.handlers.get("session_start")?.({}, { model: TEST_MODEL, ui });
+    await usageCommand("status", ctx);
+    expect(notifications.at(-1)?.message).toMatch(/status is off/);
   });
   it("wires model, session, and before-agent events to fail-closed tool synchronization", async () => {
     const harness = createExtensionHarness();

--- a/tests/provider/registration.test.ts
+++ b/tests/provider/registration.test.ts
@@ -40,12 +40,15 @@ describe("provider registration", () => {
     expect(harness.tools.size).toBe(20);
     expect(harness.tools.has("xai_edit_image")).toBe(true);
     expect(harness.commands.has("xai-tools")).toBe(true);
+    expect(harness.commands.has("xai-usage")).toBe(true);
     expect([...harness.handlers.keys()]).toEqual(
       expect.arrayContaining([
         "session_start",
         "input",
         "model_select",
         "before_agent_start",
+        "turn_end",
+        "session_shutdown",
       ]),
     );
   });

--- a/tests/responses/routing.test.ts
+++ b/tests/responses/routing.test.ts
@@ -199,6 +199,7 @@ describe("Responses routing and protected metadata", () => {
       "x-grok-agent-id": "spoofed-agent",
       "x-grok-turn-idx": "999",
       "x-grok-user-id": "spoofed-user",
+      "x-userid": "spoofed-billing-user",
       "x-grok-deployment-id": "spoofed-deployment",
       "x-grok-unknown-private-id": "spoofed-private",
       Accept: "application/x-spoofed",
@@ -224,6 +225,7 @@ describe("Responses routing and protected metadata", () => {
     expect(headerValue(request.init.headers, "X-Custom-Safe")).toBe(
       "preserved",
     );
+    expect(headerValue(request.init.headers, "x-userid")).toBeUndefined();
   });
 
   it.each(["xai-auth/grok-4.5", "XAI-AUTH/GROK-4.5"])(

--- a/tests/usage/parser.test.ts
+++ b/tests/usage/parser.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseXaiUsage,
+  parseXaiUserId,
+  renderXaiUsage,
+  renderXaiUsageStatus,
+} from "../../extensions/xai/usage";
+import newCredits from "../fixtures/usage/credits-new.json";
+import legacyCredits from "../fixtures/usage/credits-legacy.json";
+import identity from "../fixtures/usage/identity.json";
+
+describe("xAI usage parsing", () => {
+  it("extracts only a bounded header-safe identity", () => {
+    expect(parseXaiUserId(identity)).toBe("user-fixture-82");
+    for (const invalid of [
+      {},
+      { userId: "" },
+      { userId: "user\r\nx-userid: attacker" },
+      { userId: "x".repeat(257) },
+      { userId: 82 },
+    ]) {
+      expect(() => parseXaiUserId(invalid)).toThrow(/identity could not be verified/);
+    }
+  });
+
+  it("parses and renders the observed credits shape", () => {
+    const usage = parseXaiUsage(newCredits);
+    expect(usage).toMatchObject({
+      creditUsagePercent: 42.5,
+      currentPeriod: {
+        type: "USAGE_PERIOD_TYPE_WEEKLY",
+        end: "2026-07-20T00:00:00Z",
+      },
+      onDemandCapCents: 5000,
+      onDemandUsedCents: 300,
+      prepaidBalanceCents: 1250,
+      isUnifiedBillingUser: true,
+      onDemandEnabled: true,
+      subscriptionTier: "SuperGrok",
+    });
+    expect(usage.history).toHaveLength(1);
+    expect(renderXaiUsage(usage)).toContain("Included usage: 42.5%");
+    expect(renderXaiUsage(usage)).toContain("Reset: 2026-07-20T00:00:00Z");
+    expect(renderXaiUsageStatus(usage)).toBe("xAI 42.5% used · reset 2026-07-20");
+  });
+
+  it("supports only observed legacy fallbacks and proto zero-cent wrappers", () => {
+    const usage = parseXaiUsage(legacyCredits);
+    expect(usage).toMatchObject({
+      monthlyLimitCents: 2000,
+      usedCents: 500,
+      onDemandCapCents: 500,
+      onDemandUsedCents: 0,
+      currentPeriod: {
+        start: "2026-07-01T00:00:00Z",
+        end: "2026-08-01T00:00:00Z",
+      },
+    });
+    expect(usage.history[0]).toMatchObject({
+      billingCycle: { year: 2026, month: 6 },
+      includedUsedCents: 1800,
+      totalUsedCents: 1800,
+    });
+    expect(renderXaiUsage(usage)).toContain("Included usage: 25%");
+  });
+
+  it("handles null/missing config and ignores unsupported or out-of-range optional values", () => {
+    expect(parseXaiUsage({ config: null, subscriptionTier: "Pro" })).toEqual({
+      history: [],
+      subscriptionTier: "Pro",
+    });
+    expect(parseXaiUsage({})).toEqual({ history: [] });
+    expect(parseXaiUsage({
+      config: {
+        creditUsagePercent: 101,
+        monthlyLimit: { val: -1 },
+        used: { val: Number.MAX_SAFE_INTEGER },
+        currentPeriod: { end: "not-a-time" },
+        history: [{ billingCycle: { year: 1900, month: 13 } }],
+      },
+      subscriptionTier: "x".repeat(81),
+    })).toEqual({ history: [] });
+  });
+
+  it("rejects malformed, over-deep, and over-count response shapes", () => {
+    expect(() => parseXaiUsage([])).toThrow(/invalid response/);
+    expect(() => parseXaiUsage({ config: "bad" })).toThrow(/invalid response/);
+    expect(() => parseXaiUsage({ config: { history: {} } })).toThrow(/invalid billing history/);
+    expect(() => parseXaiUsage({
+      config: { history: Array.from({ length: 25 }, () => ({})) },
+    })).toThrow(/too many billing periods/);
+    expect(() => parseXaiUsage({ unrelated: Array.from({ length: 65 }, () => 1) }))
+      .toThrow(/too many response entries/);
+
+    let nested: Record<string, unknown> = {};
+    for (let index = 0; index < 14; index += 1) nested = { nested };
+    expect(() => parseXaiUsage(nested)).toThrow(/over-complex response/);
+  });
+});

--- a/tests/usage/parser.test.ts
+++ b/tests/usage/parser.test.ts
@@ -76,6 +76,8 @@ describe("xAI usage parsing", () => {
         monthlyLimit: { val: -1 },
         used: { val: Number.MAX_SAFE_INTEGER },
         currentPeriod: { end: "not-a-time" },
+        billingPeriodStart: "2026-02-30T00:00:00Z",
+        billingPeriodEnd: "2026-01-01T24:00:00Z",
         history: [{ billingCycle: { year: 1900, month: 13 } }],
       },
       subscriptionTier: "x".repeat(81),
@@ -91,9 +93,31 @@ describe("xAI usage parsing", () => {
     })).toThrow(/too many billing periods/);
     expect(() => parseXaiUsage({ unrelated: Array.from({ length: 65 }, () => 1) }))
       .toThrow(/too many response entries/);
+    expect(parseXaiUsage(Object.fromEntries(
+      Array.from({ length: 64 }, (_, index) => [`field${index}`, null]),
+    ))).toEqual({ history: [] });
+    expect(() => parseXaiUsage(Object.fromEntries(
+      Array.from({ length: 65 }, (_, index) => [`field${index}`, null]),
+    ))).toThrow(/too many response fields/);
 
     let nested: Record<string, unknown> = {};
     for (let index = 0; index < 14; index += 1) nested = { nested };
     expect(() => parseXaiUsage(nested)).toThrow(/over-complex response/);
+
+    const tree = (depth: number): unknown =>
+      depth === 0 ? null : { left: tree(depth - 1), right: tree(depth - 1) };
+    expect(() => parseXaiUsage(tree(11))).toThrow(/over-complex response/);
+  });
+
+  it("accepts real leap days but omits impossible calendar timestamps", () => {
+    expect(parseXaiUsage({
+      config: { billingPeriodStart: "2024-02-29T00:00:00Z" },
+    }).currentPeriod).toEqual({ start: "2024-02-29T00:00:00Z" });
+    expect(parseXaiUsage({
+      config: {
+        billingPeriodStart: "2026-02-30T00:00:00Z",
+        billingPeriodEnd: "2026-01-01T24:00:00Z",
+      },
+    }).currentPeriod).toBeUndefined();
   });
 });

--- a/tests/usage/status.test.ts
+++ b/tests/usage/status.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  registerXaiUsage,
+  type XaiUsageSnapshot,
+} from "../../extensions/xai/usage";
+import { commandContext, createExtensionHarness } from "../fixtures/extension-api";
+import { TEST_MODEL } from "../fixtures/models";
+
+const usage: XaiUsageSnapshot = {
+  creditUsagePercent: 25,
+  currentPeriod: { end: "2026-08-01T00:00:00Z" },
+  history: [],
+};
+
+function setup(model: any = TEST_MODEL) {
+  const harness = createExtensionHarness();
+  const notifications: Array<{ message: string; type?: string }> = [];
+  const statuses: Array<{ key: string; text?: string }> = [];
+  let now = 1_000;
+  const resolveCredential = vi.fn(async () => ({ kind: "oauth-session" as const, token: "SECRET" }));
+  const fetchUsage = vi.fn(async () => usage);
+  const feature = registerXaiUsage(harness.api, {
+    resolveCredential,
+    fetchUsage,
+    now: () => now,
+    minimumRefreshMs: 60_000,
+  });
+  const ctx = commandContext(model, notifications, {
+    signal: undefined,
+    modelRegistry: {},
+    ui: {
+      notify(message: string, type?: string) {
+        notifications.push({ message, type });
+      },
+      setStatus(key: string, text: string | undefined) {
+        statuses.push({ key, text });
+      },
+    },
+  });
+  const run = (args: string) => harness.commands.get("xai-usage").handler(args, ctx);
+  return {
+    ctx,
+    feature,
+    fetchUsage,
+    harness,
+    notifications,
+    resolveCredential,
+    run,
+    statuses,
+    setNow(value: number) { now = value; },
+  };
+}
+
+describe("/xai-usage command and status lifecycle", () => {
+  it("performs an explicit one-shot lookup without enabling status", async () => {
+    const { fetchUsage, harness, notifications, run, statuses } = setup();
+    expect(harness.commands.has("xai-usage")).toBe(true);
+    await run("");
+    expect(fetchUsage).toHaveBeenCalledTimes(1);
+    expect(notifications.at(-1)).toMatchObject({ type: "info" });
+    expect(notifications.at(-1)?.message).toContain("Included usage: 25%");
+    expect(statuses).toEqual([]);
+    await run("status");
+    expect(notifications.at(-1)?.message).toMatch(/status is off/);
+  });
+
+  it("keeps status off for non-xAI models and validates command arguments", async () => {
+    const { fetchUsage, notifications, run, statuses } = setup({ provider: "anthropic", id: "claude" });
+    await run("status on");
+    expect(fetchUsage).not.toHaveBeenCalled();
+    expect(notifications.at(-1)?.message).toMatch(/Select an xAI\/Grok model/);
+    expect(statuses.at(-1)).toEqual({ key: "xai-usage", text: undefined });
+    await run("enable");
+    expect(notifications.at(-1)?.message).toBe("Usage: /xai-usage [status [on|off]]");
+  });
+
+  it("never treats an unrelated active-model API key as an xAI OAuth bearer", async () => {
+    const harness = createExtensionHarness();
+    const notifications: Array<{ message: string; type?: string }> = [];
+    registerXaiUsage(harness.api);
+    const ctx = commandContext(
+      { provider: "anthropic", id: "claude" },
+      notifications,
+      {
+        apiKey: "UNRELATED_API_KEY",
+        modelRegistry: {
+          find: vi.fn(() => undefined),
+          getApiKeyAndHeaders: vi.fn(),
+        },
+      },
+    );
+
+    await harness.commands.get("xai-usage").handler("", ctx);
+
+    expect(ctx.modelRegistry.getApiKeyAndHeaders).not.toHaveBeenCalled();
+    expect(notifications.at(-1)).toEqual({
+      message: "xAI OAuth credentials are required. Run /login xai-auth first.",
+      type: "error",
+    });
+  });
+
+  it("refreshes only on bounded events and clears when disabled", async () => {
+    const state = setup();
+    await state.run("status on");
+    expect(state.fetchUsage).toHaveBeenCalledTimes(1);
+    expect(state.statuses.at(-1)?.text).toBe("xAI 25% used · reset 2026-08-01");
+
+    state.setNow(60_999);
+    await state.feature.refreshStatus(state.ctx as any);
+    expect(state.fetchUsage).toHaveBeenCalledTimes(1);
+    state.setNow(61_000);
+    await state.feature.refreshStatus(state.ctx as any);
+    expect(state.fetchUsage).toHaveBeenCalledTimes(2);
+
+    await state.run("status off");
+    expect(state.statuses.at(-1)).toEqual({ key: "xai-usage", text: undefined });
+    state.setNow(200_000);
+    await state.feature.refreshStatus(state.ctx as any);
+    expect(state.fetchUsage).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears and disables status on provider, model, account, or session resets", async () => {
+    const state = setup();
+    await state.run("status on");
+    state.feature.clearIfInactive({
+      ...state.ctx,
+      model: { provider: "anthropic", id: "claude" },
+    } as any);
+    expect(state.statuses.at(-1)).toEqual({ key: "xai-usage", text: undefined });
+    await state.run("status");
+    expect(state.notifications.at(-1)?.message).toMatch(/status is off/);
+
+    await state.run("status on");
+    state.feature.reset(state.ctx as any);
+    expect(state.statuses.at(-1)).toEqual({ key: "xai-usage", text: undefined });
+    await state.feature.refreshStatus(state.ctx as any);
+    expect(state.fetchUsage).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails closed and leaves status off after an initial refresh error", async () => {
+    const state = setup();
+    state.fetchUsage.mockRejectedValueOnce(new Error("SECRET_RAW_ERROR"));
+    await state.run("status on");
+    expect(state.notifications.at(-1)).toEqual({
+      message: "xAI usage request failed.",
+      type: "error",
+    });
+    expect(state.statuses.at(-1)).toEqual({ key: "xai-usage", text: undefined });
+    await state.run("status");
+    expect(state.notifications.at(-1)?.message).toMatch(/status is off/);
+  });
+});

--- a/tests/usage/status.test.ts
+++ b/tests/usage/status.test.ts
@@ -17,8 +17,14 @@ function setup(model: any = TEST_MODEL) {
   const notifications: Array<{ message: string; type?: string }> = [];
   const statuses: Array<{ key: string; text?: string }> = [];
   let now = 1_000;
+  let storedCredential: any = {
+    type: "oauth",
+    access: "SECRET",
+    refresh: "refresh",
+    expires: Date.now() + 60_000,
+  };
   const resolveCredential = vi.fn(async () => ({ kind: "oauth-session" as const, token: "SECRET" }));
-  const fetchUsage = vi.fn(async () => usage);
+  const fetchUsage = vi.fn(async (_credential: any, _signal?: AbortSignal) => usage);
   const feature = registerXaiUsage(harness.api, {
     resolveCredential,
     fetchUsage,
@@ -27,7 +33,13 @@ function setup(model: any = TEST_MODEL) {
   });
   const ctx = commandContext(model, notifications, {
     signal: undefined,
-    modelRegistry: {},
+    modelRegistry: {
+      authStorage: {
+        get: () => storedCredential,
+      },
+      find: () => TEST_MODEL,
+      isUsingOAuth: () => storedCredential?.type === "oauth",
+    },
     ui: {
       notify(message: string, type?: string) {
         notifications.push({ message, type });
@@ -48,6 +60,7 @@ function setup(model: any = TEST_MODEL) {
     run,
     statuses,
     setNow(value: number) { now = value; },
+    setStoredCredential(value: any) { storedCredential = value; },
   };
 }
 
@@ -135,6 +148,54 @@ describe("/xai-usage command and status lifecycle", () => {
     expect(state.statuses.at(-1)).toEqual({ key: "xai-usage", text: undefined });
     await state.feature.refreshStatus(state.ctx as any);
     expect(state.fetchUsage).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails closed on stored credential removal before the refresh throttle", async () => {
+    const state = setup();
+    await state.run("status on");
+    expect(state.fetchUsage).toHaveBeenCalledTimes(1);
+    state.setStoredCredential(undefined);
+    await state.feature.refreshStatus(state.ctx as any);
+    expect(state.fetchUsage).toHaveBeenCalledTimes(1);
+    expect(state.statuses.at(-1)).toEqual({ key: "xai-usage", text: undefined });
+    await state.run("status");
+    expect(state.notifications.at(-1)?.message).toMatch(/status is off/);
+  });
+
+  it("suppresses a stale one-shot completion after an account or session reset", async () => {
+    const state = setup();
+    state.fetchUsage.mockImplementationOnce(async (_credential: any, signal?: AbortSignal) =>
+      new Promise<XaiUsageSnapshot>((_resolve, reject) => {
+        signal?.addEventListener(
+          "abort",
+          () => reject(new DOMException("cancelled", "AbortError")),
+          { once: true },
+        );
+      }));
+    const pending = state.run("");
+    await vi.waitFor(() => expect(state.fetchUsage).toHaveBeenCalledTimes(1));
+    state.feature.reset(state.ctx as any);
+    await pending;
+    expect(state.notifications).toEqual([]);
+  });
+
+  it("aborts an in-flight status refresh without a late footer write", async () => {
+    const state = setup();
+    state.fetchUsage.mockImplementationOnce(async (_credential: any, signal?: AbortSignal) =>
+      new Promise<XaiUsageSnapshot>((_resolve, reject) => {
+        signal?.addEventListener(
+          "abort",
+          () => reject(new DOMException("cancelled", "AbortError")),
+          { once: true },
+        );
+      }));
+    const pending = state.run("status on");
+    await vi.waitFor(() => expect(state.fetchUsage).toHaveBeenCalledTimes(1));
+    state.feature.reset(state.ctx as any);
+    await pending;
+    expect(state.statuses.some(({ text }) => text?.includes("used"))).toBe(false);
+    await state.run("status");
+    expect(state.notifications.at(-1)?.message).toMatch(/status is off/);
   });
 
   it("fails closed and leaves status off after an initial refresh error", async () => {

--- a/tests/usage/transport.test.ts
+++ b/tests/usage/transport.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  fetchXaiUsage,
+  XaiUsageError,
+} from "../../extensions/xai/usage";
+import { XAI_CLI_BILLING_URL, XAI_CLI_USER_URL } from "../../extensions/xai/constants";
+import { headerValue, jsonResponse } from "../fixtures/http";
+import newCredits from "../fixtures/usage/credits-new.json";
+import identity from "../fixtures/usage/identity.json";
+
+const credential = { kind: "oauth-session" as const, token: "SECRET_BEARER_82" };
+
+async function capturedError(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await promise;
+  } catch (error) {
+    return error as Error;
+  }
+  throw new Error("expected request to fail");
+}
+
+describe("xAI usage transport", () => {
+  it("uses the pinned identity-first contract and required proxy metadata", async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      requests.push({ url, init });
+      return url === XAI_CLI_USER_URL ? jsonResponse(identity) : jsonResponse(newCredits);
+    }));
+
+    const usage = await fetchXaiUsage(credential);
+    expect(usage.creditUsagePercent).toBe(42.5);
+    expect(requests.map(({ url }) => url)).toEqual([XAI_CLI_USER_URL, XAI_CLI_BILLING_URL]);
+    for (const request of requests) {
+      expect(request.init).toMatchObject({ method: "GET", redirect: "error" });
+      expect(headerValue(request.init?.headers, "Authorization")).toBe("Bearer SECRET_BEARER_82");
+      expect(headerValue(request.init?.headers, "X-XAI-Token-Auth")).toBe("xai-grok-cli");
+      expect(headerValue(request.init?.headers, "x-grok-client-version")).toMatch(/^\d+\.\d+\.\d+/);
+      expect(headerValue(request.init?.headers, "x-grok-client-mode")).toMatch(/interactive|headless/);
+    }
+    expect(headerValue(requests[0]?.init?.headers, "x-userid")).toBeUndefined();
+    expect(headerValue(requests[1]?.init?.headers, "x-userid")).toBe("user-fixture-82");
+    expect(JSON.stringify(usage)).not.toMatch(/SECRET_BEARER_82|user-fixture-82/);
+  });
+
+  it.each([
+    ["missing identity", jsonResponse({})],
+    ["identity auth failure", jsonResponse({ error: "SECRET_BODY" }, 401)],
+    ["identity redirect", jsonResponse({}, 302, { Location: "https://attacker.invalid" })],
+    ["malformed identity", new Response("{not-json")],
+    ["oversized identity", new Response("x".repeat(64 * 1024 + 1))],
+  ])("fails closed before billing on %s", async (_label, response) => {
+    const fetchMock = vi.fn(async () => response);
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(fetchXaiUsage(credential)).rejects.toBeInstanceOf(XaiUsageError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds billing bodies and never reflects response or transport secrets", async () => {
+    const bodies = [
+      jsonResponse({ error: "RAW_BILLING_SECRET" }, 500),
+      new Response("x".repeat(64 * 1024 + 1)),
+    ];
+    for (const billingResponse of bodies) {
+      const fetchMock = vi.fn(async (input: string | URL | Request) =>
+        String(input) === XAI_CLI_USER_URL ? jsonResponse(identity) : billingResponse);
+      vi.stubGlobal("fetch", fetchMock);
+      const error = await capturedError(fetchXaiUsage(credential));
+      expect(error).toBeInstanceOf(XaiUsageError);
+      expect(error.message).not.toMatch(/RAW_BILLING_SECRET|SECRET_BEARER_82|user-fixture-82/);
+    }
+
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("transport leaked SECRET_BEARER_82");
+    }));
+    const transportError = await capturedError(fetchXaiUsage(credential));
+    expect(transportError.message).toBe("xAI usage request failed.");
+  });
+
+  it("propagates cancellation safely before billing", async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new DOMException("SECRET", "AbortError")), { once: true });
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+    const request = fetchXaiUsage(credential, controller.signal);
+    controller.abort();
+    const error = await request.catch((caught) => caught as XaiUsageError);
+    expect(error).toMatchObject({ code: "cancelled", message: "xAI usage request was cancelled." });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies the 15-second timeout without leaking fetch errors", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", vi.fn(async (_input: string | URL | Request, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new Error("SECRET_TIMEOUT")), { once: true });
+      })));
+    const request = fetchXaiUsage(credential).catch((error) => error as XaiUsageError);
+    await vi.advanceTimersByTimeAsync(15_000);
+    await expect(request).resolves.toMatchObject({
+      code: "timeout",
+      message: "xAI usage request timed out.",
+    });
+  });
+
+  it("rejects API-key provenance before any request", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(fetchXaiUsage({ kind: "api-key", token: "SECRET" })).rejects.toMatchObject({
+      code: "auth",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/usage/transport.test.ts
+++ b/tests/usage/transport.test.ts
@@ -48,6 +48,7 @@ describe("xAI usage transport", () => {
     ["identity auth failure", jsonResponse({ error: "SECRET_BODY" }, 401)],
     ["identity redirect", jsonResponse({}, 302, { Location: "https://attacker.invalid" })],
     ["malformed identity", new Response("{not-json")],
+    ["invalid UTF-8 identity", new Response(Uint8Array.from([0xc3, 0x28]))],
     ["oversized identity", new Response("x".repeat(64 * 1024 + 1))],
   ])("fails closed before billing on %s", async (_label, response) => {
     const fetchMock = vi.fn(async () => response);
@@ -77,18 +78,50 @@ describe("xAI usage transport", () => {
     expect(transportError.message).toBe("xAI usage request failed.");
   });
 
+  it("cancels unsuccessful response bodies before returning a redacted error", async () => {
+    const cancel = vi.fn();
+    const fetchMock = vi.fn(async () =>
+      new Response(new ReadableStream<Uint8Array>({ cancel }), { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(fetchXaiUsage(credential)).rejects.toMatchObject({
+      code: "http",
+      status: 500,
+      message: "xAI usage request failed with status 500.",
+    });
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalledTimes(1));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("propagates cancellation safely before billing", async () => {
     const controller = new AbortController();
-    const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) =>
-      new Promise<Response>((_resolve, reject) => {
-        init?.signal?.addEventListener("abort", () => reject(new DOMException("SECRET", "AbortError")), { once: true });
-      }));
+    const cancel = vi.fn();
+    const fetchMock = vi.fn(async () =>
+      new Response(new ReadableStream<Uint8Array>({ cancel })));
     vi.stubGlobal("fetch", fetchMock);
     const request = fetchXaiUsage(credential, controller.signal);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     controller.abort();
     const error = await request.catch((caught) => caught as XaiUsageError);
     expect(error).toMatchObject({ code: "cancelled", message: "xAI usage request was cancelled." });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not await a response stream whose cancellation never settles", async () => {
+    const controller = new AbortController();
+    const cancel = vi.fn(() => new Promise<void>(() => {}));
+    const fetchMock = vi.fn(async () =>
+      new Response(new ReadableStream<Uint8Array>({ cancel })));
+    vi.stubGlobal("fetch", fetchMock);
+    const request = fetchXaiUsage(credential, controller.signal)
+      .catch((caught) => caught as XaiUsageError);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    controller.abort();
+    await expect(request).resolves.toMatchObject({
+      code: "cancelled",
+      message: "xAI usage request was cancelled.",
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
   });
 
   it("applies the 15-second timeout without leaking fetch errors", async () => {
@@ -103,6 +136,20 @@ describe("xAI usage transport", () => {
       code: "timeout",
       message: "xAI usage request timed out.",
     });
+  });
+
+  it("applies the timeout after response headers when the body stalls", async () => {
+    vi.useFakeTimers();
+    const cancel = vi.fn();
+    vi.stubGlobal("fetch", vi.fn(async () =>
+      new Response(new ReadableStream<Uint8Array>({ cancel }))));
+    const request = fetchXaiUsage(credential).catch((error) => error as XaiUsageError);
+    await vi.advanceTimersByTimeAsync(15_000);
+    await expect(request).resolves.toMatchObject({
+      code: "timeout",
+      message: "xAI usage request timed out.",
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
   });
 
   it("rejects API-key provenance before any request", async () => {


### PR DESCRIPTION
## Summary

- add explicit `/xai-usage` with a pinned authenticated `/v1/user` lookup followed by `/v1/billing?format=credits`
- keep `x-userid` transient and billing-only; scrub caller-supplied identity headers from Responses requests
- require Pi-stored xAI OAuth provenance across the public Pi 0.80.1 and 0.80.10 registry surfaces, rejecting stored and runtime API keys
- keep the optional usage status off by default, session-only, rate-bounded, and detached from Pi's awaited turn lifecycle
- bound redirects, request and body stalls, cancellation, bytes, JSON complexity, history, timestamps, percentages, and monetary values
- abort and suppress stale one-shot/footer completion after model, account, or session changes

## Validation

- `npm test` — 37 files / 398 tests passed; real Pi loader passed
- `npm run typecheck` — passed
- `npm run test:coverage` — 86.03% statements, 79.27% branches, 86.09% functions, 89.88% lines
- `npm run compatibility:check` — policy, registry, 111-file packed manifest, and unsupported-peer checks passed
- `npm run compatibility:boundaries` — clean packed Pi 0.80.1 and 0.80.10 test/loader/typecheck matrices passed
- independent security and final test re-reviews — clean
- `git diff --check` — passed

## Scope notes

- rebased onto merged `main` at `af31e83`, preserving PRs #90, #91, #92, and #94
- billing remains an unofficial xAI contract pinned to `xai-org/grok-build@b189869b7755d2b482969acf6c92da3ecfeffd36`
- no live xAI request or interactive OAuth flow is part of the deterministic gate

Closes #82
