### PR TITLE
feat: add bounded xAI image editing

### DIFF
--- a/.scaffold/constraints.md
+++ b/.scaffold/constraints.md
@@ -1,31 +1,30 @@
-# Constraints & Safety Rules — Issue #80
+# Constraints & Safety Rules — Issue #83
 
-## Catalog and cache
+## Image-edit boundary
 
-- Preserve authenticated `/models-v2` as exact entitlement membership; capability enrichment must never union or remove IDs.
-- Parse only exact `acceptsImages` booleans and bounded `inputModalities` arrays from an entry or `_meta`.
-- Precedence is `entry.acceptsImages`, `_meta.acceptsImages`, `entry.inputModalities`, `_meta.inputModalities`, known metadata, then conservative unknown text.
-- Malformed higher-priority evidence falls through; it does not exclude the entitlement or become an authenticated denial.
-- Do not mark Composer text-only without authenticated or official evidence.
-- Schema-1 migration is in-memory and never labels legacy input as authenticated. Preserve membership, order, IDs, and normalized non-input metadata.
-- Store only normalized models, timestamps, and bounded provenance. Never cache raw catalog bodies, tokens, headers, endpoints, or identity fields.
-- Preserve atomic writes, TTL, stale-if-transient behavior, invalidation, permissions, cancellation, refresh ownership, and centralized catalog wire headers.
+- `xai_edit_image` remains disabled by default and session-scoped through `/xai-tools`.
+- Disabled calls fail before parameter/context reads, credential lookup, filesystem/codecs, fetch, or output writes.
+- Accept one to three byte-validated PNG/JPEG references from workspace-contained regular files or strict canonical data URLs.
+- Reject four references before credential, filesystem, codec, or network access.
+- Reject remote/file URLs, attachment or Files API identifiers, WebP, caller endpoints, and caller output paths.
+- Require a supported aspect ratio for multiple references; validate any supplied singular ratio but omit it from the wire.
+- Pin `/v1/images/edits`, fixed model/count/resolution/response format, redirect rejection, cancellation, timeout, and bounded bodies.
+- Verify exactly one canonical base64 PNG/JPEG output, including decoded byte/pixel/side limits, before atomic 0700/0600 session storage.
+- Never reflect prompts, source paths/data URLs/images, credentials, headers, raw bodies, or lower-layer codec messages.
 
-## Transport and OAuth
+## Inherited main invariants
 
-- Keep existing unentitled-model rejection and evaluate image capability from the current runtime entitlement snapshot at the final pre-network point.
-- Run the image guard after package rewriting, caller payload hooks, and image compaction; zero fetches may occur on rejection.
-- Error text may identify the model but must not echo payloads, image locations/data, credentials, headers, or raw upstream bodies.
-- Central direct-helper enforcement must cover `xai_generate_text(image_url)` and `xai_analyze_image`; do not apply image-input policy to image generation.
-- Preserve pinned routes, centralized truthful wire headers, reserved-header scrubbing, redirect rejection, and suppression of generic delegate affinity IDs.
-- Preserve browser PKCE/state/nonce/OIDC validation, bounded cancellable device polling, and state-bound callback requirements.
-- Preserve Pi peers at `>=0.80.1 <0.81.0`, exact 0.80.1/0.80.10 boundaries, and read-only startup credential compatibility.
-- Encrypted reasoning remains deferred to issue #79.
+- Preserve exact authenticated catalog membership, schema-2 modality provenance, cache migration, refresh locking, and privacy behavior.
+- Preserve inert final Responses payload canonicalization, canonical runtime model binding, computer-screenshot detection, zero SDK retries, and pre/post-compaction modality enforcement.
+- Preserve centralized route-aware wire headers, reserved-header scrubbing, redirect rejection, safe errors, and generic-affinity suppression.
+- Image editing is independent of the active Responses model's authenticated text/image modality.
+- Preserve OAuth PKCE/state/nonce/OIDC and bounded device authorization behavior.
+- Keep Pi peers at `>=0.80.1 <0.81.0` with exact packed 0.80.1/0.80.10 boundaries.
 
 ## Delivery
 
-- This worktree has one writer; delegated reviewers are read-only.
+- The issue-83 worktree has one writer; delegated agents are read-only.
+- Base the rebased branch on merged PR #90 at `b0556a8`; preserve safety branch `safety/issue-83-pre-pr90-rebase`.
 - Update scaffold state after major phases.
-- Run focused tests, strict full tests, typecheck, coverage, live package checks, and both exact packed compatibility boundaries before push.
-- Rebase without dropping merged issue #78 wire/security or issue #93 Pi compatibility behavior.
-- Force-push only after independent final review reports no blockers.
+- Run focused, strict full, typecheck, coverage, package, loader, and exact boundary validation before publishing.
+- Do not merge PR #91 or make live paid xAI calls.

--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -26,3 +26,7 @@
 
 - Rebase started from clean `e31303f` after verifying `origin/main=b0556a8` contains the exact reviewed PR #90 tree.
 - No live xAI request is part of deterministic validation.
+
+## Delivery
+
+The original implementation (`4a61389`) and delivery record (`e31303f`) were pushed to unmerged PR #91. The branch is now being rebased and revalidated before its next push: https://github.com/BlockedPath/pi-xai-oauth/pull/91

--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -1,28 +1,28 @@
-# Shared Agent Context — Issue #80
+# Shared Agent Context — Issue #83
 
-**Branch:** feature/issue-80-model-modalities
-**Issue:** https://github.com/BlockedPath/pi-xai-oauth/issues/80
-**Original baseline:** 579f965
-**Rebased baseline:** c0c89b0
-**Reviewed upstream:** `xai-org/grok-build@b189869b7755d2b482969acf6c92da3ecfeffd36`
+**Branch:** feature/issue-83-image-editing
+**Issue:** https://github.com/BlockedPath/pi-xai-oauth/issues/83
+**Original commits:** `4a61389`, `e31303f`
+**Post-PR-90 baseline:** `b0556a8`
+**Safety branch:** `safety/issue-83-pre-pr90-rebase`
 
-## Evidence
+## Evidence and decisions
 
-- A bounded redacted authenticated `/models-v2` observation on 2026-07-16 found no `acceptsImages` or `inputModalities` fields in either entry or `_meta`. Raw responses, credentials, headers, identity fields, endpoints, and account membership were not retained.
-- The pinned Grok Build source recognizes `acceptsImages` before `inputModalities`, defaults missing evidence image-capable in its own client, and does not establish Composer as text-only.
-- Current main includes issue #78's centralized route/header contract, redirect rejection, safe errors, and generic affinity suppression, plus issue #93's Pi 0.80.10 compatibility migration.
+- Pinned source: `xai-org/grok-build@b189869b7755d2b482969acf6c92da3ecfeffd36`.
+- Current first-party documentation limits edits to three source images, so the final package contract is one to three.
+- Use Pi's public worker-backed `resizeImage`; add no image dependency.
+- Keep the source-backed 400 KiB pass-through, 768 px compression maximum, 256 px floor, and quality steps inside stricter package-owned byte/pixel budgets.
+- Route both credential provenance tags to the pinned public edit endpoint without adding API-key environment fallback.
+- Persist one verified output under hashed Pi session storage and return only safe metadata.
 
-## Decisions
+## Integration focus
 
-- Keep distinct normalized provenance for authenticated `acceptsImages`, authenticated `inputModalities`, known metadata, and conservative unknown default.
-- Accept only exact `text` / `image` values in nonempty arrays of at most two unique entries, with canonical ordering.
-- Authenticated `acceptsImages` wins over authenticated `inputModalities`; entry wins over `_meta` for the same key; malformed values fall through.
-- Missing/malformed evidence uses known metadata when available, so Composer remains image-capable unless stronger evidence says otherwise. Unknown models remain conservative text without authenticated-denial provenance.
-- Read schema 1 safely in memory by rederiving input from known/default policy; the next normal atomic write emits schema 2.
-- Keep provenance internal to runtime/cache and omit it from Pi provider definitions.
-- Reject image input only for authenticated text-only provenance, using the current runtime snapshot after all rewrites/hooks/compaction and immediately before OAuth transport. Image generation is unchanged.
-- Keep Pi's generic delegate `sessionId` undefined to suppress its affinity headers while passing the stable session only to payload rewriting for `prompt_cache_key`.
+- PR #90 is merged exactly as reviewed. Preserve its catalog modality, payload canonicalization, retry, canonical-model, and privacy behavior.
+- Adopt shared direct-JSON header construction and route classification from `wire.ts`; edits remain direct public media requests, never proxy requests.
+- Keep disabled zero-I/O behavior and permit explicitly enabled edits under an authenticated text-only active Responses model.
+- Reapply decoded output side and pixel limits after codec verification and redact all codec/compression failures.
 
-## Validation focus
+## Validation state
 
-Guard against malformed/missing metadata becoming denial, schema-1 input gaining authenticated provenance, raw-field leakage, stale snapshot capture, pre-hook enforcement, image-generation conflation, weakened entitlement/cache races, wire-header regressions, redirect-guard leakage, or Pi-boundary drift.
+- Rebase started from clean `e31303f` after verifying `origin/main=b0556a8` contains the exact reviewed PR #90 tree.
+- No live xAI request is part of deterministic validation.

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -10,14 +10,14 @@ Finish PR #91 as a disabled-by-default, bounded `xai_edit_image` feature integra
 ## Phases
 
 1. [x] Verify PR #90 merged exactly as reviewed and create a safety branch for `e31303f`.
-2. [ ] Rebase the two PR #91 commits onto `b0556a8` and semantically synthesize conflicts.
-3. [ ] Change the reference contract to one to three and tighten cheap aspect-ratio validation.
-4. [ ] Integrate shared direct-JSON headers and route classification without weakening bounded edit response handling.
-5. [ ] Enforce decoded output side/pixel limits and redact codec/compression failures.
-6. [ ] Preserve disabled zero-I/O and text-only Responses-model independence with focused regressions.
-7. [ ] Synthesize cumulative docs/scaffold content and remove stale counts, versions, and one-to-four claims.
-8. [ ] Run focused, typecheck, strict full, coverage, package, loader, and exact Pi boundary validation.
-9. [ ] Complete range-diff/invariant review and independent final reviews.
+2. [x] Rebase the two PR #91 commits onto `b0556a8` and semantically synthesize conflicts.
+3. [x] Change the reference contract to one to three and tighten cheap aspect-ratio validation.
+4. [x] Integrate shared direct-JSON headers and route classification without weakening bounded edit response handling.
+5. [x] Enforce decoded output side/pixel limits and redact codec/compression failures.
+6. [x] Preserve disabled zero-I/O and text-only Responses-model independence with focused regressions.
+7. [x] Synthesize cumulative docs/scaffold content and remove stale counts, versions, and one-to-four claims.
+8. [x] Run focused, typecheck, strict full, coverage, package, loader, and exact Pi boundary validation.
+9. [x] Complete range-diff/invariant review and independent final reviews.
 10. [ ] Push the rebased branch with lease, refresh PR #91, and verify all checks without merging.
 
 ## Validation contract

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -18,7 +18,7 @@ Finish PR #91 as a disabled-by-default, bounded `xai_edit_image` feature integra
 7. [x] Synthesize cumulative docs/scaffold content and remove stale counts, versions, and one-to-four claims.
 8. [x] Run focused, typecheck, strict full, coverage, package, loader, and exact Pi boundary validation.
 9. [x] Complete range-diff/invariant review and independent final reviews.
-10. [ ] Push the rebased branch with lease, refresh PR #91, and verify all checks without merging.
+10. [x] Push the rebased branch with lease, refresh PR #91, and verify all checks without merging.
 
 ## Validation contract
 

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,40 +1,30 @@
-# Implementation Plan: Issue #80 authenticated model input modalities
+# Implementation Plan — Issue #83
 
-**Branch:** feature/issue-80-model-modalities
-**Original baseline:** 579f965
-**Rebased baseline:** c0c89b0
-**Issue:** https://github.com/BlockedPath/pi-xai-oauth/issues/80
+**Branch:** feature/issue-83-image-editing
+**Baseline:** `b0556a8`
 
 ## Goal
 
-Derive advertised model input modalities from bounded authenticated evidence when present, preserve conservative known/default behavior when evidence is absent or malformed, migrate the normalized cache without changing entitlement membership, and stop image-bearing OAuth Responses locally for an authenticated text-only entitlement.
+Finish PR #91 as a disabled-by-default, bounded `xai_edit_image` feature integrated with merged PR #90 transport, modality, and privacy guarantees.
 
 ## Phases
 
-1. [x] Read issue #80, pinned upstream evidence, provider/catalog/cache/payload/Responses/tool paths, tests, docs, and package policy.
-2. [x] Add strict `acceptsImages` / `inputModalities` resolution with explicit provenance and documented precedence.
-3. [x] Migrate schema-1 normalized caches in memory while preserving exact membership and emitting schema 2 only on the next normal atomic write.
-4. [x] Keep provenance in runtime entitlement snapshots but strip it from Pi provider definitions.
-5. [x] Add final current-snapshot image-input enforcement after payload hooks and before direct/stream OAuth network I/O.
-6. [x] Add redacted/synthetic fixtures and focused catalog, cache, provider, Responses, and custom-tool coverage.
-7. [x] Document observed schema absence, source revision, precedence, fallback, cache migration/privacy, and local rejection behavior.
-8. [x] Complete the rebase onto current main while retaining issue #78 wire/security and issue #93 Pi 0.80.10 behavior.
-9. [x] Run focused suites, strict full tests, typecheck, coverage, package checks, and exact packed Pi 0.80.1/0.80.10 boundaries.
-10. [x] Obtain clean independent re-reviews after accepted security/correctness fixes.
-11. [x] Commit and force-push, refresh PR #90, keep it ready, and receive fresh green policy plus exact Pi 0.80.1/0.80.10 checks.
-12. [x] Resolve final transport review findings by canonicalizing caller-controlled JSON once, recognizing computer screenshots, forcing zero delegated retries, using canonical error IDs, and avoiding variadic traversal.
-13. [x] Re-run focused/full/coverage/package/boundary validation, obtain independent review, and push the reviewed follow-up without merging.
+1. [x] Verify PR #90 merged exactly as reviewed and create a safety branch for `e31303f`.
+2. [ ] Rebase the two PR #91 commits onto `b0556a8` and semantically synthesize conflicts.
+3. [ ] Change the reference contract to one to three and tighten cheap aspect-ratio validation.
+4. [ ] Integrate shared direct-JSON headers and route classification without weakening bounded edit response handling.
+5. [ ] Enforce decoded output side/pixel limits and redact codec/compression failures.
+6. [ ] Preserve disabled zero-I/O and text-only Responses-model independence with focused regressions.
+7. [ ] Synthesize cumulative docs/scaffold content and remove stale counts, versions, and one-to-four claims.
+8. [ ] Run focused, typecheck, strict full, coverage, package, loader, and exact Pi boundary validation.
+9. [ ] Complete range-diff/invariant review and independent final reviews.
+10. [ ] Push the rebased branch with lease, refresh PR #91, and verify all checks without merging.
 
 ## Validation contract
 
-- Successful authenticated catalogs retain exact additions, removals, ordering, and empty membership.
-- Only exact bounded camelCase capability fields are accepted; malformed evidence falls through without excluding a model.
-- Authenticated evidence overrides known metadata; missing evidence does not make Composer text-only.
-- Schema-1 caches never acquire authenticated provenance and retain exact normalized entitlement membership.
-- No raw response, credential, identity, endpoint, header, image URL, or image data enters cache or rejection errors.
-- Authenticated text-only image input is rejected after all payload hooks and compaction, before any fetch, including custom text/image-analysis tools.
-- Direct and streaming security checks observe the same inert JSON representation that transport serializes; custom serializers and accessors cannot change it afterward.
-- Computer screenshots referenced by URL or file ID are image-bearing, and delegated xAI streams never reuse a once-validated payload through SDK retries.
-- Redirect rejection, reserved-header protection, stable prompt cache keys, and generic affinity suppression remain intact.
-- Image generation is unchanged; encrypted reasoning remains deferred to #79.
-- Pi peers remain `>=0.80.1 <0.81.0` with exact packed 0.80.1/0.80.10 proof.
+- Four references and invalid singular ratios fail before credentials, filesystem, codec, or network I/O.
+- Both credential provenance tags use the exact pinned direct edit URL and protected direct-media headers.
+- Exactly one bounded verified output is atomically persisted with private permissions.
+- No prompt, source reference, credential, raw body, or codec/server detail is reflected.
+- PR #90 catalog, payload, modality, routing, retry, and privacy behavior remains intact.
+- Pi peers and exact 0.80.1/0.80.10 boundaries remain unchanged.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -10,10 +10,24 @@
 - [x] Created `safety/issue-83-pre-pr90-rebase`.
 - [x] Started rebasing the original implementation/docs commits onto merged main.
 - [x] Preserved the original bounded media implementation, focused tests, and disabled-by-default tool lifecycle for semantic integration.
+- [x] Completed the rebase as `316884d` plus `f3e0fd8` on merged baseline `b0556a8`.
+- [x] Enforced one to three references and cheap validation of every supplied aspect ratio.
+- [x] Added shared protected direct-media headers and edit-route error classification without proxy metadata.
+- [x] Reapplied decoded output limits, redacted codec/compression failures, and hardened body/output cancellation.
+- [x] Added regressions for four-reference zero-I/O rejection, both credential provenance tags, stalled bodies, request-ID filtering, decoded dimensions, and text-only active models.
+- [x] Passed the primary and cumulative focused image-edit/media/provider/tool suites plus strict TypeScript.
+- [x] Passed the strict full suite, real loader smoke, and V8 coverage above every configured floor.
+- [x] Passed policy/registry, packed-manifest, unsupported-peer, and package dry-run checks.
+- [x] Passed clean packed test/loader/typecheck matrices with exact Pi 0.80.1 and 0.80.10.
+- [x] Applied security review feedback so disabled tools prove explicit opt-in before reading active-model context, with a throwing-getter regression.
+- [x] Replaced a false-positive cancellation test with deterministic cleanup checks after temporary write and final rename, and added POSIX FIFO rejection coverage.
+- [x] Completed the old-vs-rebased range diff and verified protected PR #90/OAuth/catalog/package-policy files were not replaced.
+- [x] Functional, security/privacy, and test/validation re-reviews returned CLEAN after their accepted fixes.
+- [x] Confirmed PR #91 has no review submissions or unresolved review threads; its only comments are review-bot usage-limit notices.
 
 ## In progress
 
-- [ ] Resolve cumulative docs/scaffold conflicts and audit every auto-merged runtime hunk.
+- [ ] Commit the final reviewed delta, push with lease, and verify fresh PR checks without merging.
 
 ## Delivery
 

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -27,7 +27,10 @@
 
 ## In progress
 
-- [ ] Commit the final reviewed delta, push with lease, and verify fresh PR checks without merging.
+- [x] Committed the final reviewed implementation as `b29c119` (`fix: finalize bounded image editing`).
+- [x] Replaced the known pre-rebase remote head with an exact force-with-lease and refreshed PR #91's description.
+- [x] Verified fresh GitHub policy, Socket, and exact Pi 0.80.1/0.80.10 checks are green.
+- [x] Kept PR #91 open and unmerged for maintainer approval.
 
 ## Delivery
 

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,53 +1,26 @@
-# Execution Progress — Issue #80
+# Execution Progress — Issue #83
 
-**Branch:** feature/issue-80-model-modalities
-**Original baseline:** 579f965
-**Rebased baseline:** c0c89b0
+**Branch:** feature/issue-83-image-editing
+**Baseline:** `b0556a8`
 
 ## Completed
 
-- [x] Audited issue #80, the pinned Grok Build revision, current runtime boundaries, fixtures, tests, and documentation.
-- [x] Performed one bounded authenticated schema observation without retaining secrets, raw bodies, endpoints, identity, or account membership.
-- [x] Added bounded capability precedence with authenticated/known/default provenance.
-- [x] Added schema-2 cache validation and safe in-memory schema-1 migration without changing exact entitlement membership.
-- [x] Kept provenance in cloned runtime snapshots while stripping it from provider model definitions.
-- [x] Added final current-snapshot image-input enforcement after package rewriting, caller hooks, and compaction for streaming/direct OAuth Responses and shared custom tools.
-- [x] Added redacted fixtures and focused normalization, cache, provider, payload, transport, and custom-tool regressions.
-- [x] Documented observed schema absence, pinned source revision, precedence, fallback, cache/privacy, and local rejection behavior.
-- [x] Original branch validation passed 270 tests, loader smoke, typecheck, coverage, package checks, and its then-current exact boundaries; independent review was clean.
-- [x] Merged PR #92 is present on current main at c0c89b0, including redirect rejection and generic delegate affinity suppression.
-- [x] Read-only conflict reviews identified the required combined catalog/Responses resolution.
+- [x] Confirmed PR #90 merged as `b0556a8` and contains exact reviewed head `fe0b95f`.
+- [x] Confirmed the issue-83 worktree and remote branch were clean at `e31303f`.
+- [x] Created `safety/issue-83-pre-pr90-rebase`.
+- [x] Started rebasing the original implementation/docs commits onto merged main.
+- [x] Preserved the original bounded media implementation, focused tests, and disabled-by-default tool lifecycle for semantic integration.
 
