### PR TITLE
feat: advertise known aliases of entitled OAuth models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Core flow: `bin/setup.js` → `pi install` → bounded catalog selection in `ext
 - Fetch OAuth-visible models only from the pinned authenticated CLI proxy `/models-v2` endpoint
 - Treat successful catalog responses as exact entitlement state; additions appear and removals disappear
 - Keep the normalized token-free catalog cache atomic and apply the documented TTL/stale/fallback policy
-- Preserve known model metadata and compatibility behavior without advertising models absent from the authenticated catalog
+- Preserve known model metadata and compatibility behavior without inventing unentitled model families; known aliases of already-entitled models may be advertised at registration/runtime only (cache stays exact)
 - Keep both Pi peers aligned to the checked-in bounded range in `compatibility/pi-versions.json`
 - Install/report exact Pi matrix versions from a clean packed package; never reuse the repository lockfile for boundary jobs
 - Keep normal Pi dev dependencies exact at the policy's latest tested release and review candidate releases before widening support

--- a/README.md
+++ b/README.md
@@ -635,7 +635,7 @@ If you have the official Grok CLI installed and authenticated (`~/.grok/auth.jso
 
 ### "Why is a model missing or still cached?"
 
-The xAI model list is entitlement-aware. If a model is missing, the authenticated `/models-v2` response did not include a usable OAuth Responses entry, or discovery fell back to the curated offline catalog. Run `/login xai-auth` to force an account-bound refresh. `/reload` reloads the extension but intentionally reuses a cache younger than 15 minutes; after the TTL it performs a bounded refresh.
+The xAI model list is entitlement-aware. If a model is missing, the authenticated `/models-v2` response did not include a usable OAuth Responses entry, or discovery fell back to the curated offline catalog. Run `/login xai-auth` to force an account-bound refresh. `/reload` reloads the extension but intentionally reuses a cache younger than 15 minutes; after the TTL it performs a bounded refresh. Known renames such as `grok-composer-2.5-fast` and `grok-build-latest` are advertised only as aliases of an already-entitled canonical model (currently `grok-4.5`), so settings patterns keep matching without inventing unentitled catalog entries.
 
 A one-shot `pi --list-models` cannot refresh an already-expired pi-stored OAuth token before the model registry is bound. It can still use a fresh official Grok CLI bearer when available; otherwise it uses fresh cache or the curated fallback. Starting a normal session lets pi refresh its stored credential under the credential-store lock and then revalidate the catalog.
 

--- a/extensions/xai-oauth.ts
+++ b/extensions/xai-oauth.ts
@@ -3,7 +3,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { selectXaiModelCatalog, type XaiCatalogSelection } from "./xai/catalog";
 import { getGrokAuthCredentials, getStartupXaiCatalogAuth } from "./xai/auth";
 import { DEFAULT_XAI_MODEL, XAI_PROVIDER_ID } from "./xai/constants";
-import { CURATED_FALLBACK_MODELS, setXaiRuntimeModels, type XaiCatalogModel } from "./xai/models";
+import { CURATED_FALLBACK_MODELS, expandXaiCatalogWithAliases, setXaiRuntimeModels, type XaiCatalogModel } from "./xai/models";
 import { createXaiOAuth } from "./xai/oauth";
 import { streamSimpleXaiResponses } from "./xai/responses";
 import { resolveXaiRoute } from "./xai/routing";