-- [x] Rebased issue #80 onto c0c89b0 and retained centralized catalog headers, redirect rejection, generic affinity suppression, and Pi 0.80.10 credential compatibility.
-- [x] Fixed the merged stream seam so bounded text-only errors remain actionable while upstream errors stay sanitized and fetch guards restore before terminal results.
-- [x] Review fixes now reject impossible cached provenance/input pairs, preserve exact schema-1 files on post-rename cancellation, and remove image locations/data from all image-analysis error details.
-- [x] Final focused transport/cache/tool validation passed: 5 files / 70 tests.
-- [x] Strict full tests passed: 29 files / 282 tests plus loader smoke and typecheck.
-- [x] Coverage passed at 84.73% statements, 76.70% branches, 87.26% functions, and 88.28% lines.
-- [x] Live policy/registry/90-file pack/unsupported-peer checks passed.
-- [x] Exact clean packed Pi 0.80.1 and 0.80.10 matrices passed 282 tests, loader smoke, and typecheck under npm 11.6.2.
-- [x] Two independent final re-reviews returned CLEAN with no merge blockers.
+## In progress
 
-- [x] Committed and force-pushed the rebased branch and refreshed PR #90 with current scope and validation.
-- [x] Fresh GitHub policy and exact Pi 0.80.1/0.80.10 compatibility checks passed.
-- [x] Confirmed the final review's five findings against the exact clean PR head at `09a60f4`.
-- [x] Added inert JSON canonicalization before direct/stream model and modality enforcement, including stable redacted serialization failures.
-- [x] Added computer-screenshot detection, canonical model IDs in text-only errors, iterative wide-payload traversal, and forced zero SDK retries.
-- [x] Added direct/stream serializer-bypass, screenshot URL/file ID, retry, redaction, canonical-ID, entitlement-race, and wide-payload regressions.
-- [x] Applied independent review feedback so runtime catalog IDs now drive OAuth rewrite, body, headers, checks, and errors, with modality checks both before compaction and immediately before transport.
-- [x] Final focused validation passed 73 tests plus typecheck; strict full validation passed 299 tests and loader smoke.
-- [x] Coverage passed at 84.88% statements, 77.02% branches, 87.03% functions, and 88.40% lines.
-- [x] Live policy/registry, 90-file pack, unsupported-peer checks, and clean packed Pi 0.80.1/0.80.10 test/loader/typecheck matrices passed.
-- [x] Two independent final read-only re-reviews returned CLEAN after canonical model binding and pre/post-compaction enforcement were added.
+- [ ] Resolve cumulative docs/scaffold conflicts and audit every auto-merged runtime hunk.
 
-## Delivery
+## Next
 
-- [x] Committed the reviewed transport hardening as `b935cbe` (`fix: harden Responses payload enforcement`).
-- [x] Pushed the existing feature branch without force and posted the finding-by-finding resolution evidence on PR #90.
-- [x] Fresh GitHub policy, Socket, and exact Pi 0.80.1/0.80.10 compatibility checks passed.
-- [x] Kept PR #90 open and unmerged for maintainer approval.
+- Apply the one-to-three, shared-header, decoded-output-limit, redaction, and modality-independence changes from the final handoff.
+- Run the complete post-rebase validation and independent review contract.
 
 ## Residual
 
-- No live xAI request or interactive OAuth flow is part of the deterministic compatibility gate.
-- Encrypted reasoning remains deferred to issue #79.
+- No live xAI request or interactive OAuth flow is part of this offline gate.
+- Parent-directory replacement remains a documented trusted-parent filesystem assumption.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -15,10 +15,12 @@
 
 - [ ] Resolve cumulative docs/scaffold conflicts and audit every auto-merged runtime hunk.
 
-## Next
+## Delivery
 
 - Apply the one-to-three, shared-header, decoded-output-limit, redaction, and modality-independence changes from the final handoff.
 - Run the complete post-rebase validation and independent review contract.
+- Original implementation commit `4a61389` and delivery record `e31303f` were pushed to unmerged PR #91 before this rebase.
+- PR #91 remains open and must not be merged until the rebased branch passes the full gate: https://github.com/BlockedPath/pi-xai-oauth/pull/91
 
 ## Residual
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Core flow: `bin/setup.js` → `pi install` → bounded catalog selection in `ext
 - Verify Pi policy/package metadata: `npm run compatibility:check`
 - Verify exact packed Pi boundaries: `npm run compatibility:boundaries`
 - Evaluate an unadvertised Pi candidate: `node scripts/run-compatibility-matrix.js X.Y.Z --candidate`
-- Git: Always work on feature branches. Current branch for this work: `feature/issue-78-grok-protocol`
+- Git: Always work on feature branches. Current branch for this work: `feature/issue-83-image-editing`
 
 ## Architecture & Boundaries (MUST / MUST NOT)
 **MUST:**
@@ -69,6 +69,8 @@ pi-xai-oauth/
 │       ├── responses.ts  # xAI request/stream helpers
 │       ├── routing.ts    # Credential-aware Responses/Images endpoint routing
 │       ├── wire.ts       # Route-aware headers, scrubbing, identity, safe errors
+│       ├── image-edit.ts # Bounded pinned image-edit orchestration
+│       ├── media/        # Reusable strict media/path/compression/storage primitives
 │       └── tools/        # Custom xAI tools + Cursor/Grok CLI shims
 ├── compatibility/
 │   ├── pi-versions.json # Peer range plus exact minimum/latest matrix policy
@@ -147,6 +149,6 @@ This file should be updated whenever architecture, commands, or rules change.
 This repo is a **pi extension package (a library/CLI), not a standalone server**. There is nothing to "boot" — dependency install happens automatically via the startup update script (`npm ci`). Node engine note: the pi peer deps request Node `>=22.19.0` and the pod ships `22.14.0`, so `npm ci` prints `EBADENGINE` warnings; these are non-blocking — typecheck, tests, and extension load all pass.
 
 - Build / typecheck gate: `npm run typecheck` (`tsc --noEmit`). There is **no separate lint tool** configured; typecheck is the static gate.
-- Tests: `npm test` runs compatibility policy, 282 focused Vitest regressions, and the small real Pi loader smoke. Use `npm run test:coverage` for V8 output and `npm run test:unit -- <path> -t <name>` for focus.
+- Tests: `npm test` runs compatibility policy, focused Vitest regressions, and the small real Pi loader smoke. Use `npm run test:coverage` for V8 output and `npm run test:unit -- <path> -t <name>` for focus.
 - Running the "app": full end-to-end use (`pi`, `/login xai-auth`, live Grok streaming) needs the external `pi` CLI, an interactive browser OAuth flow, and a real xAI/Grok account, so it is **not runnable headless** here. Offline behavior lives in focused `tests/` suites with isolated fixtures; `npm run test:loader` exercises the real Pi loader without live xAI access. Catalog fixtures live under `tests/fixtures/models-v2/`.
 - Any temporary demo script that imports deps must live inside the repo root (so it resolves `node_modules`), not `/tmp`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 - Added deterministic streaming/direct Responses, catalog, OAuth form, client-mode, media-boundary, reserved-header, bounded-error, and proxy version-gate request-shape coverage.
 - Added bounded authenticated `acceptsImages` / `inputModalities` normalization with explicit input-capability provenance and redacted schema fixtures.
 - Added 246 focused typed Vitest regressions across provider/catalog routing, browser/device OAuth and OIDC, Responses payloads/streams/errors, images, network-tool lifecycle, custom tools, Cursor shims, and setup/settings.
+- Added the disabled-by-default `xai_edit_image` tool with exact singular/plural Imagine edit payloads, a distinct pinned `/images/edits` route, timeout/cancellation, and redacted errors.
+- Added reusable bounded media primitives for byte-validated PNG/JPEG data URLs and workspace files, source-backed compression, explicit request/response/output budgets, and atomic 0700/0600 Pi-session storage.
 - Added a small real Pi extension-loader smoke plus V8 text/JSON/LCOV coverage with measured regression floors.
 - Added a browser-first native login-method selector with device authorization for SSH, WSL, containers, remote workspaces/VMs, and human-operated headless sessions.
 - Added pinned, bounded, cancellable RFC 8628 polling with initial wait, server interval plus cumulative `slow_down`, denial/expiry handling, strict secret-safe schema validation, and deterministic timing tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 - Added a revision-pinned Grok Build wire-protocol matrix, ID-ownership policy, repeatable upstream review procedure, and an explicit encrypted-reasoning handoff to issue #79.
 - Added deterministic streaming/direct Responses, catalog, OAuth form, client-mode, media-boundary, reserved-header, bounded-error, and proxy version-gate request-shape coverage.
 - Added bounded authenticated `acceptsImages` / `inputModalities` normalization with explicit input-capability provenance and redacted schema fixtures.
-- Added 246 focused typed Vitest regressions across provider/catalog routing, browser/device OAuth and OIDC, Responses payloads/streams/errors, images, network-tool lifecycle, custom tools, Cursor shims, and setup/settings.
+- Added focused typed Vitest regressions across provider/catalog routing, browser/device OAuth and OIDC, Responses payloads/streams/errors, images, network-tool lifecycle, custom tools, Cursor shims, and setup/settings.
 - Added the disabled-by-default `xai_edit_image` tool with exact singular/plural Imagine edit payloads, a distinct pinned `/images/edits` route, timeout/cancellation, and redacted errors.
 - Added reusable bounded media primitives for byte-validated PNG/JPEG data URLs and workspace files, source-backed compression, explicit request/response/output budgets, and atomic 0700/0600 Pi-session storage.
 - Added a small real Pi extension-loader smoke plus V8 text/JSON/LCOV coverage with measured regression floors.

--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ This opt-in boundary applies only to the extra tools below. Normal conversation 
 | `xai_deep_research` | Research | High/variable model and web/X tool usage |
 | `xai_code_execution` | Execution | Model tokens plus code-interpreter usage |
 | `xai_generate_image` | Image generation | Charged per generated image; supports 1-4 images |
+| `xai_edit_image` | Image editing | Imagine usage for one output conditioned on 1-4 local references |
 | `xai_analyze_image` | Vision | Separate model-token and image-input usage |
 | `xai_critique` | Reasoning | Separate high-reasoning model-token usage |
 | `WebSearch` | Search | Grok Build/Composer model tokens plus native tool usage |
@@ -393,6 +394,7 @@ The picker shows each tool's category and cost-risk context, warns that calls ma
 /xai-tools enable xai_web_search
 /xai-tools disable xai_web_search
 /xai-tools enable xai_generate_image
+/xai-tools enable xai_edit_image
 ```
 
 `WebSearch` appears in the picker only for Grok Build and Composer models. `/xai-tools` is owned by this package; it does not depend on pi's optional example `/tools` extension.
@@ -468,6 +470,25 @@ Opt-in analysis of an image URL, data URL, or local `.png` / `.jpg` path with Gr
 }
 ```
 
+### `xai_edit_image`
+
+Opt-in paid image editing through xAI Imagine. Enable it through `/xai-tools` first, then explicitly request the edit. One reference preserves its input aspect ratio; multiple references require a supported `aspect_ratio`.
+
+```json
+{
+  "prompt": "Keep the subject, replace the background with a clean studio gradient",
+  "image": [{ "path": "assets/reference.png" }]
+}
+```
+
+References are limited to 1-4 byte-validated PNG/JPEG files inside the current workspace or strict bounded `data:image/png;base64,...` / `data:image/jpeg;base64,...` values. Paths are resolved through realpath, so `..` escapes and symlinks leaving the workspace are rejected. HTTPS URLs, `file://` URLs, current-turn attachment tokens, arbitrary outside paths, SVG, WebP, GIF, and HEIC are intentionally unsupported.
+
+Reference handling uses the pinned Grok Build policy as its starting point: sources are capped at 8 MiB and 12 million decoded pixels; compatible references up to 400 KiB pass through after decode verification; larger references are re-encoded under 400 KiB with a 768 px maximum side, a 256 px compression floor, and reviewed quality steps. The package separately limits aggregate reference bytes to 1,200 KiB and caps reference count, request JSON, response JSON, output base64, decoded output bytes, output pixels, and output dimensions.
+
+Exactly one verified PNG/JPEG output is saved atomically with a collision-resistant name under Pi's session directory at `pi-xai-oauth/<session-hash>/image-edits/`. Directories use mode `0700`, files use `0600`, and the tool returns path/dimension/size metadata instead of raw base64. Prompts, source paths, data URLs, image bytes, credentials, headers, and raw authenticated error bodies are never included in image-edit errors.
+
+Image editing can consume xAI Imagine allowances, credits, or rate limits. Exact pricing and quota behavior are controlled by xAI; see [xAI pricing](https://docs.x.ai/developers/pricing) before enabling the tool.
+
 ### `xai_critique`
 Opt-in structured critique for code, designs, writing, or ideas. Enable it through `/xai-tools` first.
 
@@ -488,7 +509,7 @@ Opt-in research using the active xAI model plus native web and X search tools. E
 }
 ```
 
-> **Note:** Every tool in this section makes a separate xAI request and can consume subscription allowances, credits, or rate limits. Responses-based helpers use the OAuth session proxy. Image generation is the intentional exception: matching official Grok Build behavior, it sends the OAuth bearer directly to `https://api.x.ai/v1/images/generations` and is charged per generated image. See [xAI pricing](https://docs.x.ai/developers/pricing) for current rates.
+> **Note:** Every tool in this section makes a separate xAI request and can consume subscription allowances, credits, or rate limits. Responses-based helpers use the OAuth session proxy. Image generation and image editing are intentional exceptions: matching official Grok Build behavior, they send the OAuth bearer directly to the pinned public Images routes at `https://api.x.ai/v1/images/generations` and `https://api.x.ai/v1/images/edits`. See [xAI pricing](https://docs.x.ai/developers/pricing) for current rates.
 
 ---
 
@@ -786,6 +807,8 @@ pi-xai-oauth/
 │       ├── responses.ts      # xAI request + streaming helpers
 │       ├── routing.ts        # Credential-aware Responses and Images endpoints
 │       ├── wire.ts           # Route-aware headers, scrubbing, identity, safe errors
+│       ├── image-edit.ts     # Bounded edit request/response orchestration
+│       ├── media/            # Reusable strict media parsing, compression, paths, and storage
 │       └── tools/            # Custom xAI tools + Cursor/Grok CLI shims
 ├── bin/
 │   └── setup.js              # One-command setup (npx pi-xai-oauth)
@@ -799,6 +822,7 @@ pi-xai-oauth/
 │   ├── provider/              # Registration, routing, credentials, lifecycle, and races
 │   ├── responses/             # Payload, stream, error, routing, and image transport
 │   ├── images/                # Codec budgets and Images tool behavior
+│   ├── media/                 # Strict media/path/compression/storage primitives
 │   ├── tools/                 # Network lifecycle, command, custom, and Cursor shims
 │   └── setup/                 # Installer/settings behavior
 ├── scripts/

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ This opt-in boundary applies only to the extra tools below. Normal conversation 
 | `xai_deep_research` | Research | High/variable model and web/X tool usage |
 | `xai_code_execution` | Execution | Model tokens plus code-interpreter usage |
 | `xai_generate_image` | Image generation | Charged per generated image; supports 1-4 images |
-| `xai_edit_image` | Image editing | Imagine usage for one output conditioned on 1-4 local references |
+| `xai_edit_image` | Image editing | Imagine usage for one output conditioned on 1-3 local references |
 | `xai_analyze_image` | Vision | Separate model-token and image-input usage |
 | `xai_critique` | Reasoning | Separate high-reasoning model-token usage |
 | `WebSearch` | Search | Grok Build/Composer model tokens plus native tool usage |
@@ -472,7 +472,7 @@ Opt-in analysis of an image URL, data URL, or local `.png` / `.jpg` path with Gr
 
 ### `xai_edit_image`
 
-Opt-in paid image editing through xAI Imagine. Enable it through `/xai-tools` first, then explicitly request the edit. One reference preserves its input aspect ratio; multiple references require a supported `aspect_ratio`.
+Opt-in paid image editing through xAI Imagine. Enable it through `/xai-tools` first, then explicitly request the edit. Supply one to three references. One reference preserves its input aspect ratio; a supported `aspect_ratio` may be supplied but is omitted from the wire. Multiple references require a supported `aspect_ratio`.
 
 ```json
 {
@@ -481,7 +481,7 @@ Opt-in paid image editing through xAI Imagine. Enable it through `/xai-tools` fi
 }
 ```
 
-References are limited to 1-4 byte-validated PNG/JPEG files inside the current workspace or strict bounded `data:image/png;base64,...` / `data:image/jpeg;base64,...` values. Paths are resolved through realpath, so `..` escapes and symlinks leaving the workspace are rejected. HTTPS URLs, `file://` URLs, current-turn attachment tokens, arbitrary outside paths, SVG, WebP, GIF, and HEIC are intentionally unsupported.
+References are limited to 1-3 byte-validated PNG/JPEG files inside the current workspace or strict bounded `data:image/png;base64,...` / `data:image/jpeg;base64,...` values. Paths are resolved through realpath, so `..` escapes and symlinks leaving the workspace are rejected. HTTPS URLs, `file://` URLs, current-turn attachment tokens, arbitrary outside paths, SVG, WebP, GIF, and HEIC are intentionally unsupported.
 
 Reference handling uses the pinned Grok Build policy as its starting point: sources are capped at 8 MiB and 12 million decoded pixels; compatible references up to 400 KiB pass through after decode verification; larger references are re-encoded under 400 KiB with a 768 px maximum side, a 256 px compression floor, and reviewed quality steps. The package separately limits aggregate reference bytes to 1,200 KiB and caps reference count, request JSON, response JSON, output base64, decoded output bytes, output pixels, and output dimensions.
 

--- a/bin/setup.js
+++ b/bin/setup.js
@@ -224,6 +224,7 @@ function printNextSteps(nonInteractive = false) {
   console.log("   • xai_x_search          — Native X/Twitter search");
   console.log("   • xai_code_execution    — Native code interpreter");
   console.log("   • xai_generate_image    — Image generation");
+  console.log("   • xai_edit_image        — Bounded local PNG/JPEG image editing");
   console.log("   • xai_analyze_image     — Image analysis");
   console.log("   • xai_critique          — Structured critique");
   console.log("   • xai_deep_research     — Deep research with web/X tools\n");

--- a/docs/testing/assertion-parity.md
+++ b/docs/testing/assertion-parity.md
@@ -192,7 +192,6 @@ not in another monolith.
 
 **Completed evidence:** all legacy and replacement behavior tests passed together
 under strict unhandled-rejection handling before the four legacy files were
-removed. At issue #68 completion, the replacement suite had 246 named tests
-across 29 files and three independent parity review rounds ended with a CLEAN
-focused re-review. Issue #83 extends that suite to 291 tests across 34 files;
-the real loader smoke remains intentionally small at 41 lines.
+removed. Three independent parity review rounds ended with a CLEAN focused
+re-review. Issue #83 extends that suite with bounded image-edit coverage; the
+real loader smoke remains intentionally small.

--- a/docs/testing/assertion-parity.md
+++ b/docs/testing/assertion-parity.md
@@ -104,6 +104,16 @@ replacement tests pass alongside the legacy verifier.
 | `verify-extension.js:1058-1124` | direct/stream/hook compaction | `tests/responses/images.test.ts` | [x] |
 | `verify-extension.js:2543-2598` | analysis part ordering; direct Images route; default model; omitted unsupported defaults; schema min/max; explicit count; unsupported size and invalid count fail before network | `tests/images/tools.test.ts` | [x] |
 
+### Issue #83 bounded image-edit additions
+
+| New behavior | Destination | Status |
+|---|---|---|
+| strict PNG/JPEG headers, canonical data URLs, byte/pixel/side limits | `tests/media/primitives.test.ts` | [x] |
+| workspace realpath containment, traversal/symlink/special-file rejection, cancellation | `tests/media/paths.test.ts` | [x] |
+| source-backed compression policy, real worker codec, aggregate/count bounds, atomic 0700/0600 storage | `tests/media/compression-storage.test.ts` | [x] |
+| pinned edit route, exact singular/plural payloads, timeout/cancellation, redaction, response/output validation, successful save | `tests/images/image-edit.test.ts` | [x] |
+| disabled zero-I/O guard, explicit intent, opt-in lifecycle, registration and loader smoke | `tests/tools/custom-tools.test.ts`, `tests/tools/commands.test.ts`, `tests/provider/registration.test.ts`, `scripts/verify-extension-loader.mjs` | [x] |
+
 ### Network-tool lifecycle and `/xai-tools`
 
 | Legacy source | Behavior preserved | Destination | Status |
@@ -182,6 +192,7 @@ not in another monolith.
 
 **Completed evidence:** all legacy and replacement behavior tests passed together
 under strict unhandled-rejection handling before the four legacy files were
-removed. The final replacement suite has 246 named tests across 29 files, the
-loader smoke is 40 lines, every live destination path above exists, and three
-independent parity review rounds ended with a CLEAN focused re-review.
+removed. At issue #68 completion, the replacement suite had 246 named tests
+across 29 files and three independent parity review rounds ended with a CLEAN
+focused re-review. Issue #83 extends that suite to 291 tests across 34 files;
+the real loader smoke remains intentionally small at 41 lines.

--- a/docs/testing/coverage-baseline.md
+++ b/docs/testing/coverage-baseline.md
@@ -26,6 +26,25 @@ adapters) that are not safe to force merely for percentage. Security-critical
 state, endpoint pinning, cancellation, redaction, entitlement, routing/header,
 cache invalidation, and fail-closed tool branches are covered directly.
 
+## Issue #83 measurement
+
+After adding bounded image-edit parsing, workspace containment, compression,
+transport, and atomic session storage, the focused suite contains 291 tests in
+34 files. The new security-heavy production surface increases the measured
+statement denominator while remaining above every established floor:
+
+| Metric | Measured | Configured floor |
+|---|---:|---:|
+| Statements | 82.91% (2204/2658) | 82% |
+| Branches | 75.53% (1701/2252) | 74% |
+| Functions | 84.31% (328/389) | 84% |
+| Lines | 87.10% (2013/2311) | 85% |
+
+The image-edit tests directly cover endpoint pinning, disabled zero-I/O,
+workspace and symlink escapes, strict media validation, per-item and aggregate
+budgets, real PNG/JPEG codec paths, cancellation/timeouts, response redaction,
+verified output limits, permissions, and successful persistence.
+
 Coverage includes `extensions/**/*.ts` and excludes only the constants module.
 Tests, fixtures, generated coverage output, compatibility scripts, and setup CLI
 code are outside the extension-runtime threshold. Terminal text, JSON summary,

--- a/docs/testing/coverage-baseline.md
+++ b/docs/testing/coverage-baseline.md
@@ -29,16 +29,18 @@ cache invalidation, and fail-closed tool branches are covered directly.
 ## Issue #83 measurement
 
 After adding bounded image-edit parsing, workspace containment, compression,
-transport, and atomic session storage, the focused suite contains 291 tests in
-34 files. The new security-heavy production surface increases the measured
-statement denominator while remaining above every established floor:
+transport, and atomic session storage, the security-heavy production surface
+increases the measured denominator while remaining above every configured
+floor:
 
 | Metric | Measured | Configured floor |
 |---|---:|---:|
-| Statements | 82.91% (2204/2658) | 82% |
-| Branches | 75.53% (1701/2252) | 74% |
-| Functions | 84.31% (328/389) | 84% |
-| Lines | 87.10% (2013/2311) | 85% |
+| Statements | 84.68% (2467/2913) | 82% |
+| Branches | 77.71% (1932/2486) | 74% |
+| Functions | 85.48% (371/434) | 84% |
+| Lines | 88.72% (2243/2528) | 85% |
+
+`npm run test:coverage` remains the source of truth for future changes.
 
 The image-edit tests directly cover endpoint pinning, disabled zero-I/O,
 workspace and symlink escapes, strict media validation, per-item and aggregate

--- a/extensions/xai/constants.ts
+++ b/extensions/xai/constants.ts
@@ -30,6 +30,7 @@ export const XAI_RESPONSES_URL = "https://api.x.ai/v1/responses";
 export const XAI_CLI_RESPONSES_URL = "https://cli-chat-proxy.grok.com/v1/responses";
 export const XAI_CLI_MODELS_URL = "https://cli-chat-proxy.grok.com/v1/models-v2";
 export const XAI_IMAGES_GENERATIONS_URL = "https://api.x.ai/v1/images/generations";
+export const XAI_IMAGES_EDITS_URL = "https://api.x.ai/v1/images/edits";
 
 export const XAI_MODEL_CATALOG_CACHE_SCHEMA = 2;
 export const XAI_MODEL_CATALOG_FRESH_TTL_MS = 15 * 60 * 1000;

--- a/extensions/xai/image-edit.ts
+++ b/extensions/xai/image-edit.ts
@@ -1,0 +1,378 @@
+import type { XaiCredential } from "./routing";
+import { resolveXaiRoute } from "./routing";
+import {
+  IMAGE_EDIT_MAX_OUTPUT_BASE64_CHARS,
+  IMAGE_EDIT_MAX_OUTPUT_BYTES,
+  IMAGE_EDIT_MAX_OUTPUT_PIXELS,
+  IMAGE_EDIT_MAX_OUTPUT_SIDE_PX,
+  IMAGE_EDIT_MAX_PROMPT_BYTES,
+  IMAGE_EDIT_MAX_PROMPT_CHARS,
+  IMAGE_EDIT_MAX_REFERENCES,
+  IMAGE_EDIT_MAX_REQUEST_JSON_BYTES,
+  IMAGE_EDIT_MAX_RESPONSE_JSON_BYTES,
+  IMAGE_EDIT_MODEL,
+  IMAGE_EDIT_OUTPUT_COUNT,
+  IMAGE_EDIT_REQUEST_TIMEOUT_MS,
+  IMAGE_EDIT_RESOLUTION,
+  IMAGE_EDIT_RESPONSE_FORMAT,
+} from "./media/constants";
+import { prepareImageReferences, type ImageCodec, defaultImageCodec } from "./media/compression";
+import { decodeStrictBase64, parseBoundedImageDataUrl } from "./media/data-url";
+import { inspectSupportedImageBytes } from "./media/image-info";
+import { imageEditOutputRoot, saveVerifiedOutputImage } from "./media/output-storage";
+import { readBoundedWorkspaceImageFile } from "./media/paths";
+import type { PreparedImageReference, SavedImageOutput, VerifiedImageBytes } from "./media/types";
+
+export const IMAGE_EDIT_ASPECT_RATIOS = [
+  "1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3", "2:1", "1:2",
+  "19.5:9", "9:19.5", "20:9", "9:20", "auto",
+] as const;
+
+export interface XaiEditImagePathReference {
+  path: string;
+}
+
+export interface XaiEditImageDataUrlReference {
+  data_url: string;
+}
+
+export interface XaiEditImageInput {
+  prompt: string;
+  image: Array<XaiEditImagePathReference | XaiEditImageDataUrlReference>;
+  aspect_ratio?: string;
+}
+
+interface SessionLocation {
+  getSessionDir(): string;
+  getSessionId(): string;
+}
+
+export interface ExecuteXaiImageEditOptions {
+  credential: XaiCredential;
+  input: XaiEditImageInput;
+  workspaceRoot: string;
+  sessionManager: SessionLocation;
+  signal?: AbortSignal;
+}
+
+export interface ImageEditDependencies {
+  codec?: ImageCodec;
+  fetch?: typeof fetch;
+  requestTimeoutMs?: number;
+  responseMaxBytes?: number;
+}
+
+export type ImageEditErrorCode =
+  | "invalid_input"
+  | "cancelled"
+  | "timeout"
+  | "network_failure"
+  | "http_failure"
+  | "invalid_response"
+  | "output_failure";
+
+export class ImageEditOperationError extends Error {
+  constructor(
+    message: string,
+    readonly code: ImageEditErrorCode,
+    readonly status?: number,
+  ) {
+    super(message);
+    this.name = "ImageEditOperationError";
+  }
+}
+
+function invalidInput(message: string): never {
+  throw new ImageEditOperationError(message, "invalid_input");
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+function safeRequestId(value: string | null): string | undefined {
+  return value && /^[A-Za-z0-9._:-]{1,128}$/.test(value) ? value : undefined;
+}
+
+function validateReferenceShape(value: unknown): XaiEditImagePathReference | XaiEditImageDataUrlReference {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return invalidInput("Each image reference must contain exactly one path or data_url field.");
+  }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record);
+  if (keys.length !== 1 || (keys[0] !== "path" && keys[0] !== "data_url")) {
+    return invalidInput("Each image reference must contain exactly one path or data_url field.");
+  }
+  const field = keys[0] as "path" | "data_url";
+  const source = record[field];
+  if (typeof source !== "string" || !source.trim()) {
+    return invalidInput("Image reference values must be non-empty strings.");
+  }
+  if (field === "path") {
+    const windowsDrivePath = /^[A-Za-z]:[\\/]/.test(source);
+    if (!windowsDrivePath && /^[A-Za-z][A-Za-z0-9+.-]*:/.test(source)) {
+      return invalidInput("Image path references do not accept URL schemes.");
+    }
+    return { path: source };
+  }
+  return { data_url: source };
+}
+
+/** Validate cheap image-edit input shape before credential or media I/O. */
+export function validateXaiEditImageInput(input: unknown): XaiEditImageInput {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return invalidInput("Image edit input must be an object.");
+  }
+  const record = input as Record<string, unknown>;
+  if (Object.keys(record).some((key) => key !== "prompt" && key !== "image" && key !== "aspect_ratio")) {
+    return invalidInput("Image edit input contains unsupported fields.");
+  }
+  if (typeof record.prompt !== "string" || !record.prompt.trim()) {
+    return invalidInput("Image edit prompt must be a non-empty string.");
+  }
+  if (
+    record.prompt.length > IMAGE_EDIT_MAX_PROMPT_CHARS
+    || Buffer.byteLength(record.prompt, "utf8") > IMAGE_EDIT_MAX_PROMPT_BYTES
+  ) {
+    return invalidInput("Image edit prompt exceeds the length limit.");
+  }
+  if (!Array.isArray(record.image) || record.image.length < 1 || record.image.length > IMAGE_EDIT_MAX_REFERENCES) {
+    return invalidInput(`Image edit requires 1-${IMAGE_EDIT_MAX_REFERENCES} references.`);
+  }
+  const image = record.image.map(validateReferenceShape);
+  const aspectRatio = record.aspect_ratio;
+  if (image.length > 1) {
+    if (typeof aspectRatio !== "string" || !(IMAGE_EDIT_ASPECT_RATIOS as readonly string[]).includes(aspectRatio)) {
+      return invalidInput("Multiple image references require a supported aspect_ratio.");
+    }
+  }
+  return {
+    prompt: record.prompt,
+    image,
+    ...(typeof aspectRatio === "string" ? { aspect_ratio: aspectRatio } : {}),
+  };
+}
+
+/** Build the exact source-backed singular/plural xAI image-edit wire payload. */
+export function buildXaiImageEditPayload(
+  input: XaiEditImageInput,
+  references: readonly PreparedImageReference[],
+): Record<string, unknown> {
+  if (references.length !== input.image.length || references.length < 1) {
+    return invalidInput("Prepared image reference count does not match the request.");
+  }
+  const payload: Record<string, unknown> = {
+    model: IMAGE_EDIT_MODEL,
+    prompt: input.prompt,
+    n: IMAGE_EDIT_OUTPUT_COUNT,
+    resolution: IMAGE_EDIT_RESOLUTION,
+    response_format: IMAGE_EDIT_RESPONSE_FORMAT,
+  };
+  const wireReferences = references.map(({ dataUrl }) => ({ url: dataUrl }));
+  if (wireReferences.length === 1) {
+    payload.image = wireReferences[0];
+  } else {
+    if (!input.aspect_ratio || !(IMAGE_EDIT_ASPECT_RATIOS as readonly string[]).includes(input.aspect_ratio)) {
+      return invalidInput("Multiple image references require a supported aspect_ratio.");
+    }
+    payload.images = wireReferences;
+    payload.aspect_ratio = input.aspect_ratio;
+  }
+  if (Buffer.byteLength(JSON.stringify(payload), "utf8") > IMAGE_EDIT_MAX_REQUEST_JSON_BYTES) {
+    return invalidInput("Image edit request exceeds the aggregate request-byte limit.");
+  }
+  return payload;
+}
+
+async function readBoundedResponse(response: Response, maxBytes: number, signal: AbortSignal): Promise<string> {
+  if (!response.body) return "";
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      if (signal.aborted) throw new DOMException("The operation was cancelled.", "AbortError");
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel().catch(() => undefined);
+        throw new ImageEditOperationError("xAI image edit response exceeded the byte limit.", "invalid_response");
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)), total).toString("utf8");
+}
+
+async function postBoundedImageEdit(
+  credential: XaiCredential,
+  body: Record<string, unknown>,
+  callerSignal: AbortSignal | undefined,
+  dependencies: ImageEditDependencies,
+): Promise<unknown> {
+  const controller = new AbortController();
+  let timedOut = false;
+  const forwardAbort = () => controller.abort();
+  callerSignal?.addEventListener("abort", forwardAbort, { once: true });
+  if (callerSignal?.aborted) controller.abort();
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, dependencies.requestTimeoutMs ?? IMAGE_EDIT_REQUEST_TIMEOUT_MS);
+
+  try {
+    if (callerSignal?.aborted) {
+      throw new ImageEditOperationError("xAI image edit was cancelled.", "cancelled");
+    }
+    const route = resolveXaiRoute(credential.kind, "image-edit");
+    let response: Response;
+    try {
+      response = await (dependencies.fetch ?? fetch)(route.url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${credential.token}`,
+        },
+        body: JSON.stringify(body),
+        redirect: "error",
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (callerSignal?.aborted) throw new ImageEditOperationError("xAI image edit was cancelled.", "cancelled");
+      if (timedOut) throw new ImageEditOperationError("xAI image edit timed out.", "timeout");
+      if (isAbortError(error)) throw new ImageEditOperationError("xAI image edit was cancelled.", "cancelled");
+      throw new ImageEditOperationError("xAI image edit request failed. Check the network and try again.", "network_failure");
+    }
+
+    if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined);
+      const requestId = safeRequestId(response.headers.get("x-request-id"));
+      const suffix = requestId ? ` Request ID: ${requestId}.` : "";
+      throw new ImageEditOperationError(
+        `xAI image edit failed with HTTP ${response.status}.${suffix} Check the prompt and reference images.`,
+        "http_failure",
+        response.status,
+      );
+    }
+    const text = await readBoundedResponse(
+      response,
+      dependencies.responseMaxBytes ?? IMAGE_EDIT_MAX_RESPONSE_JSON_BYTES,
+      controller.signal,
+    );
+    try {
+      return JSON.parse(text);
+    } catch {
+      throw new ImageEditOperationError("xAI image edit returned an invalid JSON response.", "invalid_response");
+    }
+  } catch (error) {
+    if (error instanceof ImageEditOperationError) throw error;
+    if (callerSignal?.aborted) throw new ImageEditOperationError("xAI image edit was cancelled.", "cancelled");
+    if (timedOut) throw new ImageEditOperationError("xAI image edit timed out.", "timeout");
+    throw new ImageEditOperationError("xAI image edit response could not be read safely.", "invalid_response");
+  } finally {
+    clearTimeout(timeout);
+    callerSignal?.removeEventListener("abort", forwardAbort);
+  }
+}
+
+async function verifyOutputImage(
+  response: unknown,
+  codec: ImageCodec,
+  signal?: AbortSignal,
+): Promise<VerifiedImageBytes> {
+  const data = (response as any)?.data;
+  if (!Array.isArray(data) || data.length !== 1 || typeof data[0]?.b64_json !== "string") {
+    throw new ImageEditOperationError("xAI image edit must return exactly one base64 image.", "invalid_response");
+  }
+  let bytes: Buffer;
+  try {
+    bytes = decodeStrictBase64(
+      data[0].b64_json,
+      IMAGE_EDIT_MAX_OUTPUT_BASE64_CHARS,
+      IMAGE_EDIT_MAX_OUTPUT_BYTES,
+    );
+  } catch {
+    throw new ImageEditOperationError("xAI image edit returned invalid or oversized base64 image data.", "invalid_response");
+  }
+  let inspected;
+  try {
+    inspected = inspectSupportedImageBytes(bytes, {
+      maxPixels: IMAGE_EDIT_MAX_OUTPUT_PIXELS,
+      maxSidePx: IMAGE_EDIT_MAX_OUTPUT_SIDE_PX,
+    });
+    const image: VerifiedImageBytes = { bytes, ...inspected, source: "output" };
+    const decoded = await codec.verify(image, signal);
+    return { ...image, ...decoded };
+  } catch (error) {
+    if (isAbortError(error)) throw error;
+    throw new ImageEditOperationError("xAI image edit returned an invalid or oversized PNG/JPEG.", "invalid_response");
+  }
+}
+
+/** Execute a bounded pinned image edit and atomically persist one verified output. */
+export async function executeXaiImageEdit(
+  options: ExecuteXaiImageEditOptions,
+  dependencies: ImageEditDependencies = {},
+): Promise<SavedImageOutput> {
+  const input = validateXaiEditImageInput(options.input);
+  const codec = dependencies.codec ?? defaultImageCodec();
+  let sessionRoot: string;
+  let outputRoot: string;
+  try {
+    sessionRoot = options.sessionManager.getSessionDir();
+    outputRoot = imageEditOutputRoot(options.sessionManager);
+  } catch {
+    throw new ImageEditOperationError("A safe Pi session output directory is unavailable.", "output_failure");
+  }
+
+  const images: VerifiedImageBytes[] = [];
+  try {
+    for (const reference of input.image) {
+      images.push(
+        "path" in reference
+          ? await readBoundedWorkspaceImageFile(reference.path, options.workspaceRoot, options.signal)
+          : parseBoundedImageDataUrl(reference.data_url),
+      );
+    }
+  } catch (error) {
+    if (isAbortError(error)) throw new ImageEditOperationError("xAI image edit was cancelled.", "cancelled");
+    throw new ImageEditOperationError(
+      error instanceof Error ? error.message : "Image reference could not be read safely.",
+      "invalid_input",
+    );
+  }
+
+  let references: PreparedImageReference[];
+  try {
+    references = await prepareImageReferences(images, { codec, signal: options.signal });
+  } catch (error) {
+    if (isAbortError(error)) throw new ImageEditOperationError("xAI image edit was cancelled.", "cancelled");
+    throw new ImageEditOperationError(
+      error instanceof Error ? error.message : "Image reference could not be compressed safely.",
+      "invalid_input",
+    );
+  }
+
+  const payload = buildXaiImageEditPayload(input, references);
+  const response = await postBoundedImageEdit(options.credential, payload, options.signal, dependencies);
+  let output: VerifiedImageBytes;
+  try {
+    output = await verifyOutputImage(response, codec, options.signal);
+  } catch (error) {
+    if (isAbortError(error)) throw new ImageEditOperationError("xAI image edit was cancelled.", "cancelled");
+    throw error;
+  }
+  try {
+    return await saveVerifiedOutputImage(output, {
+      outputRoot,
+      sessionRoot,
+      signal: options.signal,
+    });
+  } catch (error) {
+    if (isAbortError(error)) throw new ImageEditOperationError("xAI image edit was cancelled.", "cancelled");
+    throw new ImageEditOperationError("The verified image could not be saved to Pi session storage.", "output_failure");
+  }
+}

--- a/extensions/xai/image-edit.ts
+++ b/extensions/xai/image-edit.ts
@@ -22,6 +22,7 @@ import { inspectSupportedImageBytes } from "./media/image-info";
 import { imageEditOutputRoot, saveVerifiedOutputImage } from "./media/output-storage";
 import { readBoundedWorkspaceImageFile } from "./media/paths";
 import type { PreparedImageReference, SavedImageOutput, VerifiedImageBytes } from "./media/types";
+import { xaiDirectMediaJsonHeaders } from "./wire";
 
 export const IMAGE_EDIT_ASPECT_RATIOS = [
   "1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3", "2:1", "1:2",
@@ -141,8 +142,17 @@ export function validateXaiEditImageInput(input: unknown): XaiEditImageInput {
   }
   const image = record.image.map(validateReferenceShape);
   const aspectRatio = record.aspect_ratio;
+  if (
+    aspectRatio !== undefined
+    && (
+      typeof aspectRatio !== "string"
+      || !(IMAGE_EDIT_ASPECT_RATIOS as readonly string[]).includes(aspectRatio)
+    )
+  ) {
+    return invalidInput("Image edit aspect_ratio must be supported when supplied.");
+  }
   if (image.length > 1) {
-    if (typeof aspectRatio !== "string" || !(IMAGE_EDIT_ASPECT_RATIOS as readonly string[]).includes(aspectRatio)) {
+    if (typeof aspectRatio !== "string") {
       return invalidInput("Multiple image references require a supported aspect_ratio.");
     }
   }
@@ -189,10 +199,17 @@ async function readBoundedResponse(response: Response, maxBytes: number, signal:
   const reader = response.body.getReader();
   const chunks: Uint8Array[] = [];
   let total = 0;
+  const abortError = () => new DOMException("The operation was cancelled.", "AbortError");
+  let rejectOnAbort: ((reason: unknown) => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    rejectOnAbort = reject;
+  });
+  const onAbort = () => rejectOnAbort?.(abortError());
+  signal.addEventListener("abort", onAbort, { once: true });
   try {
+    if (signal.aborted) throw abortError();
     while (true) {
-      if (signal.aborted) throw new DOMException("The operation was cancelled.", "AbortError");
-      const { done, value } = await reader.read();
+      const { done, value } = await Promise.race([reader.read(), aborted]);
       if (done) break;
       total += value.byteLength;
       if (total > maxBytes) {
@@ -202,6 +219,8 @@ async function readBoundedResponse(response: Response, maxBytes: number, signal:
       chunks.push(value);
     }
   } finally {
+    signal.removeEventListener("abort", onAbort);
+    if (signal.aborted) await reader.cancel().catch(() => undefined);
     reader.releaseLock();
   }
   return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)), total).toString("utf8");
@@ -232,10 +251,7 @@ async function postBoundedImageEdit(
     try {
       response = await (dependencies.fetch ?? fetch)(route.url, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${credential.token}`,
-        },
+        headers: xaiDirectMediaJsonHeaders(credential.token),
         body: JSON.stringify(body),
         redirect: "error",
         signal: controller.signal,
@@ -305,6 +321,16 @@ async function verifyOutputImage(
     });
     const image: VerifiedImageBytes = { bytes, ...inspected, source: "output" };
     const decoded = await codec.verify(image, signal);
+    if (
+      !Number.isSafeInteger(decoded.width)
+      || !Number.isSafeInteger(decoded.height)
+      || decoded.width <= 0
+      || decoded.height <= 0
+      || Math.max(decoded.width, decoded.height) > IMAGE_EDIT_MAX_OUTPUT_SIDE_PX
+      || decoded.width > Math.floor(IMAGE_EDIT_MAX_OUTPUT_PIXELS / decoded.height)
+    ) {
+      throw new Error("Decoded image dimensions exceed the output limit.");
+    }
     return { ...image, ...decoded };
   } catch (error) {
     if (isAbortError(error)) throw error;
@@ -318,6 +344,9 @@ export async function executeXaiImageEdit(
   dependencies: ImageEditDependencies = {},
 ): Promise<SavedImageOutput> {
   const input = validateXaiEditImageInput(options.input);
+  if (options.signal?.aborted) {
+    throw new ImageEditOperationError("xAI image edit was cancelled.", "cancelled");
+  }
   const codec = dependencies.codec ?? defaultImageCodec();
   let sessionRoot: string;
   let outputRoot: string;
@@ -351,7 +380,7 @@ export async function executeXaiImageEdit(
   } catch (error) {
     if (isAbortError(error)) throw new ImageEditOperationError("xAI image edit was cancelled.", "cancelled");
     throw new ImageEditOperationError(
-      error instanceof Error ? error.message : "Image reference could not be compressed safely.",
+      "Image reference could not be verified or compressed safely.",
       "invalid_input",
     );
   }

--- a/extensions/xai/media/compression.ts
+++ b/extensions/xai/media/compression.ts
@@ -1,0 +1,185 @@
+import { resizeImage } from "@earendil-works/pi-coding-agent";
+import {
+  IMAGE_EDIT_MAX_AGGREGATE_REFERENCE_BYTES,
+  IMAGE_EDIT_MAX_REFERENCES,
+  MEDIA_MAX_SOURCE_PIXELS,
+  MEDIA_REFERENCE_COMPRESS_MAX_SIDE_PX,
+  MEDIA_REFERENCE_COMPRESS_MIN_SIDE_PX,
+  MEDIA_REFERENCE_PASSTHROUGH_MAX_BYTES,
+  MEDIA_REFERENCE_QUALITY_STEPS,
+} from "./constants";
+import { decodeStrictBase64, toImageDataUrl } from "./data-url";
+import { inspectSupportedImageBytes } from "./image-info";
+import type { PreparedImageReference, VerifiedImageBytes } from "./types";
+
+export interface ImageCodec {
+  verify(image: VerifiedImageBytes, signal?: AbortSignal): Promise<{ width: number; height: number }>;
+  compress(
+    image: VerifiedImageBytes,
+    options: {
+      maxSidePx: number;
+      minSidePx: number;
+      maxBytes: number;
+      qualitySteps: readonly number[];
+    },
+    signal?: AbortSignal,
+  ): Promise<VerifiedImageBytes | null>;
+}
+
+function abortError() {
+  return new DOMException("The operation was cancelled.", "AbortError");
+}
+
+function abortable<T>(task: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return task;
+  if (signal.aborted) return Promise.reject(abortError());
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(abortError());
+    signal.addEventListener("abort", onAbort, { once: true });
+    const cleanup = () => signal.removeEventListener("abort", onAbort);
+    task.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
+
+function maxEncodedLength(rawBytes: number): number {
+  return Math.ceil(rawBytes / 3) * 4;
+}
+
+const piImageCodec: ImageCodec = {
+  async verify(image, signal) {
+    const side = Math.max(image.width, image.height);
+    const result = await abortable(
+      resizeImage(image.bytes, image.mimeType, {
+        maxWidth: side,
+        maxHeight: side,
+        maxBytes: maxEncodedLength(image.bytes.length) + 1,
+        jpegQuality: MEDIA_REFERENCE_QUALITY_STEPS[0],
+      }),
+      signal,
+    );
+    if (!result) throw new Error("Image reference could not be decoded safely.");
+    const decoded = decodeStrictBase64(
+      result.data,
+      maxEncodedLength(image.bytes.length) + 4,
+      image.bytes.length,
+    );
+    if (!decoded.equals(image.bytes)) throw new Error("Image reference decode verification failed.");
+    return { width: result.width, height: result.height };
+  },
+  async compress(image, options, signal) {
+    for (const jpegQuality of options.qualitySteps) {
+      const result = await abortable(
+        resizeImage(image.bytes, image.mimeType, {
+          maxWidth: options.maxSidePx,
+          maxHeight: options.maxSidePx,
+          maxBytes: maxEncodedLength(options.maxBytes) + 1,
+          jpegQuality,
+        }),
+        signal,
+      );
+      if (!result) continue;
+      const bytes = decodeStrictBase64(
+        result.data,
+        maxEncodedLength(options.maxBytes) + 4,
+        options.maxBytes,
+      );
+      const inspected = inspectSupportedImageBytes(bytes, { maxPixels: MEDIA_MAX_SOURCE_PIXELS });
+      if (Math.max(inspected.width, inspected.height) < options.minSidePx) continue;
+      return { bytes, ...inspected, source: "compressed" };
+    }
+    return null;
+  },
+};
+
+/** Return the production Pi worker-backed PNG/JPEG codec adapter. */
+export function defaultImageCodec(): ImageCodec {
+  return piImageCodec;
+}
+
+/** Decode-verify and source-backed compress references under per-item and aggregate budgets. */
+export async function prepareImageReferences(
+  images: readonly VerifiedImageBytes[],
+  options: { codec?: ImageCodec; signal?: AbortSignal } = {},
+): Promise<PreparedImageReference[]> {
+  const codec = options.codec ?? defaultImageCodec();
+  if (images.length < 1 || images.length > IMAGE_EDIT_MAX_REFERENCES) {
+    throw new Error("Image reference count is outside the supported limit.");
+  }
+  const prepared: PreparedImageReference[] = [];
+  let aggregateBytes = 0;
+
+  for (const image of images) {
+    if (options.signal?.aborted) throw abortError();
+    const decodedDimensions = await codec.verify(image, options.signal);
+    if (
+      !Number.isSafeInteger(decodedDimensions.width)
+      || !Number.isSafeInteger(decodedDimensions.height)
+      || decodedDimensions.width <= 0
+      || decodedDimensions.height <= 0
+      || decodedDimensions.width > Math.floor(MEDIA_MAX_SOURCE_PIXELS / decodedDimensions.height)
+    ) {
+      throw new Error("Image reference exceeds the decoded-pixel limit.");
+    }
+    const verified = { ...image, ...decodedDimensions };
+    let output = verified;
+    let wasCompressed = false;
+
+    if (verified.bytes.length > MEDIA_REFERENCE_PASSTHROUGH_MAX_BYTES) {
+      const compressed = await codec.compress(
+        verified,
+        {
+          maxSidePx: MEDIA_REFERENCE_COMPRESS_MAX_SIDE_PX,
+          minSidePx: MEDIA_REFERENCE_COMPRESS_MIN_SIDE_PX,
+          maxBytes: MEDIA_REFERENCE_PASSTHROUGH_MAX_BYTES,
+          qualitySteps: MEDIA_REFERENCE_QUALITY_STEPS,
+        },
+        options.signal,
+      );
+      if (!compressed || compressed.bytes.length > MEDIA_REFERENCE_PASSTHROUGH_MAX_BYTES) {
+        throw new Error("Image reference could not be compressed within the Imagine limit.");
+      }
+      const inspected = inspectSupportedImageBytes(compressed.bytes, {
+        maxPixels: MEDIA_MAX_SOURCE_PIXELS,
+      });
+      if (inspected.mimeType !== compressed.mimeType) {
+        throw new Error("Compressed image reference MIME does not match its bytes.");
+      }
+      compressed.width = inspected.width;
+      compressed.height = inspected.height;
+      if (Math.max(compressed.width, compressed.height) > MEDIA_REFERENCE_COMPRESS_MAX_SIDE_PX) {
+        throw new Error("Compressed image reference exceeds the dimension limit.");
+      }
+      if (
+        Math.max(verified.width, verified.height) > MEDIA_REFERENCE_COMPRESS_MIN_SIDE_PX
+        && Math.max(compressed.width, compressed.height) < MEDIA_REFERENCE_COMPRESS_MIN_SIDE_PX
+      ) {
+        throw new Error("Image reference cannot fit without dropping below the compression floor.");
+      }
+      output = compressed;
+      wasCompressed = true;
+    }
+
+    aggregateBytes += output.bytes.length;
+    if (aggregateBytes > IMAGE_EDIT_MAX_AGGREGATE_REFERENCE_BYTES) {
+      throw new Error("Image references exceed the aggregate byte limit.");
+    }
+    prepared.push({
+      dataUrl: toImageDataUrl(output),
+      mimeType: output.mimeType,
+      byteLength: output.bytes.length,
+      width: output.width,
+      height: output.height,
+      wasCompressed,
+    });
+  }
+  return prepared;
+}

--- a/extensions/xai/media/constants.ts
+++ b/extensions/xai/media/constants.ts
@@ -1,0 +1,37 @@
+/** MIME types accepted for image-edit references and generated output. */
+export const SUPPORTED_IMAGE_MIME_TYPES = ["image/png", "image/jpeg"] as const;
+
+/** Source-backed xAI Imagine reference-image limits. */
+export const MEDIA_REFERENCE_PASSTHROUGH_MAX_BYTES = 400 * 1024;
+export const MEDIA_REFERENCE_COMPRESS_MAX_SIDE_PX = 768;
+export const MEDIA_REFERENCE_COMPRESS_MIN_SIDE_PX = 256;
+export const MEDIA_REFERENCE_QUALITY_STEPS = [80, 65, 50, 35] as const;
+export const MEDIA_MAX_SOURCE_PIXELS = 12_000_000;
+
+/** Package-owned input and request budgets. */
+export const MEDIA_MAX_SOURCE_BYTES = 8 * 1024 * 1024;
+export const MEDIA_MAX_DATA_URL_CHARS = 12 * 1024 * 1024;
+export const IMAGE_EDIT_MAX_REFERENCES = 4;
+export const IMAGE_EDIT_MAX_AGGREGATE_REFERENCE_BYTES =
+  3 * MEDIA_REFERENCE_PASSTHROUGH_MAX_BYTES;
+export const IMAGE_EDIT_MAX_PROMPT_CHARS = 4_000;
+export const IMAGE_EDIT_MAX_PROMPT_BYTES = 16 * 1024;
+export const IMAGE_EDIT_MAX_REQUEST_JSON_BYTES = 3 * 1024 * 1024;
+
+/** Package-owned network and response budgets. */
+export const IMAGE_EDIT_REQUEST_TIMEOUT_MS = 120_000;
+export const IMAGE_EDIT_MAX_RESPONSE_JSON_BYTES = 24 * 1024 * 1024;
+export const IMAGE_EDIT_MAX_OUTPUT_BASE64_CHARS = 24 * 1024 * 1024;
+export const IMAGE_EDIT_MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
+export const IMAGE_EDIT_MAX_OUTPUT_PIXELS = 16_000_000;
+export const IMAGE_EDIT_MAX_OUTPUT_SIDE_PX = 4_096;
+
+/** Fixed source-backed image-edit request fields. */
+export const IMAGE_EDIT_MODEL = "grok-imagine-image-quality";
+export const IMAGE_EDIT_RESOLUTION = "1k";
+export const IMAGE_EDIT_RESPONSE_FORMAT = "b64_json";
+export const IMAGE_EDIT_OUTPUT_COUNT = 1;
+
+/** Safe output permissions. */
+export const IMAGE_EDIT_OUTPUT_DIRECTORY_MODE = 0o700;
+export const IMAGE_EDIT_OUTPUT_FILE_MODE = 0o600;

--- a/extensions/xai/media/constants.ts
+++ b/extensions/xai/media/constants.ts
@@ -11,7 +11,7 @@ export const MEDIA_MAX_SOURCE_PIXELS = 12_000_000;
 /** Package-owned input and request budgets. */
 export const MEDIA_MAX_SOURCE_BYTES = 8 * 1024 * 1024;
 export const MEDIA_MAX_DATA_URL_CHARS = 12 * 1024 * 1024;
-export const IMAGE_EDIT_MAX_REFERENCES = 4;
+export const IMAGE_EDIT_MAX_REFERENCES = 3;
 export const IMAGE_EDIT_MAX_AGGREGATE_REFERENCE_BYTES =
   3 * MEDIA_REFERENCE_PASSTHROUGH_MAX_BYTES;
 export const IMAGE_EDIT_MAX_PROMPT_CHARS = 4_000;

--- a/extensions/xai/media/data-url.ts
+++ b/extensions/xai/media/data-url.ts
@@ -1,0 +1,38 @@
+import { MEDIA_MAX_DATA_URL_CHARS, MEDIA_MAX_SOURCE_BYTES, MEDIA_MAX_SOURCE_PIXELS } from "./constants";
+import { inspectSupportedImageBytes } from "./image-info";
+import type { SupportedImageMimeType, VerifiedImageBytes } from "./types";
+
+const STRICT_BASE64 = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+const STRICT_IMAGE_DATA_URL = /^data:(image\/(?:png|jpeg));base64,([A-Za-z0-9+/]*={0,2})$/;
+
+/** Decode canonical standard base64 without accepting whitespace, base64url, or bad padding. */
+export function decodeStrictBase64(value: string, maxChars: number, maxBytes: number): Buffer {
+  if (typeof value !== "string" || value.length === 0) throw new Error("Image base64 is empty.");
+  if (value.length > maxChars) throw new Error("Image base64 exceeds the encoded-size limit.");
+  if (!STRICT_BASE64.test(value)) throw new Error("Image base64 is malformed.");
+  const decoded = Buffer.from(value, "base64");
+  if (decoded.length === 0 || decoded.length > maxBytes) {
+    throw new Error("Image exceeds the decoded-byte limit.");
+  }
+  if (decoded.toString("base64") !== value) throw new Error("Image base64 is not canonical.");
+  return decoded;
+}
+
+/** Parse a strict, bounded PNG/JPEG data URL and verify its declared MIME from bytes. */
+export function parseBoundedImageDataUrl(value: string): VerifiedImageBytes {
+  if (typeof value !== "string" || value.length > MEDIA_MAX_DATA_URL_CHARS) {
+    throw new Error("Image data URL exceeds the encoded-size limit.");
+  }
+  const match = STRICT_IMAGE_DATA_URL.exec(value);
+  if (!match) throw new Error("Only strict base64 PNG and JPEG data URLs are supported.");
+  const declaredMime = match[1] as SupportedImageMimeType;
+  const bytes = decodeStrictBase64(match[2], MEDIA_MAX_DATA_URL_CHARS, MEDIA_MAX_SOURCE_BYTES);
+  const inspected = inspectSupportedImageBytes(bytes, { maxPixels: MEDIA_MAX_SOURCE_PIXELS });
+  if (inspected.mimeType !== declaredMime) throw new Error("Image data URL MIME does not match its bytes.");
+  return { bytes, ...inspected, source: "data-url" };
+}
+
+/** Serialize verified PNG/JPEG bytes as a canonical data URL. */
+export function toImageDataUrl(image: Pick<VerifiedImageBytes, "bytes" | "mimeType">): string {
+  return `data:${image.mimeType};base64,${image.bytes.toString("base64")}`;
+}

--- a/extensions/xai/media/image-info.ts
+++ b/extensions/xai/media/image-info.ts
@@ -1,0 +1,89 @@
+import type { SupportedImageMimeType } from "./types";
+
+export interface ImageInspectionLimits {
+  maxPixels: number;
+  maxSidePx?: number;
+}
+
+export interface InspectedImage {
+  mimeType: SupportedImageMimeType;
+  width: number;
+  height: number;
+}
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const JPEG_START_OF_FRAME_MARKERS = new Set([
+  0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf,
+]);
+
+function validateDimensions(width: number, height: number, limits: ImageInspectionLimits) {
+  if (!Number.isSafeInteger(width) || !Number.isSafeInteger(height) || width <= 0 || height <= 0) {
+    throw new Error("Image dimensions are invalid.");
+  }
+  if (!Number.isSafeInteger(limits.maxPixels) || limits.maxPixels <= 0) {
+    throw new Error("Image pixel budget is invalid.");
+  }
+  if (width > Math.floor(limits.maxPixels / height)) {
+    throw new Error("Image exceeds the decoded-pixel limit.");
+  }
+  if (limits.maxSidePx !== undefined && Math.max(width, height) > limits.maxSidePx) {
+    throw new Error("Image exceeds the dimension limit.");
+  }
+}
+
+function inspectPng(bytes: Buffer): InspectedImage | undefined {
+  if (bytes.length < 24 || !bytes.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE)) {
+    return undefined;
+  }
+  if (bytes.readUInt32BE(8) !== 13 || bytes.toString("ascii", 12, 16) !== "IHDR") {
+    throw new Error("PNG image has an invalid IHDR header.");
+  }
+  return {
+    mimeType: "image/png",
+    width: bytes.readUInt32BE(16),
+    height: bytes.readUInt32BE(20),
+  };
+}
+
+function inspectJpeg(bytes: Buffer): InspectedImage | undefined {
+  if (bytes.length < 4 || bytes[0] !== 0xff || bytes[1] !== 0xd8) return undefined;
+
+  let offset = 2;
+  while (offset < bytes.length) {
+    if (bytes[offset] !== 0xff) throw new Error("JPEG image contains an invalid marker.");
+    while (offset < bytes.length && bytes[offset] === 0xff) offset += 1;
+    if (offset >= bytes.length) break;
+    const marker = bytes[offset++];
+
+    if (marker === 0xd9 || marker === 0xda) break;
+    if (marker === 0x01 || marker === 0xd8 || (marker >= 0xd0 && marker <= 0xd7)) continue;
+    if (offset + 2 > bytes.length) throw new Error("JPEG image has a truncated segment.");
+
+    const segmentLength = bytes.readUInt16BE(offset);
+    if (segmentLength < 2 || offset + segmentLength > bytes.length) {
+      throw new Error("JPEG image has an invalid segment length.");
+    }
+    if (JPEG_START_OF_FRAME_MARKERS.has(marker)) {
+      if (segmentLength < 7) throw new Error("JPEG image has a truncated frame header.");
+      return {
+        mimeType: "image/jpeg",
+        height: bytes.readUInt16BE(offset + 3),
+        width: bytes.readUInt16BE(offset + 5),
+      };
+    }
+    offset += segmentLength;
+  }
+  throw new Error("JPEG image has no supported frame header.");
+}
+
+/** Inspect PNG/JPEG bytes and enforce explicit decoded dimension limits. */
+export function inspectSupportedImageBytes(
+  bytes: Buffer,
+  limits: ImageInspectionLimits,
+): InspectedImage {
+  if (!Buffer.isBuffer(bytes) || bytes.length === 0) throw new Error("Image contains no data.");
+  const inspected = inspectPng(bytes) ?? inspectJpeg(bytes);
+  if (!inspected) throw new Error("Only byte-validated PNG and JPEG images are supported.");
+  validateDimensions(inspected.width, inspected.height, limits);
+  return inspected;
+}

--- a/extensions/xai/media/output-storage.ts
+++ b/extensions/xai/media/output-storage.ts
@@ -106,7 +106,9 @@ export async function saveVerifiedOutputImage(
     throwIfAborted(options.signal);
     await rename(temporaryPath, finalPath);
     finalCreated = true;
+    throwIfAborted(options.signal);
     await chmod(finalPath, IMAGE_EDIT_OUTPUT_FILE_MODE);
+    throwIfAborted(options.signal);
     return {
       path: finalPath,
       mimeType: image.mimeType,

--- a/extensions/xai/media/output-storage.ts
+++ b/extensions/xai/media/output-storage.ts
@@ -1,0 +1,123 @@
+import { createHash, randomUUID } from "node:crypto";
+import { chmod, lstat, mkdir, open, realpath, rename, rm } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import { IMAGE_EDIT_OUTPUT_DIRECTORY_MODE, IMAGE_EDIT_OUTPUT_FILE_MODE } from "./constants";
+import type { SavedImageOutput, VerifiedImageBytes } from "./types";
+
+interface ReadonlySessionLocation {
+  getSessionDir(): string;
+  getSessionId(): string;
+}
+
+function throwIfAborted(signal?: AbortSignal) {
+  if (signal?.aborted) throw new DOMException("The operation was cancelled.", "AbortError");
+}
+
+function isWithin(root: string, target: string): boolean {
+  const difference = relative(root, target);
+  return difference === "" || (
+    difference !== ".."
+    && !difference.startsWith(`..${sep}`)
+    && !isAbsolute(difference)
+  );
+}
+
+async function ensurePrivateOutputDirectory(outputRoot: string, sessionRoot: string): Promise<string> {
+  const absoluteSessionRoot = resolve(sessionRoot);
+  const absoluteOutputRoot = resolve(outputRoot);
+  if (!isWithin(absoluteSessionRoot, absoluteOutputRoot) || absoluteSessionRoot === absoluteOutputRoot) {
+    throw new Error("Image output directory is outside Pi session storage.");
+  }
+
+  const realSessionRoot = await realpath(absoluteSessionRoot);
+  const components = relative(absoluteSessionRoot, absoluteOutputRoot).split(sep).filter(Boolean);
+  let current = realSessionRoot;
+
+  for (const component of components) {
+    const candidate = join(current, component);
+    try {
+      const info = await lstat(candidate);
+      if (info.isSymbolicLink() || !info.isDirectory()) {
+        throw new Error("Image output path contains an unsafe filesystem entry.");
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") throw error;
+      try {
+        await mkdir(candidate, { mode: IMAGE_EDIT_OUTPUT_DIRECTORY_MODE });
+      } catch (mkdirError) {
+        if ((mkdirError as NodeJS.ErrnoException)?.code !== "EEXIST") throw mkdirError;
+      }
+      const created = await lstat(candidate);
+      if (created.isSymbolicLink() || !created.isDirectory()) {
+        throw new Error("Image output path contains an unsafe filesystem entry.");
+      }
+    }
+
+    const realCandidate = await realpath(candidate);
+    if (!isWithin(realSessionRoot, realCandidate)) {
+      throw new Error("Image output directory resolves outside Pi session storage.");
+    }
+    await chmod(realCandidate, IMAGE_EDIT_OUTPUT_DIRECTORY_MODE);
+    current = realCandidate;
+  }
+
+  return current;
+}
+
+/** Derive a package-owned, session-specific image-edit output directory. */
+export function imageEditOutputRoot(sessionManager: ReadonlySessionLocation): string {
+  const sessionDir = sessionManager?.getSessionDir?.();
+  const sessionId = sessionManager?.getSessionId?.();
+  if (typeof sessionDir !== "string" || !isAbsolute(sessionDir) || typeof sessionId !== "string" || !sessionId) {
+    throw new Error("A safe Pi session output directory is unavailable.");
+  }
+  const sessionKey = createHash("sha256").update(sessionId).digest("hex").slice(0, 32);
+  return join(sessionDir, "pi-xai-oauth", sessionKey, "image-edits");
+}
+
+/** Atomically save a verified image to controlled session storage with 0700/0600 modes. */
+export async function saveVerifiedOutputImage(
+  image: VerifiedImageBytes,
+  options: { outputRoot: string; sessionRoot: string; signal?: AbortSignal },
+): Promise<SavedImageOutput> {
+  throwIfAborted(options.signal);
+  if (!isAbsolute(options.outputRoot) || !isAbsolute(options.sessionRoot)) {
+    throw new Error("Image output path is invalid.");
+  }
+
+  const realOutputRoot = await ensurePrivateOutputDirectory(
+    options.outputRoot,
+    options.sessionRoot,
+  );
+  throwIfAborted(options.signal);
+
+  const extension = image.mimeType === "image/png" ? "png" : "jpg";
+  const stem = `xai-edit-${Date.now()}-${randomUUID()}`;
+  const finalPath = join(realOutputRoot, `${stem}.${extension}`);
+  const temporaryPath = join(realOutputRoot, `.${stem}.${extension}.tmp`);
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  let finalCreated = false;
+  try {
+    handle = await open(temporaryPath, "wx", IMAGE_EDIT_OUTPUT_FILE_MODE);
+    await handle.writeFile(image.bytes);
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    throwIfAborted(options.signal);
+    await rename(temporaryPath, finalPath);
+    finalCreated = true;
+    await chmod(finalPath, IMAGE_EDIT_OUTPUT_FILE_MODE);
+    return {
+      path: finalPath,
+      mimeType: image.mimeType,
+      width: image.width,
+      height: image.height,
+      byteLength: image.bytes.length,
+    };
+  } catch (error) {
+    await handle?.close().catch(() => undefined);
+    await rm(temporaryPath, { force: true }).catch(() => undefined);
+    if (finalCreated) await rm(finalPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}

--- a/extensions/xai/media/paths.ts
+++ b/extensions/xai/media/paths.ts
@@ -1,0 +1,86 @@
+import { constants } from "node:fs";
+import { open, realpath, stat as fsStat } from "node:fs/promises";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+import { MEDIA_MAX_SOURCE_BYTES, MEDIA_MAX_SOURCE_PIXELS } from "./constants";
+import { inspectSupportedImageBytes } from "./image-info";
+import type { VerifiedImageBytes } from "./types";
+
+function throwIfAborted(signal?: AbortSignal) {
+  if (signal?.aborted) throw new DOMException("The operation was cancelled.", "AbortError");
+}
+
+function isContainedPath(root: string, target: string): boolean {
+  const difference = relative(root, target);
+  return difference !== "" && difference !== ".." && !difference.startsWith(`..${sep}`)
+    && !isAbsolute(difference);
+}
+
+async function readHandleBounded(
+  handle: Awaited<ReturnType<typeof open>>,
+  maxBytes: number,
+  signal?: AbortSignal,
+): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  while (total <= maxBytes) {
+    throwIfAborted(signal);
+    const chunk = Buffer.allocUnsafe(Math.min(64 * 1024, maxBytes + 1 - total));
+    const { bytesRead } = await handle.read(chunk, 0, chunk.length, null);
+    if (bytesRead === 0) break;
+    chunks.push(chunk.subarray(0, bytesRead));
+    total += bytesRead;
+  }
+  if (total > maxBytes) throw new Error("Image reference exceeds the source-byte limit.");
+  return Buffer.concat(chunks, total);
+}
+
+/** Read a byte-bounded regular image whose resolved path remains inside the workspace. */
+export async function readBoundedWorkspaceImageFile(
+  inputPath: string,
+  workspaceRoot: string,
+  signal?: AbortSignal,
+): Promise<VerifiedImageBytes> {
+  if (typeof inputPath !== "string" || !inputPath.trim() || inputPath.includes("\0")) {
+    throw new Error("Image reference path is invalid.");
+  }
+  if (typeof workspaceRoot !== "string" || !workspaceRoot.trim()) {
+    throw new Error("Workspace root is unavailable.");
+  }
+  throwIfAborted(signal);
+
+  let root: string;
+  let target: string;
+  try {
+    root = await realpath(workspaceRoot);
+    const candidate = isAbsolute(inputPath) ? resolve(inputPath) : resolve(root, inputPath);
+    target = await realpath(candidate);
+  } catch {
+    throw new Error("Image reference is not a readable workspace file.");
+  }
+  if (!isContainedPath(root, target)) throw new Error("Image reference resolves outside the workspace.");
+
+  const noFollow = typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
+  const nonBlock = typeof constants.O_NONBLOCK === "number" ? constants.O_NONBLOCK : 0;
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    const initialStat = await fsStat(target);
+    if (!initialStat.isFile()) throw new Error("Image reference must be a regular file.");
+    handle = await open(target, constants.O_RDONLY | noFollow | nonBlock);
+    const stat = await handle.stat();
+    if (!stat.isFile()) throw new Error("Image reference must be a regular file.");
+    if (stat.size <= 0) throw new Error("Image reference contains no data.");
+    if (stat.size > MEDIA_MAX_SOURCE_BYTES) throw new Error("Image reference exceeds the source-byte limit.");
+    const bytes = await readHandleBounded(handle, MEDIA_MAX_SOURCE_BYTES, signal);
+    const inspected = inspectSupportedImageBytes(bytes, { maxPixels: MEDIA_MAX_SOURCE_PIXELS });
+    return { bytes, ...inspected, source: "workspace-path" };
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") throw error;
+    if (
+      error instanceof Error
+      && /^(?:Image reference|Image |Only byte-validated|PNG image|JPEG image)/.test(error.message)
+    ) throw error;
+    throw new Error("Image reference is not a readable workspace file.");
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}

--- a/extensions/xai/media/types.ts
+++ b/extensions/xai/media/types.ts
@@ -1,0 +1,28 @@
+import type { SUPPORTED_IMAGE_MIME_TYPES } from "./constants";
+
+export type SupportedImageMimeType = (typeof SUPPORTED_IMAGE_MIME_TYPES)[number];
+
+export interface VerifiedImageBytes {
+  bytes: Buffer;
+  mimeType: SupportedImageMimeType;
+  width: number;
+  height: number;
+  source: "workspace-path" | "data-url" | "compressed" | "output";
+}
+
+export interface PreparedImageReference {
+  dataUrl: string;
+  mimeType: SupportedImageMimeType;
+  byteLength: number;
+  width: number;
+  height: number;
+  wasCompressed: boolean;
+}
+
+export interface SavedImageOutput {
+  path: string;
+  mimeType: SupportedImageMimeType;
+  width: number;
+  height: number;
+  byteLength: number;
+}

--- a/extensions/xai/routing.ts
+++ b/extensions/xai/routing.ts
@@ -2,6 +2,7 @@ import {
   XAI_API_BASE_URL,
   XAI_CLI_BASE_URL,
   XAI_CLI_RESPONSES_URL,
+  XAI_IMAGES_EDITS_URL,
   XAI_IMAGES_GENERATIONS_URL,
   XAI_RESPONSES_URL,
 } from "./constants";
@@ -13,7 +14,7 @@ export interface XaiCredential {
   token: string;
 }
 
-export type XaiRequestKind = "responses" | "image-generation";
+export type XaiRequestKind = "responses" | "image-generation" | "image-edit";
 
 export interface XaiRoute {
   baseUrl: string;
@@ -26,10 +27,12 @@ const XAI_ROUTES: Record<XaiCredentialKind, Record<XaiRequestKind, XaiRoute>> = 
     // Official Grok Build sends Imagine requests directly to api.x.ai for
     // both OAuth sessions and BYOK credentials rather than via the chat proxy.
     "image-generation": { baseUrl: XAI_API_BASE_URL, url: XAI_IMAGES_GENERATIONS_URL },
+    "image-edit": { baseUrl: XAI_API_BASE_URL, url: XAI_IMAGES_EDITS_URL },
   },
   "api-key": {
     responses: { baseUrl: XAI_API_BASE_URL, url: XAI_RESPONSES_URL },
     "image-generation": { baseUrl: XAI_API_BASE_URL, url: XAI_IMAGES_GENERATIONS_URL },
+    "image-edit": { baseUrl: XAI_API_BASE_URL, url: XAI_IMAGES_EDITS_URL },
   },
 };
 

--- a/extensions/xai/tools/commands.ts
+++ b/extensions/xai/tools/commands.ts
@@ -24,7 +24,7 @@ const NETWORK_TOOL_OPTIONS: readonly NetworkToolOption[] = [
   { name: "xai_deep_research", category: "research", costRisk: "high/variable", summary: "multi-step web/X research" },
   { name: "xai_code_execution", category: "execution", costRisk: "token + tool", summary: "xAI code interpreter" },
   { name: "xai_generate_image", category: "image", costRisk: "per image", summary: "generate 1-4 images" },
-  { name: "xai_edit_image", category: "image", costRisk: "Imagine usage", summary: "edit 1-4 local image references" },
+  { name: "xai_edit_image", category: "image", costRisk: "Imagine usage", summary: "edit 1-3 local image references" },
   { name: "xai_analyze_image", category: "vision", costRisk: "token usage", summary: "analyze an image with Grok" },
   { name: "xai_critique", category: "reasoning", costRisk: "token usage", summary: "separate high-reasoning critique" },
   { name: "WebSearch", category: "search", costRisk: "token + tool", summary: "Grok Build/Composer native web search" },

--- a/extensions/xai/tools/commands.ts
+++ b/extensions/xai/tools/commands.ts
@@ -24,6 +24,7 @@ const NETWORK_TOOL_OPTIONS: readonly NetworkToolOption[] = [
   { name: "xai_deep_research", category: "research", costRisk: "high/variable", summary: "multi-step web/X research" },
   { name: "xai_code_execution", category: "execution", costRisk: "token + tool", summary: "xAI code interpreter" },
   { name: "xai_generate_image", category: "image", costRisk: "per image", summary: "generate 1-4 images" },
+  { name: "xai_edit_image", category: "image", costRisk: "Imagine usage", summary: "edit 1-4 local image references" },
   { name: "xai_analyze_image", category: "vision", costRisk: "token usage", summary: "analyze an image with Grok" },
   { name: "xai_critique", category: "reasoning", costRisk: "token usage", summary: "separate high-reasoning critique" },
   { name: "WebSearch", category: "search", costRisk: "token + tool", summary: "Grok Build/Composer native web search" },

--- a/extensions/xai/tools/custom-tools.ts
+++ b/extensions/xai/tools/custom-tools.ts
@@ -16,8 +16,8 @@ import { xaiTextInput, xaiToolError } from "./common";
 import { activeXaiModel, isXaiNetworkToolActive, type XaiNetworkToolName } from "./model-scope";
 
 function activeModelForXaiTool(pi: ExtensionAPI, ctx: any, toolName: XaiNetworkToolName) {
+  if (!isXaiNetworkToolActive(pi, toolName)) return undefined;
   const model = activeXaiModel(ctx);
-  if (!model || !isXaiNetworkToolActive(pi, toolName)) return undefined;
   return model;
 }
 
@@ -395,7 +395,7 @@ Be specific and cite examples where helpful.`;
             type: "array",
             minItems: 1,
             maxItems: IMAGE_EDIT_MAX_REFERENCES,
-            description: "One to four bounded local workspace or data-URL references",
+            description: "One to three bounded local workspace or data-URL references",
             items: {
               oneOf: [
                 {

--- a/extensions/xai/tools/custom-tools.ts
+++ b/extensions/xai/tools/custom-tools.ts
@@ -1,6 +1,12 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { resolveXaiCredential } from "../auth";
 import { DEFAULT_XAI_IMAGE_MODEL, DEFAULT_XAI_MODEL } from "../constants";
+import {
+  executeXaiImageEdit,
+  ImageEditOperationError,
+  validateXaiEditImageInput,
+} from "../image-edit";
+import { IMAGE_EDIT_MAX_PROMPT_CHARS, IMAGE_EDIT_MAX_REFERENCES } from "../media/constants";
 import { normalizeXaiImageInput } from "../images";
 import { defaultXaiRuntimeModelId, grokSupportsReasoningEffort, normalizedXaiModelId } from "../models";
 import { createXaiResponse, postXaiJson } from "../responses";
@@ -363,6 +369,104 @@ Be specific and cite examples where helpful.`;
           ? `Generated ${urls.length} image(s):\n${urls.map((u: string) => `- ${u}`).join("\n")}` 
           : "Image generation completed but no URLs returned.";
         return { content: [{ type: "text", text }], details: { prompt: params.prompt, urls, count: urls.length } };
+      },
+    } as any);
+
+    pi.registerTool({
+      name: "xai_edit_image",
+      label: "xAI Edit Image",
+      description:
+        "Opt-in paid image editing through xAI Imagine using bounded PNG/JPEG workspace files or data URLs. Enable via /xai-tools and call only when the user explicitly requests an edit.",
+      promptGuidelines: [
+        "Call xai_edit_image only when the user explicitly asks to edit or transform supplied images with xAI.",
+        "Use only user-supplied workspace paths or PNG/JPEG data URLs; never invent paths or send remote URLs.",
+      ],
+      executionMode: "sequential",
+      parameters: {
+        type: "object",
+        properties: {
+          prompt: {
+            type: "string",
+            minLength: 1,
+            maxLength: IMAGE_EDIT_MAX_PROMPT_CHARS,
+            description: "Description of the requested edit or transformation",
+          },
+          image: {
+            type: "array",
+            minItems: 1,
+            maxItems: IMAGE_EDIT_MAX_REFERENCES,
+            description: "One to four bounded local workspace or data-URL references",
+            items: {
+              oneOf: [
+                {
+                  type: "object",
+                  properties: { path: { type: "string", description: "PNG/JPEG path inside the current workspace" } },
+                  required: ["path"],
+                  additionalProperties: false,
+                },
+                {
+                  type: "object",
+                  properties: { data_url: { type: "string", description: "Strict bounded PNG/JPEG base64 data URL" } },
+                  required: ["data_url"],
+                  additionalProperties: false,
+                },
+              ],
+            },
+          },
+          aspect_ratio: {
+            type: "string",
+            enum: ["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3", "2:1", "1:2", "19.5:9", "9:19.5", "20:9", "9:20", "auto"],
+            description: "Required for multiple references; omitted on the wire for one reference",
+          },
+        },
+        required: ["prompt", "image"],
+        additionalProperties: false,
+      },
+      execute: async (_toolCallId: string, params: any, signal: AbortSignal | undefined, _onUpdate: any, ctx: any) => {
+        if (!activeModelForXaiTool(pi, ctx, "xai_edit_image")) {
+          return xaiToolDisabledError("xai_edit_image");
+        }
+
+        let input;
+        try {
+          input = validateXaiEditImageInput(params);
+        } catch (error) {
+          const message = error instanceof ImageEditOperationError ? error.message : "Image edit input is invalid.";
+          return xaiToolError(`Error: ${message}`, { error: true, code: "invalid_input" });
+        }
+        const credential = await resolveXaiCredential(ctx);
+        if (!credential) {
+          return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", {
+            error: true,
+          });
+        }
+
+        try {
+          const output = await executeXaiImageEdit({
+            credential,
+            input,
+            workspaceRoot: ctx?.cwd,
+            sessionManager: ctx?.sessionManager,
+            signal,
+          });
+          return {
+            content: [{
+              type: "text",
+              text: `Edited image saved to ${output.path} (${output.mimeType}, ${output.width}x${output.height}, ${output.byteLength} bytes).`,
+            }],
+            details: output,
+          };
+        } catch (error) {
+          const operationError = error instanceof ImageEditOperationError ? error : undefined;
+          return xaiToolError(
+            `Error: ${operationError?.message ?? "xAI image edit failed safely."}`,
+            {
+              error: true,
+              code: operationError?.code ?? "output_failure",
+              ...(operationError?.status ? { status: operationError.status } : {}),
+            },
+          );
+        }
       },
     } as any);
 

--- a/extensions/xai/tools/model-scope.ts
+++ b/extensions/xai/tools/model-scope.ts
@@ -12,6 +12,7 @@ export const XAI_NETWORK_TOOL_NAMES = [
   "xai_deep_research",
   "xai_code_execution",
   "xai_generate_image",
+  "xai_edit_image",
   "xai_analyze_image",
   "xai_critique",
   "WebSearch",

--- a/extensions/xai/wire.ts
+++ b/extensions/xai/wire.ts
@@ -2,6 +2,7 @@ import {
   XAI_CLIENT_IDENTIFIER,
   XAI_CLI_RESPONSES_URL,
   XAI_GROK_BUILD_REVIEWED_REVISION,
+  XAI_IMAGES_EDITS_URL,
   XAI_IMAGES_GENERATIONS_URL,
   XAI_PROXY_CLIENT_VERSION,
   XAI_RESPONSES_URL,
@@ -42,6 +43,7 @@ export type XaiHttpRouteKind =
   | "responses-proxy"
   | "responses-direct"
   | "image-generation"
+  | "image-edit"
   | "unknown";
 
 export interface XaiProxyRequestMetadata {
@@ -171,10 +173,16 @@ export function xaiJsonPostHeaders(
   };
 }
 
+/** Build the exact protected header contract for direct public media JSON requests. */
+export function xaiDirectMediaJsonHeaders(authToken: string): Record<string, string> {
+  return xaiJsonPostHeaders(authToken);
+}
+
 function routeKindForUrl(url: string): XaiHttpRouteKind {
   if (url === XAI_CLI_RESPONSES_URL) return "responses-proxy";
   if (url === XAI_RESPONSES_URL) return "responses-direct";
   if (url === XAI_IMAGES_GENERATIONS_URL) return "image-generation";
+  if (url === XAI_IMAGES_EDITS_URL) return "image-edit";
   return "unknown";
 }
 
@@ -193,6 +201,7 @@ function isProxyVersionGate(status: number | undefined, detail: string): boolean
 function routeLabel(routeKind: XaiHttpRouteKind): string {
   if (routeKind === "responses-proxy" || routeKind === "responses-direct") return "Responses";
   if (routeKind === "image-generation") return "image generation";
+  if (routeKind === "image-edit") return "image editing";
   return "request";
 }
 

--- a/scripts/verify-extension-loader.mjs
+++ b/scripts/verify-extension-loader.mjs
@@ -22,6 +22,7 @@ try {
   assert.equal(result.extensions.length, 1, "real Pi loader should load exactly one extension");
   const loaded = result.extensions[0];
   assert.ok(loaded.tools.has("xai_generate_text"), "representative xAI tool should be registered");
+  assert.ok(loaded.tools.has("xai_edit_image"), "bounded xAI image-edit tool should be registered");
   assert.ok(loaded.tools.has("Grep"), "representative Cursor shim should be registered");
   assert.ok(loaded.commands.has("xai-tools"), "/xai-tools should be registered");
   assert.equal(runtime.pendingProviderRegistrations.length, 1, "one provider should be queued");

--- a/tests/fixtures/images.ts
+++ b/tests/fixtures/images.ts
@@ -1,0 +1,78 @@
+import { deflateSync } from "node:zlib";
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+function crc32(bytes: Buffer): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type: string, data: Buffer): Buffer {
+  const typeBytes = Buffer.from(type, "ascii");
+  const header = Buffer.alloc(8);
+  header.writeUInt32BE(data.length, 0);
+  typeBytes.copy(header, 4);
+  const checksum = Buffer.alloc(4);
+  checksum.writeUInt32BE(crc32(Buffer.concat([typeBytes, data])), 0);
+  return Buffer.concat([header, data, checksum]);
+}
+
+/** Return a fully decodable 1x1 PNG fixture. */
+export function tinyPngBytes(): Buffer {
+  return Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+    "base64",
+  );
+}
+
+/** Return a header-only PNG fixture for byte/dimension parser tests. */
+export function pngHeaderBytes(width: number, height: number): Buffer {
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(width, 0);
+  header.writeUInt32BE(height, 4);
+  header[8] = 8;
+  header[9] = 2;
+  return Buffer.concat([PNG_SIGNATURE, pngChunk("IHDR", header)]);
+}
+
+/** Return a header-only baseline JPEG fixture for byte/dimension parser tests. */
+export function jpegHeaderBytes(width: number, height: number): Buffer {
+  const frame = Buffer.alloc(17);
+  frame.writeUInt16BE(17, 0);
+  frame[2] = 8;
+  frame.writeUInt16BE(height, 3);
+  frame.writeUInt16BE(width, 5);
+  frame[7] = 3;
+  return Buffer.concat([Buffer.from([0xff, 0xd8, 0xff, 0xc0]), frame, Buffer.from([0xff, 0xd9])]);
+}
+
+/** Return a deterministic high-entropy RGB PNG that exercises real compression. */
+export function noisePngBytes(width: number, height: number): Buffer {
+  const rows = Buffer.alloc((width * 3 + 1) * height);
+  let state = 0x12345678;
+  for (let y = 0; y < height; y += 1) {
+    const rowStart = y * (width * 3 + 1);
+    rows[rowStart] = 0;
+    for (let x = 0; x < width * 3; x += 1) {
+      state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+      rows[rowStart + 1 + x] = state >>> 24;
+    }
+  }
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(width, 0);
+  header.writeUInt32BE(height, 4);
+  header[8] = 8;
+  header[9] = 2;
+  return Buffer.concat([
+    PNG_SIGNATURE,
+    pngChunk("IHDR", header),
+    pngChunk("IDAT", deflateSync(rows, { level: 0 })),
+    pngChunk("IEND", Buffer.alloc(0)),
+  ]);
+}

--- a/tests/images/image-edit-tool.test.ts
+++ b/tests/images/image-edit-tool.test.ts
@@ -1,0 +1,99 @@
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerCustomXaiTools } from "../../extensions/xai/tools/custom-tools";
+import { setXaiNetworkToolActive } from "../../extensions/xai/tools/model-scope";
+import { createExtensionHarness } from "../fixtures/extension-api";
+import { jsonResponse, requestBody } from "../fixtures/http";
+import { tinyPngBytes } from "../fixtures/images";
+import { authContext, TEST_MODEL } from "../fixtures/models";
+import { createTempDir } from "../fixtures/temp";
+
+describe("xai_edit_image tool adapter", () => {
+  let temp: Awaited<ReturnType<typeof createTempDir>>;
+  let workspace: string;
+  let sessions: string;
+  let harness: ReturnType<typeof createExtensionHarness>;
+  const png = tinyPngBytes();
+  const dataUrl = `data:image/png;base64,${png.toString("base64")}`;
+
+  beforeEach(async () => {
+    temp = await createTempDir("pi-xai-edit-tool-");
+    workspace = join(temp.path, "workspace");
+    sessions = join(temp.path, "sessions");
+    await Promise.all([mkdir(workspace), mkdir(sessions)]);
+    harness = createExtensionHarness();
+    registerCustomXaiTools(harness.api);
+    setXaiNetworkToolActive(harness.api, TEST_MODEL, "xai_edit_image", true);
+  });
+  afterEach(async () => temp.cleanup());
+
+  function context() {
+    return {
+      ...authContext(),
+      cwd: workspace,
+      sessionManager: {
+        getSessionDir: () => sessions,
+        getSessionId: () => "tool-adapter-session",
+      },
+    };
+  }
+
+  it("runs the enabled tool end to end and returns safe saved-file metadata", async () => {
+    let body: any;
+    vi.stubGlobal("fetch", vi.fn(async (_url: any, init: RequestInit = {}) => {
+      body = requestBody(init);
+      return jsonResponse({ data: [{ b64_json: png.toString("base64") }] });
+    }));
+    const result = await harness.tools.get("xai_edit_image").execute(
+      "call",
+      { prompt: "make it blue", image: [{ data_url: dataUrl }] },
+      undefined,
+      () => {},
+      context(),
+    );
+    expect(body).toMatchObject({ n: 1, image: { url: dataUrl } });
+    expect(result.content[0].text).toMatch(/Edited image saved/);
+    expect(result.details).toMatchObject({ mimeType: "image/png", width: 1, height: 1 });
+    expect(result.details).not.toHaveProperty("base64");
+  });
+
+  it("rejects invalid input before credential or filesystem context lookup", async () => {
+    let credentialReads = 0;
+    const result = await harness.tools.get("xai_edit_image").execute(
+      "call",
+      { prompt: "edit", image: [{ path: "https://example.test/a.png" }] },
+      undefined,
+      () => {},
+      {
+        model: TEST_MODEL,
+        get modelRegistry() {
+          credentialReads += 1;
+          throw new Error("must not resolve");
+        },
+        get cwd() {
+          throw new Error("must not inspect filesystem context");
+        },
+      },
+    );
+    expect(result.content[0].text).toMatch(/do not accept URL schemes/);
+    expect(credentialReads).toBe(0);
+  });
+
+  it("returns redacted HTTP errors without reflecting prompt, data URL, or token", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse({
+      error: `oauth-token dangerous prompt ${dataUrl}`,
+    }, 429)));
+    const result = await harness.tools.get("xai_edit_image").execute(
+      "call",
+      { prompt: "dangerous prompt", image: [{ data_url: dataUrl }] },
+      undefined,
+      () => {},
+      context(),
+    );
+    expect(result.content[0].text).toMatch(/HTTP 429/);
+    expect(JSON.stringify(result)).not.toContain("oauth-token");
+    expect(JSON.stringify(result)).not.toContain("dangerous prompt");
+    expect(JSON.stringify(result)).not.toContain(dataUrl);
+  });
+});