@@ -48,7 +48,9 @@ export default async function (pi: ExtensionAPI) {
   });
 
   const applyCatalog = (selection: XaiCatalogSelection, replaceExisting: boolean) => {
-    currentModels = selection.models;
+    // Cache/remote selection stays exact; advertise known aliases of entitled models
+    // so renamed settings patterns (e.g. Composer → Grok 4.5) keep matching.
+    currentModels = expandXaiCatalogWithAliases(selection.models);
     needsSessionRefresh = selection.needsAuthenticatedRefresh;
     setXaiRuntimeModels(currentModels);
     if (replaceExisting) pi.unregisterProvider(XAI_PROVIDER_ID);

--- a/extensions/xai/models.ts
+++ b/extensions/xai/models.ts
@@ -32,9 +32,10 @@ export type XaiCatalogModel = {
 /**
  * Curated metadata for known xAI models.
  *
- * This table enriches models that the authenticated catalog actually returns;
- * it is not the provider advertisement and must never be unioned into a
- * successful entitlement response.
+ * This table enriches models that the authenticated catalog actually returns
+ * (and their known aliases after entitlement expansion). It is not the provider
+ * advertisement and must never be unioned wholesale into a successful entitlement
+ * response.
  */
 export const KNOWN_XAI_MODEL_METADATA: readonly XaiCatalogModel[] = [
   {
@@ -136,6 +137,50 @@ export const KNOWN_XAI_MODEL_METADATA: readonly XaiCatalogModel[] = [
 
 const KNOWN_MODEL_MAP = new Map(KNOWN_XAI_MODEL_METADATA.map((model) => [model.id, model]));
 
+/**
+ * Known OAuth model aliases mapped to the canonical catalog id they currently
+ * resolve to on xAI's session Responses proxy / public model registry.
+ *
+ * Only aliases of models that are already entitled are advertised. This keeps
+ * the authenticated catalog exact while preserving renamed settings patterns
+ * such as `grok-composer-2.5-fast` when the account only receives `grok-4.5`.
+ *
+ * Source evidence: official Grok catalog key/slug split, `api.x.ai/v1/models`
+ * alias lists, and OAuth Responses resolution (e.g. Composer → `grok-4.5-build`).
+ */
+export const XAI_MODEL_ALIASES: Readonly<Record<string, string>> = {
+  // Grok 4.5 family absorbs former Build-latest / Composer routing.
+  "grok-4.5-latest": "grok-4.5",
+  "grok-build-latest": "grok-4.5",
+  "grok-composer-2.5-fast": "grok-4.5",
+
+  // Grok 4.3 short names.
+  "grok-4.3-latest": "grok-4.3",
+  "grok-latest": "grok-4.3",
+
+  // Grok 4.20 short / beta aliases → dated canonicals.
+  "grok-4.20": "grok-4.20-0309-reasoning",
+  "grok-4.20-0309": "grok-4.20-0309-reasoning",
+  "grok-4.20-reasoning": "grok-4.20-0309-reasoning",
+  "grok-4.20-reasoning-latest": "grok-4.20-0309-reasoning",
+  "grok-4.20-non-reasoning": "grok-4.20-0309-non-reasoning",
+  "grok-4.20-non-reasoning-latest": "grok-4.20-0309-non-reasoning",
+  "grok-4.20-multi-agent": "grok-4.20-multi-agent-0309",
+  "grok-4.20-multi-agent-latest": "grok-4.20-multi-agent-0309",
+};
+
+const XAI_ALIASES_BY_CANONICAL = (() => {
+  const map = new Map<string, string[]>();
+  for (const [alias, canonical] of Object.entries(XAI_MODEL_ALIASES)) {
+    const key = canonical.toLowerCase();
+    const list = map.get(key);
+    if (list) list.push(alias);
+    else map.set(key, [alias]);
+  }
+  for (const list of map.values()) list.sort();
+  return map;
+})();
+
 /** Minimal catalog used only when authenticated discovery cannot be used safely. */
 export const CURATED_FALLBACK_MODELS: readonly XaiCatalogModel[] = [
   { ...KNOWN_MODEL_MAP.get(DEFAULT_XAI_MODEL)! },
@@ -188,6 +233,70 @@ export function defaultXaiRuntimeModelId(): string | undefined {
 /** Return curated metadata for a known model without advertising it. */
 export function knownXaiModelMetadata(modelId: string): XaiCatalogModel | undefined {
   return KNOWN_MODEL_MAP.get(normalizedXaiModelId(modelId));
+}
+
+/**
+ * Resolve a model id through the known alias table to its canonical catalog id.
+ * Unknown ids are returned normalized without inventing an entitlement.
+ */
+export function resolveXaiCanonicalModelId(modelId: string): string {
+  const normalized = normalizedXaiModelId(modelId);
+  if (!normalized) return normalized;
+  return XAI_MODEL_ALIASES[normalized] ?? normalized;
+}
+
+/**
+ * Expand an exact entitlement snapshot with known aliases of currently entitled
+ * models. The remote/cache catalog stays exact; only the advertised runtime
+ * provider list gains compatibility aliases.
+ */
+export function expandXaiCatalogWithAliases(
+  models: readonly XaiCatalogModel[],
+): XaiCatalogModel[] {
+  const entitled = new Map<string, XaiCatalogModel>();
+  for (const model of models) {
+    entitled.set(model.id.toLowerCase(), {
+      ...model,
+      input: [...model.input],
+      cost: { ...model.cost },
+      ...(model.thinkingLevelMap ? { thinkingLevelMap: { ...model.thinkingLevelMap } } : {}),
+    });
+  }
+
+  const expanded: XaiCatalogModel[] = [...entitled.values()];
+  const aliasEntries: Array<[string, XaiCatalogModel]> = [];
+  for (const [canonical, base] of entitled) {
+    const aliases = XAI_ALIASES_BY_CANONICAL.get(canonical) ?? [];
+    for (const alias of aliases) {
+      if (entitled.has(alias)) continue;
+      aliasEntries.push([alias, materializeAliasModel(alias, base)]);
+    }
+  }
+  aliasEntries.sort(([left], [right]) => left.localeCompare(right));
+  for (const [, model] of aliasEntries) expanded.push(model);
+  return expanded;
+}
+
+function materializeAliasModel(alias: string, base: XaiCatalogModel): XaiCatalogModel {
+  const known = knownXaiModelMetadata(alias);
+  const maxTokens = Math.min(known?.maxTokens ?? base.maxTokens, base.contextWindow);
+  return {
+    id: alias,
+    name: known?.name ?? base.name,
+    apiBackend: "responses",
+    reasoning: known?.reasoning ?? base.reasoning,
+    // Preserve authenticated modality evidence from the entitled canonical.
+    input: [...base.input],
+    inputProvenance: base.inputProvenance,
+    cost: known ? { ...known.cost } : { ...base.cost },
+    contextWindow: base.contextWindow,
+    maxTokens,
+    ...(known?.thinkingLevelMap
+      ? { thinkingLevelMap: { ...known.thinkingLevelMap } }
+      : base.thinkingLevelMap
+        ? { thinkingLevelMap: { ...base.thinkingLevelMap } }
+        : {}),
+  };
 }
 
 /** Build a pi model object for a credential-aware direct xAI request. */

--- a/scripts/verify-extension-loader.mjs
+++ b/scripts/verify-extension-loader.mjs
@@ -31,7 +31,12 @@ try {
   assert.equal(provider.name, "xai-auth");
   assert.equal(provider.config.api, "xai-responses");
   assert.equal(provider.config.baseUrl, "https://cli-chat-proxy.grok.com/v1");
-  assert.deepEqual(provider.config.models.map((model) => model.id), ["grok-4.5"]);
+  const modelIds = provider.config.models.map((model) => model.id);
+  assert.deepEqual(modelIds.slice(0, 1), ["grok-4.5"], "curated fallback canonical should lead the advertised list");
+  assert.ok(modelIds.includes("grok-composer-2.5-fast"), "known aliases of entitled fallback models should be advertised");
+  assert.ok(modelIds.includes("grok-build-latest"));
+  assert.ok(modelIds.includes("grok-4.5-latest"));
+  assert.equal(modelIds.length, 4, "fallback should advertise grok-4.5 plus its known aliases only");
   console.log("verify-extension-loader: ok");
 } finally {
   if (previousHome === undefined) delete process.env.HOME;

--- a/tests/provider/catalog-lifecycle.test.ts
+++ b/tests/provider/catalog-lifecycle.test.ts
@@ -83,9 +83,14 @@ describe.sequential("authenticated provider catalog lifecycle", () => {
       ],
     });
     expect(credentials.access).toBe("login-access");
-    expect(h.providers.get("xai-auth").models.map(({ id }: any) => id)).toEqual(
-      ["grok-4.5", "new-entitled"],
-    );
+    expect(h.providers.get("xai-auth").models.map(({ id }: any) => id)).toEqual([
+      "grok-4.5",
+      "new-entitled",
+      // Known aliases of entitled grok-4.5 only — not invented families.
+      "grok-4.5-latest",
+      "grok-build-latest",
+      "grok-composer-2.5-fast",
+    ]);
   });
   it("advertises authenticated modalities without exposing internal provenance", async () => {
     const { h } = await loadAndLogin({

--- a/tests/provider/models.test.ts
+++ b/tests/provider/models.test.ts
@@ -1,12 +1,17 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
   CURATED_FALLBACK_MODELS,
+  expandXaiCatalogWithAliases,
   getXaiRuntimeModels,
   grokSupportsReasoningEffort,
   isGrokCliCompatibilityModel,
+  isXaiRuntimeModelEntitled,
+  knownXaiModelMetadata,
   normalizedXaiModelId,
+  resolveXaiCanonicalModelId,
   resolveXaiClientMode,
   setXaiRuntimeModels,
+  XaiModelInputProvenance,
   xaiProxyRequestHeaders,
 } from "../../extensions/xai/models";
 import { xaiCatalogHeaders } from "../../extensions/xai/wire";
@@ -18,6 +23,63 @@ describe("model compatibility metadata", () => {
     expect(isGrokCliCompatibilityModel("grok-build")).toBe(true);
     expect(isGrokCliCompatibilityModel("grok-composer-2.5-fast")).toBe(true);
     expect(isGrokCliCompatibilityModel("grok-4.5")).toBe(false);
+  });
+
+  it("resolves known renamed model aliases to canonical catalog ids", () => {
+    expect(resolveXaiCanonicalModelId("xai-auth/grok-composer-2.5-fast")).toBe("grok-4.5");
+    expect(resolveXaiCanonicalModelId("grok-build-latest")).toBe("grok-4.5");
+    expect(resolveXaiCanonicalModelId("grok-4.20")).toBe("grok-4.20-0309-reasoning");
+    expect(resolveXaiCanonicalModelId("grok-4.20-multi-agent")).toBe("grok-4.20-multi-agent-0309");
+    expect(resolveXaiCanonicalModelId("grok-4.5")).toBe("grok-4.5");
+    expect(resolveXaiCanonicalModelId("unknown-model")).toBe("unknown-model");
+  });
+
+  it("expands only aliases of entitled models and preserves authenticated input", () => {
+    const entitled = {
+      ...CURATED_FALLBACK_MODELS[0],
+      id: "grok-4.5",
+      input: ["text"] as ("text" | "image")[],
+      inputProvenance: XaiModelInputProvenance.AuthenticatedAcceptsImages,
+    };
+    const expanded = expandXaiCatalogWithAliases([entitled]);
+    const ids = expanded.map((model) => model.id);
+
+    expect(ids).toContain("grok-4.5");
+    expect(ids).toContain("grok-composer-2.5-fast");
+    expect(ids).toContain("grok-build-latest");
+    expect(ids).toContain("grok-4.5-latest");
+    // Unentitled families stay hidden.
+    expect(ids).not.toContain("grok-4.20-0309-reasoning");
+    expect(ids).not.toContain("grok-4.20");
+    expect(ids).not.toContain("grok-build");
+
+    const composer = expanded.find((model) => model.id === "grok-composer-2.5-fast");
+    expect(composer).toMatchObject({
+      name: knownXaiModelMetadata("grok-composer-2.5-fast")?.name,
+      reasoning: false,
+      input: ["text"],
+      inputProvenance: XaiModelInputProvenance.AuthenticatedAcceptsImages,
+      contextWindow: entitled.contextWindow,
+    });
+
+    setXaiRuntimeModels(expanded);
+    expect(isXaiRuntimeModelEntitled("grok-composer-2.5-fast")).toBe(true);
+    expect(isXaiRuntimeModelEntitled("grok-4.20")).toBe(false);
+  });
+
+  it("does not invent aliases when the canonical model is absent", () => {
+    const onlyFourThree = expandXaiCatalogWithAliases([
+      {
+        ...CURATED_FALLBACK_MODELS[0],
+        id: "grok-4.3",
+        name: "Grok 4.3",
+      },
+    ]);
+    const ids = onlyFourThree.map((model) => model.id);
+    expect(ids).toContain("grok-4.3");
+    expect(ids).toContain("grok-latest");
+    expect(ids).not.toContain("grok-composer-2.5-fast");
+    expect(ids).not.toContain("grok-4.5");
   });
   it("looks up runtime reasoning case-insensitively", () => {
     setXaiRuntimeModels([

--- a/tests/provider/registration.test.ts
+++ b/tests/provider/registration.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import extension from "../../extensions/xai-oauth";
 import {
   CURATED_FALLBACK_MODELS,
+  expandXaiCatalogWithAliases,
   KNOWN_XAI_MODEL_METADATA,
   setXaiRuntimeModels,
 } from "../../extensions/xai/models";
@@ -31,7 +32,9 @@ describe("provider registration", () => {
       baseUrl: "https://cli-chat-proxy.grok.com/v1",
       authHeader: true,
     });
-    expect(provider.models.map(({ id }: any) => id)).toEqual(["grok-4.5"]);
+    expect(provider.models.map(({ id }: any) => id)).toEqual(
+      expandXaiCatalogWithAliases(CURATED_FALLBACK_MODELS).map((model) => model.id),
+    );
     expect(provider.models[0]).toMatchObject({
       contextWindow: 500_000,
       reasoning: true,


### PR DESCRIPTION
## Summary
- Keep authenticated `/models-v2` entitlement exact (cache/remote unchanged)
- At advertisement time, expand known aliases of already-entitled models
- Restores settings patterns like `xai-auth/grok-composer-2.5-fast` when the catalog only returns `grok-4.5`
- Composer alias keeps Composer-shaped metadata/CLI-compat; authenticated input comes from the entitled canonical

## Why
xAI’s OAuth catalog currently returns only `grok-4.5` for many accounts, while the session Responses proxy still accepts renamed ids (Composer → `grok-4.5-build`, short 4.20 aliases → dated canonicals). Without alias expansion, pi warns that enabled model patterns no longer match.

## Design choice (option 1 / approach A)
- Do **not** re-hardcode the full historical model list
- Do **not** invent unentitled families
- Do advertise aliases only when their canonical is entitled
- Keep Composer-shaped UI/tools for the Composer alias (not pure 4.5 clone)

## Test plan
- [x] `npm run test:unit -- tests/provider/models.test.ts`
- [x] `npm run typecheck`
- [ ] `/reload` or restart pi with existing `enabledModels` including `xai-auth/grok-composer-2.5-fast` — warning should clear when `grok-4.5` is entitled
- [ ] `/model` shows Composer alias when catalog has `grok-4.5`
- [ ] Selecting Composer still enables Cursor/Grok CLI shims

## Residual / follow-up (non-blocking)
- Alias table may need updates as xAI renames again
- Optional later: rewrite wire model to canonical, or inherit more capabilities from base for pure renames

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which models pi advertises and treats as entitled at runtime; mistakes in the alias table could show wrong IDs or break Grok CLI compatibility shims, but scope is limited to aliases of already-entitled canonicals.
> 
> **Overview**
> Keeps authenticated `/models-v2` cache and remote entitlement **exact**, but expands the **runtime/provider advertisement** with known renamed model IDs when their canonical model is already entitled—so settings like `xai-auth/grok-composer-2.5-fast` still match when the catalog only returns `grok-4.5`.
> 
> Adds `XAI_MODEL_ALIASES`, `resolveXaiCanonicalModelId`, and `expandXaiCatalogWithAliases` in `extensions/xai/models.ts`. Alias rows inherit authenticated input/modality from the entitled canonical while pulling Composer/Build-style display metadata from curated known-model tables where applicable. `applyCatalog` in `extensions/xai-oauth.ts` runs expansion only at registration/runtime, not when persisting cache.
> 
> **Docs:** `AGENTS.md` and README troubleshooting clarify that aliases are compatibility advertisements, not invented catalog families.
> 
> **Tests:** Provider registration, catalog lifecycle, loader smoke, and new unit cases assert alias expansion is gated on entitlement and preserves authenticated input provenance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e71e0611d5e53ec7a33476b05cec1ebef505b916. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->