--- a/tests/images/image-edit-tool.test.ts
+++ b/tests/images/image-edit-tool.test.ts
@@ -80,6 +80,62 @@ describe("xai_edit_image tool adapter", () => {
     expect(credentialReads).toBe(0);
   });
 
+  it("rejects four references before credentials, filesystem context, or network", async () => {
+    let credentialReads = 0;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const result = await harness.tools.get("xai_edit_image").execute(
+      "call",
+      {
+        prompt: "edit",
+        image: Array.from({ length: 4 }, () => ({ data_url: dataUrl })),
+        aspect_ratio: "1:1",
+      },
+      undefined,
+      () => {},
+      {
+        model: TEST_MODEL,
+        get modelRegistry() {
+          credentialReads += 1;
+          throw new Error("must not resolve");
+        },
+        get cwd() {
+          throw new Error("must not inspect filesystem context");
+        },
+        get sessionManager() {
+          throw new Error("must not inspect session storage");
+        },
+      },
+    );
+    expect(result.content[0].text).toMatch(/1-3 references/);
+    expect(credentialReads).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("runs under an authenticated text-only active Responses model", async () => {
+    const textOnlyModel = { ...TEST_MODEL, id: "text-only-edit-host", input: ["text"] };
+    setXaiNetworkToolActive(harness.api, textOnlyModel as any, "xai_edit_image", true);
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ data: [{ b64_json: png.toString("base64") }] }));
+    vi.stubGlobal("fetch", fetchMock);
+    const result = await harness.tools.get("xai_edit_image").execute(
+      "call",
+      { prompt: "make it blue", image: [{ data_url: dataUrl }] },
+      undefined,
+      () => {},
+      {
+        ...authContext(textOnlyModel),
+        cwd: workspace,
+        sessionManager: {
+          getSessionDir: () => sessions,
+          getSessionId: () => "text-only-tool-adapter-session",
+        },
+      },
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.content[0].text).toMatch(/Edited image saved/);
+  });
+
   it("returns redacted HTTP errors without reflecting prompt, data URL, or token", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => jsonResponse({
       error: `oauth-token dangerous prompt ${dataUrl}`,

--- a/tests/images/image-edit.test.ts
+++ b/tests/images/image-edit.test.ts
@@ -1,0 +1,248 @@
+import { lstat, mkdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildXaiImageEditPayload,
+  executeXaiImageEdit,
+  ImageEditOperationError,
+  validateXaiEditImageInput,
+  type ImageEditDependencies,
+  type XaiEditImageInput,
+} from "../../extensions/xai/image-edit";
+import type { ImageCodec } from "../../extensions/xai/media/compression";
+import {
+  IMAGE_EDIT_MAX_OUTPUT_BYTES,
+  IMAGE_EDIT_MAX_OUTPUT_PIXELS,
+} from "../../extensions/xai/media/constants";
+import { imageEditOutputRoot } from "../../extensions/xai/media/output-storage";
+import { createTempDir } from "../fixtures/temp";
+import { jsonResponse, requestBody } from "../fixtures/http";
+import { pngHeaderBytes, tinyPngBytes } from "../fixtures/images";
+
+const png = tinyPngBytes();
+const dataUrl = `data:image/png;base64,${png.toString("base64")}`;
+const codec: ImageCodec = {
+  verify: vi.fn(async (image) => ({ width: image.width, height: image.height })),
+  compress: vi.fn(async () => null),
+};
+
+describe("image-edit validation and wire payload", () => {
+  it("validates bounded prompt, reference shape/count, schemes, and multi-image ratio", () => {
+    expect(validateXaiEditImageInput({ prompt: "edit", image: [{ data_url: dataUrl }] })).toMatchObject({
+      prompt: "edit",
+    });
+    expect(validateXaiEditImageInput({
+      prompt: "edit",
+      image: [{ path: "C:\\workspace\\image.png" }],
+    })).toMatchObject({ image: [{ path: "C:\\workspace\\image.png" }] });
+    for (const input of [
+      {},
+      { prompt: " ", image: [{ data_url: dataUrl }] },
+      { prompt: "edit", image: [] },
+      { prompt: "edit", image: Array.from({ length: 5 }, () => ({ data_url: dataUrl })) },
+      { prompt: "edit", image: [{ path: "a", data_url: dataUrl }] },
+      { prompt: "edit", image: [{ path: "https://example.test/a.png" }] },
+      { prompt: "edit", image: [{ path: "file:///tmp/a.png" }] },
+      { prompt: "edit", image: [{ data_url: dataUrl }, { data_url: dataUrl }] },
+      { prompt: "edit", image: [{ data_url: dataUrl }, { data_url: dataUrl }], aspect_ratio: "bad" },
+    ]) {
+      expect(() => validateXaiEditImageInput(input)).toThrow(ImageEditOperationError);
+    }
+  });
+
+  it("builds the exact singular body and omits aspect_ratio even when supplied", () => {
+    const input = validateXaiEditImageInput({
+      prompt: "edit",
+      image: [{ data_url: dataUrl }],
+      aspect_ratio: "16:9",
+    });
+    expect(buildXaiImageEditPayload(input, [{
+      dataUrl,
+      mimeType: "image/png",
+      byteLength: png.length,
+      width: 1,
+      height: 1,
+      wasCompressed: false,
+    }])).toEqual({
+      model: "grok-imagine-image-quality",
+      prompt: "edit",
+      n: 1,
+      resolution: "1k",
+      response_format: "b64_json",
+      image: { url: dataUrl },
+    });
+  });
+
+  it("builds the exact plural body with a validated aspect ratio", () => {
+    const input = validateXaiEditImageInput({
+      prompt: "combine",
+      image: [{ data_url: dataUrl }, { data_url: dataUrl }],
+      aspect_ratio: "4:3",
+    });
+    const reference = { dataUrl, mimeType: "image/png" as const, byteLength: png.length, width: 1, height: 1, wasCompressed: false };
+    expect(buildXaiImageEditPayload(input, [reference, reference])).toEqual({
+      model: "grok-imagine-image-quality",
+      prompt: "combine",
+      n: 1,
+      resolution: "1k",
+      response_format: "b64_json",
+      images: [{ url: dataUrl }, { url: dataUrl }],
+      aspect_ratio: "4:3",
+    });
+  });
+});
+
+describe("bounded xAI image-edit execution", () => {
+  let temp: Awaited<ReturnType<typeof createTempDir>>;
+  let workspaceRoot: string;
+  let sessionRoot: string;
+  let requests: Array<{ url: string; init: RequestInit; body: any }>;
+  const sessionManager = () => ({ getSessionDir: () => sessionRoot, getSessionId: () => "image-edit-session" });
+  const input = (): XaiEditImageInput => ({ prompt: "make it blue", image: [{ data_url: dataUrl }] });
+
+  beforeEach(async () => {
+    temp = await createTempDir("pi-xai-image-edit-");
+    workspaceRoot = join(temp.path, "workspace");
+    sessionRoot = join(temp.path, "sessions");
+    await Promise.all([mkdir(workspaceRoot), mkdir(sessionRoot)]);
+    requests = [];
+  });
+  afterEach(async () => temp.cleanup());
+
+  function dependencies(response: Response = jsonResponse({ data: [{ b64_json: png.toString("base64") }] })): ImageEditDependencies {
+    return {
+      codec,
+      fetch: vi.fn(async (url: any, init: RequestInit = {}) => {
+        requests.push({ url: String(url), init, body: requestBody(init) });
+        return response;
+      }),
+    };
+  }
+
+  it("posts only to the pinned edit route and atomically saves one verified output", async () => {
+    const output = await executeXaiImageEdit({
+      credential: { kind: "oauth-session", token: "secret-token" },
+      input: input(),
+      workspaceRoot,
+      sessionManager: sessionManager(),
+    }, dependencies());
+    expect(requests).toHaveLength(1);
+    expect(requests[0].url).toBe("https://api.x.ai/v1/images/edits");
+    expect(requests[0].init.redirect).toBe("error");
+    expect(new Headers(requests[0].init.headers).get("Authorization")).toBe("Bearer secret-token");
+    expect(requests[0].body).toMatchObject({
+      model: "grok-imagine-image-quality",
+      n: 1,
+      response_format: "b64_json",
+      image: { url: dataUrl },
+    });
+    expect(requests[0].body).not.toHaveProperty("images");
+    expect(requests[0].body).not.toHaveProperty("aspect_ratio");
+    expect(output).toMatchObject({ mimeType: "image/png", width: 1, height: 1, byteLength: png.length });
+    expect((await lstat(output.path)).mode & 0o777).toBe(0o600);
+  });
+
+  it("preserves caller cancellation and performs no output save", async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.fn((_url: any, init: RequestInit = {}) => new Promise<Response>((_resolve, reject) => {
+      init.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), { once: true });
+    }));
+    const pending = executeXaiImageEdit({
+      credential: { kind: "oauth-session", token: "token" },
+      input: input(),
+      workspaceRoot,
+      sessionManager: sessionManager(),
+      signal: controller.signal,
+    }, { codec, fetch: fetchMock });
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ code: "cancelled" });
+    await expect(lstat(imageEditOutputRoot(sessionManager()))).rejects.toThrow();
+  });
+
+  it("aborts a timed-out request", async () => {
+    let requestSignal: AbortSignal | undefined;
+    const fetchMock = vi.fn((_url: any, init: RequestInit = {}) => new Promise<Response>((_resolve, reject) => {
+      requestSignal = init.signal as AbortSignal;
+      init.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), { once: true });
+    }));
+    await expect(executeXaiImageEdit({
+      credential: { kind: "oauth-session", token: "token" },
+      input: input(),
+      workspaceRoot,
+      sessionManager: sessionManager(),
+    }, { codec, fetch: fetchMock, requestTimeoutMs: 5 })).rejects.toMatchObject({ code: "timeout" });
+    expect(requestSignal?.aborted).toBe(true);
+  });
+
+  it("redacts hostile HTTP bodies, prompt, source data, and bearer", async () => {
+    const hostile = `secret-token make it blue ${dataUrl}`;
+    const error = await executeXaiImageEdit({
+      credential: { kind: "oauth-session", token: "secret-token" },
+      input: input(),
+      workspaceRoot,
+      sessionManager: sessionManager(),
+    }, dependencies(jsonResponse({ error: hostile }, 400, { "x-request-id": "safe-id" }))).catch((value) => value);
+    expect(error).toMatchObject({ code: "http_failure", status: 400 });
+    expect(String(error)).toContain("safe-id");
+    expect(String(error)).not.toContain("secret-token");
+    expect(String(error)).not.toContain("make it blue");
+    expect(String(error)).not.toContain(dataUrl);
+  });
+
+  it("rejects oversized response JSON before parsing", async () => {
+    await expect(executeXaiImageEdit({
+      credential: { kind: "oauth-session", token: "token" },
+      input: input(),
+      workspaceRoot,
+      sessionManager: sessionManager(),
+    }, {
+      ...dependencies(new Response("x".repeat(65), { status: 200 })),
+      responseMaxBytes: 64,
+    })).rejects.toMatchObject({ code: "invalid_response" });
+  });
+
+  it("verifies and persists a real JPEG response with the matching extension", async () => {
+    const jpeg = await readFile("preview.jpeg");
+    const fetchMock = vi.fn(async () => jsonResponse({
+      data: [{ b64_json: jpeg.toString("base64") }],
+    }));
+    const output = await executeXaiImageEdit({
+      credential: { kind: "oauth-session", token: "token" },
+      input: input(),
+      workspaceRoot,
+      sessionManager: sessionManager(),
+    }, { fetch: fetchMock });
+    expect(output).toMatchObject({
+      mimeType: "image/jpeg",
+      width: 1672,
+      height: 941,
+      byteLength: jpeg.length,
+    });
+    expect(output.path).toMatch(/\.jpg$/);
+  });
+
+  it.each([
+    ["missing data", {}],
+    ["empty data", { data: [] }],
+    ["multiple data", { data: [{ b64_json: png.toString("base64") }, { b64_json: png.toString("base64") }] }],
+    ["URL-only output", { data: [{ url: "https://example.test/image.png" }] }],
+    ["malformed base64", { data: [{ b64_json: "%%%%" }] }],
+    ["unsupported MIME", { data: [{ b64_json: Buffer.from("GIF89a").toString("base64") }] }],
+    ["oversized dimensions", { data: [{ b64_json: pngHeaderBytes(4097, 1).toString("base64") }] }],
+    [
+      "oversized pixels",
+      { data: [{ b64_json: pngHeaderBytes(4000, Math.floor(IMAGE_EDIT_MAX_OUTPUT_PIXELS / 4000) + 1).toString("base64") }] },
+    ],
+    [
+      "oversized decoded bytes",
+      { data: [{ b64_json: Buffer.concat([png, Buffer.alloc(IMAGE_EDIT_MAX_OUTPUT_BYTES)]).toString("base64") }] },
+    ],
+  ])("rejects %s without saving", async (_label, body) => {
+    await expect(executeXaiImageEdit({
+      credential: { kind: "oauth-session", token: "token" },
+      input: input(),
+      workspaceRoot,
+      sessionManager: sessionManager(),
+    }, dependencies(jsonResponse(body)))).rejects.toMatchObject({ code: "invalid_response" });
+  });
+});

--- a/tests/images/image-edit.test.ts
+++ b/tests/images/image-edit.test.ts
@@ -1,6 +1,7 @@
 import { lstat, mkdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { XAI_USER_AGENT } from "../../extensions/xai/constants";
 import {
   buildXaiImageEditPayload,
   executeXaiImageEdit,
@@ -13,8 +14,11 @@ import type { ImageCodec } from "../../extensions/xai/media/compression";
 import {
   IMAGE_EDIT_MAX_OUTPUT_BYTES,
   IMAGE_EDIT_MAX_OUTPUT_PIXELS,
+  IMAGE_EDIT_MAX_REQUEST_JSON_BYTES,
+  MEDIA_REFERENCE_PASSTHROUGH_MAX_BYTES,
 } from "../../extensions/xai/media/constants";
 import { imageEditOutputRoot } from "../../extensions/xai/media/output-storage";
+import { xaiHttpErrorFromResponse } from "../../extensions/xai/wire";
 import { createTempDir } from "../fixtures/temp";
 import { jsonResponse, requestBody } from "../fixtures/http";
 import { pngHeaderBytes, tinyPngBytes } from "../fixtures/images";
@@ -39,10 +43,12 @@ describe("image-edit validation and wire payload", () => {
       {},
       { prompt: " ", image: [{ data_url: dataUrl }] },
       { prompt: "edit", image: [] },
-      { prompt: "edit", image: Array.from({ length: 5 }, () => ({ data_url: dataUrl })) },
+      { prompt: "edit", image: Array.from({ length: 4 }, () => ({ data_url: dataUrl })) },
       { prompt: "edit", image: [{ path: "a", data_url: dataUrl }] },
       { prompt: "edit", image: [{ path: "https://example.test/a.png" }] },
       { prompt: "edit", image: [{ path: "file:///tmp/a.png" }] },
+      { prompt: "edit", image: [{ data_url: dataUrl }], aspect_ratio: "bad" },
+      { prompt: "edit", image: [{ data_url: dataUrl }], aspect_ratio: 1 },
       { prompt: "edit", image: [{ data_url: dataUrl }, { data_url: dataUrl }] },
       { prompt: "edit", image: [{ data_url: dataUrl }, { data_url: dataUrl }], aspect_ratio: "bad" },
     ]) {
@@ -90,6 +96,35 @@ describe("image-edit validation and wire payload", () => {
       aspect_ratio: "4:3",
     });
   });
+
+  it("accepts three references but rejects four", () => {
+    const three = Array.from({ length: 3 }, () => ({ data_url: dataUrl }));
+    expect(validateXaiEditImageInput({
+      prompt: "combine",
+      image: three,
+      aspect_ratio: "1:1",
+    }).image).toHaveLength(3);
+    expect(() => validateXaiEditImageInput({
+      prompt: "combine",
+      image: [...three, { data_url: dataUrl }],
+      aspect_ratio: "1:1",
+    })).toThrow(/1-3 references/);
+  });
+
+  it("rejects an oversized serialized request before transport", () => {
+    const input = validateXaiEditImageInput({
+      prompt: "edit",
+      image: [{ data_url: dataUrl }],
+    });
+    expect(() => buildXaiImageEditPayload(input, [{
+      dataUrl: `data:image/png;base64,${"A".repeat(IMAGE_EDIT_MAX_REQUEST_JSON_BYTES)}`,
+      mimeType: "image/png",
+      byteLength: 1,
+      width: 1,
+      height: 1,
+      wasCompressed: false,
+    }])).toThrow(/aggregate request-byte limit/);
+  });
 });
 
 describe("bounded xAI image-edit execution", () => {
@@ -119,28 +154,48 @@ describe("bounded xAI image-edit execution", () => {
     };
   }
 
-  it("posts only to the pinned edit route and atomically saves one verified output", async () => {
-    const output = await executeXaiImageEdit({
-      credential: { kind: "oauth-session", token: "secret-token" },
-      input: input(),
-      workspaceRoot,
-      sessionManager: sessionManager(),
-    }, dependencies());
-    expect(requests).toHaveLength(1);
-    expect(requests[0].url).toBe("https://api.x.ai/v1/images/edits");
-    expect(requests[0].init.redirect).toBe("error");
-    expect(new Headers(requests[0].init.headers).get("Authorization")).toBe("Bearer secret-token");
-    expect(requests[0].body).toMatchObject({
-      model: "grok-imagine-image-quality",
-      n: 1,
-      response_format: "b64_json",
-      image: { url: dataUrl },
-    });
-    expect(requests[0].body).not.toHaveProperty("images");
-    expect(requests[0].body).not.toHaveProperty("aspect_ratio");
-    expect(output).toMatchObject({ mimeType: "image/png", width: 1, height: 1, byteLength: png.length });
-    expect((await lstat(output.path)).mode & 0o777).toBe(0o600);
-  });
+  it.each(["oauth-session", "api-key"] as const)(
+    "posts %s only to the pinned edit route with protected direct-media headers",
+    async (kind) => {
+      const output = await executeXaiImageEdit({
+        credential: { kind, token: "secret-token" },
+        input: input(),
+        workspaceRoot,
+        sessionManager: sessionManager(),
+      }, dependencies());
+      expect(requests).toHaveLength(1);
+      expect(requests[0].url).toBe("https://api.x.ai/v1/images/edits");
+      expect(requests[0].init.redirect).toBe("error");
+      const headers = new Headers(requests[0].init.headers);
+      expect(headers.get("Accept")).toBe("application/json");
+      expect(headers.get("Content-Type")).toBe("application/json");
+      expect(headers.get("Authorization")).toBe("Bearer secret-token");
+      expect(headers.get("User-Agent")).toBe(XAI_USER_AGENT);
+      for (const name of [
+        "x-authenticateresponse",
+        "x-grok-client-identifier",
+        "x-grok-client-mode",
+        "x-grok-client-version",
+        "x-grok-conv-id",
+        "x-grok-model-override",
+        "x-grok-req-id",
+        "x-grok-session-id",
+        "x-xai-token-auth",
+      ]) {
+        expect(headers.get(name)).toBeNull();
+      }
+      expect(requests[0].body).toMatchObject({
+        model: "grok-imagine-image-quality",
+        n: 1,
+        response_format: "b64_json",
+        image: { url: dataUrl },
+      });
+      expect(requests[0].body).not.toHaveProperty("images");
+      expect(requests[0].body).not.toHaveProperty("aspect_ratio");
+      expect(output).toMatchObject({ mimeType: "image/png", width: 1, height: 1, byteLength: png.length });
+      expect((await lstat(output.path)).mode & 0o777).toBe(0o600);
+    },
+  );
 
   it("preserves caller cancellation and performs no output save", async () => {
     const controller = new AbortController();
@@ -159,6 +214,35 @@ describe("bounded xAI image-edit execution", () => {
     await expect(lstat(imageEditOutputRoot(sessionManager()))).rejects.toThrow();
   });
 
+  it("rejects pre-cancellation before session, codec, filesystem, or network access", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const session = {
+      getSessionDir: vi.fn(() => {
+        throw new Error("must not inspect session storage");
+      }),
+      getSessionId: vi.fn(() => {
+        throw new Error("must not inspect session storage");
+      }),
+    };
+    const verify = vi.fn();
+    const fetchMock = vi.fn();
+    await expect(executeXaiImageEdit({
+      credential: { kind: "oauth-session", token: "token" },
+      input: input(),
+      workspaceRoot,
+      sessionManager: session,
+      signal: controller.signal,
+    }, {
+      codec: { verify, compress: vi.fn() },
+      fetch: fetchMock,
+    })).rejects.toMatchObject({ code: "cancelled" });
+    expect(session.getSessionDir).not.toHaveBeenCalled();
+    expect(session.getSessionId).not.toHaveBeenCalled();
+    expect(verify).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("aborts a timed-out request", async () => {
     let requestSignal: AbortSignal | undefined;
     const fetchMock = vi.fn((_url: any, init: RequestInit = {}) => new Promise<Response>((_resolve, reject) => {
@@ -174,6 +258,37 @@ describe("bounded xAI image-edit execution", () => {
     expect(requestSignal?.aborted).toBe(true);
   });
 
+  it("times out a stalled successful response body", async () => {
+    const stalled = new ReadableStream<Uint8Array>({
+      start() {},
+    });
+    await expect(executeXaiImageEdit({
+      credential: { kind: "oauth-session", token: "token" },
+      input: input(),
+      workspaceRoot,
+      sessionManager: sessionManager(),
+    }, {
+      ...dependencies(new Response(stalled, { status: 200 })),
+      requestTimeoutMs: 5,
+    })).rejects.toMatchObject({ code: "timeout" });
+  });
+
+  it("cancels a stalled successful response body", async () => {
+    const controller = new AbortController();
+    const stalled = new ReadableStream<Uint8Array>({
+      start() {},
+    });
+    const pending = executeXaiImageEdit({
+      credential: { kind: "oauth-session", token: "token" },
+      input: input(),
+      workspaceRoot,
+      sessionManager: sessionManager(),
+      signal: controller.signal,
+    }, dependencies(new Response(stalled, { status: 200 })));
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ code: "cancelled" });
+  });
+
   it("redacts hostile HTTP bodies, prompt, source data, and bearer", async () => {
     const hostile = `secret-token make it blue ${dataUrl}`;
     const error = await executeXaiImageEdit({
@@ -187,6 +302,78 @@ describe("bounded xAI image-edit execution", () => {
     expect(String(error)).not.toContain("secret-token");
     expect(String(error)).not.toContain("make it blue");
     expect(String(error)).not.toContain(dataUrl);
+  });
+
+  it("does not reflect a non-allowlisted upstream request ID", async () => {
+    const hostileId = "unsafe request id SECRET";
+    const error = await executeXaiImageEdit({
+      credential: { kind: "oauth-session", token: "token" },
+      input: input(),
+      workspaceRoot,
+      sessionManager: sessionManager(),
+    }, dependencies(jsonResponse({}, 500, { "x-request-id": hostileId }))).catch((value) => value);
+    expect(error).toMatchObject({ code: "http_failure", status: 500 });
+    expect(String(error)).not.toContain(hostileId);
+    expect(String(error)).not.toContain("Request ID:");
+  });
+
+  it("classifies the pinned edit route without reflecting its error body", async () => {
+    const error = await xaiHttpErrorFromResponse(
+      new Response("HOSTILE_EDIT_ERROR", { status: 422 }),
+      "https://api.x.ai/v1/images/edits",
+    );
+    expect(error).toMatchObject({ status: 422, routeKind: "image-edit" });
+    expect(error.message).toBe("xAI API error: image editing failed with status 422");
+    expect(error.message).not.toContain("HOSTILE_EDIT_ERROR");
+  });
+
+  it("redacts arbitrary codec verification failures", async () => {
+    const hostileCodec: ImageCodec = {
+      verify: vi.fn(async () => {
+        throw new Error(`CODEC_SECRET ${dataUrl}`);
+      }),
+      compress: vi.fn(async () => null),
+    };
+    const error = await executeXaiImageEdit({
+      credential: { kind: "oauth-session", token: "token" },
+      input: input(),
+      workspaceRoot,
+      sessionManager: sessionManager(),
+    }, {
+      ...dependencies(),
+      codec: hostileCodec,
+    }).catch((value) => value);
+    expect(error).toMatchObject({ code: "invalid_input" });
+    expect(String(error)).toContain("could not be verified or compressed safely");
+    expect(String(error)).not.toMatch(/CODEC_SECRET|data:image/);
+    expect(requests).toHaveLength(0);
+  });
+
+  it("redacts arbitrary codec compression failures", async () => {
+    const source = Buffer.concat([
+      pngHeaderBytes(100, 100),
+      Buffer.alloc(MEDIA_REFERENCE_PASSTHROUGH_MAX_BYTES),
+    ]);
+    const sourceUrl = `data:image/png;base64,${source.toString("base64")}`;
+    const hostileCodec: ImageCodec = {
+      verify: vi.fn(async (image) => ({ width: image.width, height: image.height })),
+      compress: vi.fn(async () => {
+        throw new Error(`COMPRESSION_SECRET ${sourceUrl}`);
+      }),
+    };
+    const error = await executeXaiImageEdit({
+      credential: { kind: "oauth-session", token: "token" },
+      input: { prompt: "edit", image: [{ data_url: sourceUrl }] },
+      workspaceRoot,
+      sessionManager: sessionManager(),
+    }, {
+      ...dependencies(),
+      codec: hostileCodec,
+    }).catch((value) => value);
+    expect(error).toMatchObject({ code: "invalid_input" });
+    expect(String(error)).toContain("could not be verified or compressed safely");
+    expect(String(error)).not.toMatch(/COMPRESSION_SECRET|data:image/);
+    expect(requests).toHaveLength(0);
   });
 
   it("rejects oversized response JSON before parsing", async () => {
@@ -219,6 +406,28 @@ describe("bounded xAI image-edit execution", () => {
       byteLength: jpeg.length,
     });
     expect(output.path).toMatch(/\.jpg$/);
+  });
+
+  it.each([
+    ["decoded side", { width: 4_097, height: 1 }],
+    ["decoded pixels", { width: 4_000, height: Math.floor(IMAGE_EDIT_MAX_OUTPUT_PIXELS / 4_000) + 1 }],
+  ])("reapplies the %s limit after codec verification", async (_label, decoded) => {
+    const decodedCodec: ImageCodec = {
+      verify: vi.fn(async (image) => image.source === "output"
+        ? decoded
+        : { width: image.width, height: image.height }),
+      compress: vi.fn(async () => null),
+    };
+    await expect(executeXaiImageEdit({
+      credential: { kind: "oauth-session", token: "token" },
+      input: input(),
+      workspaceRoot,
+      sessionManager: sessionManager(),
+    }, {
+      ...dependencies(),
+      codec: decodedCodec,
+    })).rejects.toMatchObject({ code: "invalid_response" });
+    await expect(lstat(imageEditOutputRoot(sessionManager()))).rejects.toThrow();
   });
 
   it.each([

--- a/tests/media/compression-storage.test.ts
+++ b/tests/media/compression-storage.test.ts
@@ -29,6 +29,16 @@ function fakeCodec(compressed = image(pngHeaderBytes(512, 512), 512, 512)): Imag
   };
 }
 
+function abortSignalOnRead(readNumber: number): AbortSignal {
+  let reads = 0;
+  return {
+    get aborted() {
+      reads += 1;
+      return reads >= readNumber;
+    },
+  } as AbortSignal;
+}
+
 describe("bounded reference compression", () => {
   it("decode-verifies but preserves sub-400 KiB PNG bytes", async () => {
     const codec = fakeCodec();
@@ -75,14 +85,18 @@ describe("bounded reference compression", () => {
     await expect(prepareImageReferences([large], { codec: fakeCodec(image(pngHeaderBytes(200, 200), 200, 200)) })).rejects.toThrow(/floor/);
   });
 
-  it("enforces a package-owned aggregate budget below four maximum-sized references", async () => {
-    const bytes = Buffer.concat([pngHeaderBytes(10, 10), Buffer.alloc(350 * 1024)]);
-    expect(bytes.length).toBeLessThan(MEDIA_REFERENCE_PASSTHROUGH_MAX_BYTES);
-    expect(bytes.length * 4).toBeGreaterThan(IMAGE_EDIT_MAX_AGGREGATE_REFERENCE_BYTES);
+  it("accepts exactly the package-owned aggregate boundary for three references", async () => {
+    const header = pngHeaderBytes(10, 10);
+    const bytes = Buffer.concat([
+      header,
+      Buffer.alloc(MEDIA_REFERENCE_PASSTHROUGH_MAX_BYTES - header.length),
+    ]);
+    expect(bytes.length * 3).toBe(IMAGE_EDIT_MAX_AGGREGATE_REFERENCE_BYTES);
     const source = image(bytes, 10, 10);
-    await expect(
-      prepareImageReferences([source, source, source, source], { codec: fakeCodec() }),
-    ).rejects.toThrow(/aggregate byte limit/);
+    await expect(prepareImageReferences(
+      [source, source, source],
+      { codec: fakeCodec() },
+    )).resolves.toHaveLength(3);
   });
 
   it("decode-verifies a real JPEG without changing under-budget bytes", async () => {
@@ -168,5 +182,18 @@ describe("atomic session image storage", () => {
       name: "AbortError",
     });
     await expect(lstat(outputRoot)).rejects.toThrow();
+  });
+
+  it.each([
+    ["temporary write", 3],
+    ["final rename", 4],
+  ])("removes all output when cancellation follows %s", async (_stage, abortRead) => {
+    const outputRoot = imageEditOutputRoot(manager());
+    await expect(saveVerifiedOutputImage(image(), {
+      outputRoot,
+      sessionRoot,
+      signal: abortSignalOnRead(abortRead),
+    })).rejects.toMatchObject({ name: "AbortError" });
+    expect(await readdir(outputRoot)).toEqual([]);
   });
 });

--- a/tests/media/compression-storage.test.ts
+++ b/tests/media/compression-storage.test.ts
@@ -1,0 +1,172 @@
+import { lstat, mkdir, readFile, readdir, symlink } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  defaultImageCodec,
+  prepareImageReferences,
+  type ImageCodec,
+} from "../../extensions/xai/media/compression";
+import {
+  IMAGE_EDIT_MAX_AGGREGATE_REFERENCE_BYTES,
+  MEDIA_REFERENCE_COMPRESS_MAX_SIDE_PX,
+  MEDIA_REFERENCE_COMPRESS_MIN_SIDE_PX,
+  MEDIA_REFERENCE_PASSTHROUGH_MAX_BYTES,
+  MEDIA_REFERENCE_QUALITY_STEPS,
+} from "../../extensions/xai/media/constants";
+import { imageEditOutputRoot, saveVerifiedOutputImage } from "../../extensions/xai/media/output-storage";
+import type { VerifiedImageBytes } from "../../extensions/xai/media/types";
+import { createTempDir } from "../fixtures/temp";
+import { noisePngBytes, pngHeaderBytes, tinyPngBytes } from "../fixtures/images";
+
+function image(bytes = tinyPngBytes(), width = 1, height = 1): VerifiedImageBytes {
+  return { bytes, mimeType: "image/png", width, height, source: "data-url" };
+}
+
+function fakeCodec(compressed = image(pngHeaderBytes(512, 512), 512, 512)): ImageCodec {
+  return {
+    verify: vi.fn(async (input) => ({ width: input.width, height: input.height })),
+    compress: vi.fn(async () => compressed),
+  };
+}
+
+describe("bounded reference compression", () => {
+  it("decode-verifies but preserves sub-400 KiB PNG bytes", async () => {
+    const codec = fakeCodec();
+    const source = image();
+    const [prepared] = await prepareImageReferences([source], { codec });
+    expect(codec.verify).toHaveBeenCalledOnce();
+    expect(codec.compress).not.toHaveBeenCalled();
+    expect(Buffer.from(prepared.dataUrl.split(",")[1], "base64")).toEqual(source.bytes);
+    expect(prepared.wasCompressed).toBe(false);
+  });
+
+  it("uses the source-backed 400 KiB, 768px, 256px, and quality-step policy", async () => {
+    const sourceBytes = Buffer.concat([
+      pngHeaderBytes(1200, 900),
+      Buffer.alloc(MEDIA_REFERENCE_PASSTHROUGH_MAX_BYTES),
+    ]);
+    const codec = fakeCodec();
+    const [prepared] = await prepareImageReferences([image(sourceBytes, 1200, 900)], { codec });
+    expect(codec.compress).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        maxSidePx: MEDIA_REFERENCE_COMPRESS_MAX_SIDE_PX,
+        minSidePx: MEDIA_REFERENCE_COMPRESS_MIN_SIDE_PX,
+        maxBytes: MEDIA_REFERENCE_PASSTHROUGH_MAX_BYTES,
+        qualitySteps: MEDIA_REFERENCE_QUALITY_STEPS,
+      },
+      undefined,
+    );
+    expect(prepared).toMatchObject({ wasCompressed: true, width: 512, height: 512 });
+  });
+
+  it("rejects count overflow, codec MIME spoofing, oversized output, dimension overflow, and floor collapse", async () => {
+    const small = image();
+    await expect(prepareImageReferences([small, small, small, small, small], { codec: fakeCodec() })).rejects.toThrow(/count/);
+
+    const large = image(Buffer.concat([pngHeaderBytes(900, 900), Buffer.alloc(MEDIA_REFERENCE_PASSTHROUGH_MAX_BYTES)]), 900, 900);
+    await expect(prepareImageReferences([large], {
+      codec: fakeCodec({ ...image(pngHeaderBytes(512, 512), 512, 512), mimeType: "image/jpeg", source: "compressed" }),
+    })).rejects.toThrow(/MIME/);
+    await expect(prepareImageReferences([large], {
+      codec: fakeCodec(image(Buffer.concat([pngHeaderBytes(512, 512), Buffer.alloc(MEDIA_REFERENCE_PASSTHROUGH_MAX_BYTES)]), 512, 512)),
+    })).rejects.toThrow(/Imagine limit/);
+    await expect(prepareImageReferences([large], { codec: fakeCodec(image(pngHeaderBytes(769, 500), 769, 500)) })).rejects.toThrow(/dimension/);
+    await expect(prepareImageReferences([large], { codec: fakeCodec(image(pngHeaderBytes(200, 200), 200, 200)) })).rejects.toThrow(/floor/);
+  });
+
+  it("enforces a package-owned aggregate budget below four maximum-sized references", async () => {
+    const bytes = Buffer.concat([pngHeaderBytes(10, 10), Buffer.alloc(350 * 1024)]);
+    expect(bytes.length).toBeLessThan(MEDIA_REFERENCE_PASSTHROUGH_MAX_BYTES);
+    expect(bytes.length * 4).toBeGreaterThan(IMAGE_EDIT_MAX_AGGREGATE_REFERENCE_BYTES);
+    const source = image(bytes, 10, 10);
+    await expect(
+      prepareImageReferences([source, source, source, source], { codec: fakeCodec() }),
+    ).rejects.toThrow(/aggregate byte limit/);
+  });
+
+  it("decode-verifies a real JPEG without changing under-budget bytes", async () => {
+    const bytes = await readFile("preview.jpeg");
+    const [prepared] = await prepareImageReferences([{
+      bytes,
+      mimeType: "image/jpeg",
+      width: 1672,
+      height: 941,
+      source: "workspace-path",
+    }], { codec: defaultImageCodec() });
+    expect(prepared).toMatchObject({
+      mimeType: "image/jpeg",
+      width: 1672,
+      height: 941,
+      wasCompressed: false,
+    });
+    expect(Buffer.from(prepared.dataUrl.split(",")[1], "base64")).toEqual(bytes);
+  });
+
+  it("compresses a real high-entropy PNG through Pi's worker codec", async () => {
+    const bytes = noisePngBytes(900, 900);
+    expect(bytes.length).toBeGreaterThan(MEDIA_REFERENCE_PASSTHROUGH_MAX_BYTES);
+    const [prepared] = await prepareImageReferences([image(bytes, 900, 900)], {
+      codec: defaultImageCodec(),
+    });
+    expect(prepared.wasCompressed).toBe(true);
+    expect(prepared.byteLength).toBeLessThanOrEqual(MEDIA_REFERENCE_PASSTHROUGH_MAX_BYTES);
+    expect(Math.max(prepared.width, prepared.height)).toBeLessThanOrEqual(768);
+    expect(Math.max(prepared.width, prepared.height)).toBeGreaterThanOrEqual(256);
+  }, 30_000);
+});
+
+describe("atomic session image storage", () => {
+  let temp: Awaited<ReturnType<typeof createTempDir>>;
+  let sessionRoot: string;
+  const manager = () => ({ getSessionDir: () => sessionRoot, getSessionId: () => "session-secret-id" });
+
+  beforeEach(async () => {
+    temp = await createTempDir("pi-xai-media-output-");
+    sessionRoot = join(temp.path, "sessions");
+    await mkdir(sessionRoot);
+  });
+  afterEach(async () => temp.cleanup());
+
+  it("derives a hashed session path and saves collision-free 0700/0600 files atomically", async () => {
+    const outputRoot = imageEditOutputRoot(manager());
+    expect(outputRoot).not.toContain("session-secret-id");
+    const first = await saveVerifiedOutputImage(image(), { outputRoot, sessionRoot });
+    const second = await saveVerifiedOutputImage(image(), { outputRoot, sessionRoot });
+    expect(first.path).not.toBe(second.path);
+    expect(first.path).toMatch(/\.png$/);
+    expect((await lstat(outputRoot)).mode & 0o777).toBe(0o700);
+    expect((await lstat(first.path)).mode & 0o777).toBe(0o600);
+    expect(await readdir(outputRoot)).toHaveLength(2);
+    expect((await readdir(outputRoot)).some((name) => name.endsWith(".tmp"))).toBe(false);
+  });
+
+  it("rejects preexisting output symlinks that escape session storage", async () => {
+    const outputRoot = imageEditOutputRoot(manager());
+    const outside = join(temp.path, "outside");
+    await mkdir(outside);
+    await mkdir(join(outputRoot, ".."), { recursive: true });
+    await symlink(outside, outputRoot);
+    await expect(saveVerifiedOutputImage(image(), { outputRoot, sessionRoot })).rejects.toThrow(/unsafe|outside/);
+    expect(await readdir(outside)).toEqual([]);
+  });
+
+  it("rejects an intermediate output symlink before mutating its target", async () => {
+    const outputRoot = imageEditOutputRoot(manager());
+    const outside = join(temp.path, "outside-intermediate");
+    await mkdir(outside);
+    await symlink(outside, join(sessionRoot, "pi-xai-oauth"));
+    await expect(saveVerifiedOutputImage(image(), { outputRoot, sessionRoot })).rejects.toThrow(/unsafe|outside/);
+    expect(await readdir(outside)).toEqual([]);
+  });
+
+  it("fails before creating output on pre-cancellation", async () => {
+    const outputRoot = imageEditOutputRoot(manager());
+    const controller = new AbortController();
+    controller.abort();
+    await expect(saveVerifiedOutputImage(image(), { outputRoot, sessionRoot, signal: controller.signal })).rejects.toMatchObject({
+      name: "AbortError",
+    });
+    await expect(lstat(outputRoot)).rejects.toThrow();
+  });
+});

--- a/tests/media/paths.test.ts
+++ b/tests/media/paths.test.ts
@@ -1,0 +1,68 @@
+import { mkdir, symlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readBoundedWorkspaceImageFile } from "../../extensions/xai/media/paths";
+import { createTempDir } from "../fixtures/temp";
+import { tinyPngBytes } from "../fixtures/images";
+
+describe("bounded workspace image reads", () => {
+  let temp: Awaited<ReturnType<typeof createTempDir>>;
+  let workspace: string;
+  let outside: string;
+
+  beforeEach(async () => {
+    temp = await createTempDir("pi-xai-media-paths-");
+    workspace = join(temp.path, "workspace");
+    outside = join(temp.path, "outside.png");
+    await mkdir(workspace);
+    await writeFile(join(workspace, "inside.png"), tinyPngBytes());
+    await writeFile(outside, tinyPngBytes());
+  });
+
+  afterEach(async () => temp.cleanup());
+
+  it("accepts relative and absolute regular files inside the real workspace", async () => {
+    await expect(readBoundedWorkspaceImageFile("inside.png", workspace)).resolves.toMatchObject({
+      mimeType: "image/png",
+      width: 1,
+      height: 1,
+    });
+    await expect(readBoundedWorkspaceImageFile(join(workspace, "inside.png"), workspace)).resolves.toMatchObject({
+      source: "workspace-path",
+    });
+  });
+
+  it("rejects lexical traversal, outside absolute paths, and outward symlinks without reflecting paths", async () => {
+    await symlink(outside, join(workspace, "escape.png"));
+    for (const value of ["../outside.png", outside, "escape.png"]) {
+      await expect(readBoundedWorkspaceImageFile(value, workspace)).rejects.toThrow(/outside the workspace/);
+      try {
+        await readBoundedWorkspaceImageFile(value, workspace);
+      } catch (error) {
+        expect(String(error)).not.toContain(outside);
+      }
+    }
+  });
+
+  it("rejects parent symlink traversal, directories, missing files, NULs, and unsupported bytes", async () => {
+    const externalDir = join(temp.path, "external");
+    await mkdir(externalDir);
+    await writeFile(join(externalDir, "image.png"), tinyPngBytes());
+    await symlink(externalDir, join(workspace, "linked"));
+    await writeFile(join(workspace, "fake.png"), Buffer.from("not an image"));
+
+    await expect(readBoundedWorkspaceImageFile("linked/image.png", workspace)).rejects.toThrow(/outside/);
+    await expect(readBoundedWorkspaceImageFile(".", workspace)).rejects.toThrow(/outside|regular/);
+    await expect(readBoundedWorkspaceImageFile("missing.png", workspace)).rejects.toThrow(/readable/);
+    await expect(readBoundedWorkspaceImageFile("bad\0.png", workspace)).rejects.toThrow(/invalid/);
+    await expect(readBoundedWorkspaceImageFile("fake.png", workspace)).rejects.toThrow(/PNG and JPEG/);
+  });
+
+  it("preserves cancellation before filesystem access", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(readBoundedWorkspaceImageFile("inside.png", workspace, controller.signal)).rejects.toMatchObject({
+      name: "AbortError",
+    });
+  });
+});

--- a/tests/media/paths.test.ts
+++ b/tests/media/paths.test.ts
@@ -1,9 +1,13 @@
+import { execFile } from "node:child_process";
 import { mkdir, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { readBoundedWorkspaceImageFile } from "../../extensions/xai/media/paths";
 import { createTempDir } from "../fixtures/temp";
 import { tinyPngBytes } from "../fixtures/images";
+
+const execFileAsync = promisify(execFile);
 
 describe("bounded workspace image reads", () => {
   let temp: Awaited<ReturnType<typeof createTempDir>>;
@@ -64,5 +68,21 @@ describe("bounded workspace image reads", () => {
     await expect(readBoundedWorkspaceImageFile("inside.png", workspace, controller.signal)).rejects.toMatchObject({
       name: "AbortError",
     });
+  });
+
+  it.runIf(process.platform !== "win32")("rejects a FIFO without blocking", async () => {
+    const fifo = join(workspace, "special.png");
+    await execFileAsync("mkfifo", [fifo]);
+    let timeout: NodeJS.Timeout | undefined;
+    try {
+      await expect(Promise.race([
+        readBoundedWorkspaceImageFile("special.png", workspace),
+        new Promise((_, reject) => {
+          timeout = setTimeout(() => reject(new Error("FIFO rejection timed out")), 1_000);
+        }),
+      ])).rejects.toThrow(/regular file/);
+    } finally {
+      clearTimeout(timeout);
+    }
   });
 });

--- a/tests/media/primitives.test.ts
+++ b/tests/media/primitives.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { MEDIA_MAX_DATA_URL_CHARS, MEDIA_MAX_SOURCE_PIXELS } from "../../extensions/xai/media/constants";
+import { decodeStrictBase64, parseBoundedImageDataUrl } from "../../extensions/xai/media/data-url";
+import { inspectSupportedImageBytes } from "../../extensions/xai/media/image-info";
+import { jpegHeaderBytes, pngHeaderBytes, tinyPngBytes } from "../fixtures/images";
+
+describe("bounded media byte primitives", () => {
+  it("inspects PNG and JPEG dimensions from bytes", () => {
+    expect(inspectSupportedImageBytes(pngHeaderBytes(640, 480), { maxPixels: 1_000_000 })).toEqual({
+      mimeType: "image/png",
+      width: 640,
+      height: 480,
+    });
+    expect(inspectSupportedImageBytes(jpegHeaderBytes(320, 240), { maxPixels: 1_000_000 })).toEqual({
+      mimeType: "image/jpeg",
+      width: 320,
+      height: 240,
+    });
+  });
+
+  it("rejects unsupported, malformed, zero-sized, pixel-bomb, and side-bomb headers", () => {
+    expect(() => inspectSupportedImageBytes(Buffer.from("GIF89a"), { maxPixels: 100 })).toThrow(/PNG and JPEG/);
+    expect(() => inspectSupportedImageBytes(pngHeaderBytes(0, 1), { maxPixels: 100 })).toThrow(/dimensions/);
+    expect(() => inspectSupportedImageBytes(pngHeaderBytes(4000, 4000), { maxPixels: MEDIA_MAX_SOURCE_PIXELS })).toThrow(/pixel/);
+    expect(() => inspectSupportedImageBytes(pngHeaderBytes(100, 2), { maxPixels: 1_000, maxSidePx: 99 })).toThrow(/dimension/);
+    expect(() => inspectSupportedImageBytes(Buffer.from([0xff, 0xd8, 0xff, 0xda]), { maxPixels: 100 })).toThrow(/frame/);
+  });
+
+  it("accepts only canonical standard base64", () => {
+    expect(decodeStrictBase64("YWJj", 8, 3).toString()).toBe("abc");
+    for (const value of ["YWJj\n", "YWJj_", "YQ=", "YQ===", ""]) {
+      expect(() => decodeStrictBase64(value, 20, 20)).toThrow();
+    }
+    expect(() => decodeStrictBase64("YWJj", 3, 3)).toThrow(/encoded/);
+    expect(() => decodeStrictBase64("YWJj", 8, 2)).toThrow(/decoded/);
+  });
+
+  it("parses strict byte-matched PNG data URLs", () => {
+    const bytes = tinyPngBytes();
+    const result = parseBoundedImageDataUrl(`data:image/png;base64,${bytes.toString("base64")}`);
+    expect(result).toMatchObject({ mimeType: "image/png", width: 1, height: 1, source: "data-url" });
+    expect(result.bytes).toEqual(bytes);
+  });
+
+  it("rejects MIME mismatch, parameters, whitespace, aliases, malformed data, and encoded overflow", () => {
+    const base64 = tinyPngBytes().toString("base64");
+    for (const value of [
+      `data:image/jpeg;base64,${base64}`,
+      `data:image/png;charset=utf-8;base64,${base64}`,
+      `data:image/png;base64,${base64}\n`,
+      `data:image/jpg;base64,${base64}`,
+      "data:image/png;base64,%%%%",
+      `data:image/png;base64,${"A".repeat(MEDIA_MAX_DATA_URL_CHARS + 1)}`,
+    ]) {
+      expect(() => parseBoundedImageDataUrl(value)).toThrow();
+    }
+  });
+});

--- a/tests/provider/registration.test.ts
+++ b/tests/provider/registration.test.ts
@@ -37,7 +37,8 @@ describe("provider registration", () => {
       cost: { input: 2, cacheRead: 0.5, output: 6 },
       thinkingLevelMap: { off: null },
     });
-    expect(harness.tools.size).toBe(19);
+    expect(harness.tools.size).toBe(20);
+    expect(harness.tools.has("xai_edit_image")).toBe(true);
     expect(harness.commands.has("xai-tools")).toBe(true);
     expect([...harness.handlers.keys()]).toEqual(
       expect.arrayContaining([

--- a/tests/provider/routing.test.ts
+++ b/tests/provider/routing.test.ts
@@ -21,4 +21,14 @@ describe("credential-aware xAI routing", () => {
       });
     },
   );
+
+  it.each(["oauth-session", "api-key"] as const)(
+    "keeps %s image editing on the distinct pinned public route",
+    (kind) => {
+      expect(resolveXaiRoute(kind, "image-edit")).toEqual({
+        baseUrl: "https://api.x.ai/v1",
+        url: "https://api.x.ai/v1/images/edits",
+      });
+    },
+  );
 });

--- a/tests/tools/commands.test.ts
+++ b/tests/tools/commands.test.ts
@@ -43,6 +43,16 @@ describe("/xai-tools command", () => {
       ]),
     );
   });
+  it("requires explicit edit intent and local-reference guidance", () => {
+    const h = createExtensionHarness();
+    registerCustomXaiTools(h.api);
+    expect(h.tools.get("xai_edit_image").promptGuidelines).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/explicitly asks to edit or transform/),
+        expect.stringMatching(/workspace paths or PNG\/JPEG data URLs/),
+      ]),
+    );
+  });
 
   it("reports every tool status and eligibility", async () => {
     const { notices, run } = setup();
@@ -202,7 +212,7 @@ describe("/xai-tools command", () => {
     expect(isXaiNetworkToolActive(h.api, "xai_generate_image")).toBe(true);
   });
 
-  it("wraps Page Up and Page Down when Composer exposes exactly ten rows", async () => {
+  it("wraps Page Up and Page Down across the expanded Composer tool catalog", async () => {
     const { h, notices } = setup();
     let afterPageUp = "";
     let afterPageDown = "";
@@ -244,7 +254,7 @@ describe("/xai-tools command", () => {
     });
 
     await h.commands.get("xai-tools").handler("", ctx);
-    expect(afterPageUp).toMatch(/WebSearch/);
+    expect(afterPageUp).toMatch(/xai_web_search/);
     expect(afterPageDown).toMatch(/xai_generate_text/);
   });
 });

--- a/tests/tools/custom-tools.test.ts
+++ b/tests/tools/custom-tools.test.ts
@@ -95,7 +95,9 @@ describe("custom xAI tools", () => {
       undefined,
       () => {},
       {
-        model: TEST_MODEL,
+        get model() {
+          throw new Error("disabled tool must not inspect active model context");
+        },
         get cwd() {
           throw new Error("disabled tool must not inspect cwd");
         },

--- a/tests/tools/custom-tools.test.ts
+++ b/tests/tools/custom-tools.test.ts
@@ -60,6 +60,7 @@ describe("custom xAI tools", () => {
     ["xai_deep_research", { topic: "guard" }],
     ["xai_code_execution", { code: "print(1)" }],
     ["xai_generate_image", { prompt: "guard" }],
+    ["xai_edit_image", { prompt: "guard", image: [{ path: "secret.png" }] }],
     ["xai_analyze_image", { image: "https://example.test/a.png" }],
     ["xai_critique", { content: "guard" }],
   ])(
@@ -82,6 +83,33 @@ describe("custom xAI tools", () => {
       expect(requests).toHaveLength(0);
     },
   );
+  it("blocks disabled image editing without touching params, credentials, filesystem context, or network", async () => {
+    const params = new Proxy({}, {
+      get() {
+        throw new Error("disabled tool must not inspect inputs");
+      },
+    });
+    const result = await h.tools.get("xai_edit_image").execute(
+      "call",
+      params,
+      undefined,
+      () => {},
+      {
+        model: TEST_MODEL,
+        get cwd() {
+          throw new Error("disabled tool must not inspect cwd");
+        },
+        get sessionManager() {
+          throw new Error("disabled tool must not inspect session storage");
+        },
+        get modelRegistry() {
+          throw new Error("disabled tool must not resolve credentials");
+        },
+      },
+    );
+    expect(result.content[0].text).toMatch(/xai_edit_image is disabled/);
+    expect(requests).toHaveLength(0);
+  });
   it("does not fall back to an API-key environment variable", async () => {
     vi.stubEnv("XAI_API_KEY", "must-not-use");
     setXaiNetworkToolActive(h.api, TEST_MODEL, "xai_generate_text", true);


### PR DESCRIPTION
## Summary

- add disabled-by-default `xai_edit_image` with exact singular/plural Imagine payloads for one to three byte-validated PNG/JPEG references
- post only to the pinned public `https://api.x.ai/v1/images/edits` route with protected direct-media headers, redirect refusal, cancellation, and a 120-second timeout
- add reusable bounded media primitives for strict data URLs, workspace containment, decode verification, source-backed compression, aggregate budgets, and private atomic Pi-session storage
- integrate on top of merged PR #90 without weakening catalog modality, canonical payload/model binding, retry suppression, or privacy behavior

## Security and behavior

- disabled calls fail before parameter, context, credential, filesystem, codec, network, or output access
- four references and invalid supplied aspect ratios fail before I/O; a valid single-reference ratio is accepted but omitted from the wire
- exactly one canonical base64 PNG/JPEG output is byte-, codec-, pixel-, and side-validated before persistence under `0700` directories and `0600` files
- prompts, source references, credentials, authenticated bodies, unsafe request IDs, and codec/compression errors are not reflected
- explicitly enabled editing remains independent of the active authenticated Responses model's text/image input modality

## Validation

- cumulative focused handoff suite: PASS
- `npm run typecheck`: PASS
- `NODE_OPTIONS=--unhandled-rejections=strict npm test`: 361 tests across 34 files + loader smoke, PASS
- `NODE_OPTIONS=--unhandled-rejections=strict npm run test:coverage`: 84.68% statements / 77.71% branches / 85.48% functions / 88.72% lines, all floors PASS
- `npm run compatibility:check`: policy, registry, packed manifest, and unsupported peers PASS
- `npm run compatibility:boundaries`: clean packed Pi 0.80.1 and 0.80.10 test/loader/typecheck matrices PASS
- `npm pack --dry-run --json`: intended runtime, tests, fixtures, and docs present
- independent functional, security/privacy, and test/validation re-reviews: CLEAN

No live paid xAI request or interactive OAuth flow was performed. Parent-directory replacement remains the documented trusted-parent filesystem assumption.

Closes #83
