### PR TITLE
fix: stop Cursor shims for Composer 4.5 alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Common catalog entries include:
 | `grok-4.5` | **Default and curated offline fallback.** xAI flagship; reasoning low (**fast**) / medium / high (default), 500K context, text+image. |
 | `grok-4.3` | When entitled: full reasoning, with limits taken from the authenticated catalog. |
 | `grok-build` | When entitled: Grok Build coding model with Cursor/Grok CLI tool compatibility. |
-| `grok-composer-2.5-fast` | When entitled: Composer coding model with Cursor/Grok CLI tool compatibility. |
+| `grok-composer-2.5-fast` | Compatibility alias of entitled `grok-4.5`. Uses normal pi tools (no Cursor shims). |
 | `grok-4.20-0309-reasoning` | When entitled: Grok 4.20 with automatic reasoning. |
 | `grok-4.20-0309-non-reasoning` | When entitled: Grok 4.20 non-reasoning variant. |
 | `grok-4.20-multi-agent-0309` | When entitled: Grok 4.20 multi-agent research model. |
@@ -348,7 +348,7 @@ pi --model grok-4.5:low "What's the weather?"   # fast / latency-sensitive
 | **`medium`** | Balanced thinking vs latency | Analysis and longer-context work |
 | **`low`** (**fast mode**) | Some reasoning, still fast | Latency-sensitive agents and simple tool calling |
 
-`grok-4.5` defaults to **high** when no effort is specified; reasoning **cannot be disabled** (`/think off` is not supported for this model). Every model actually returned and selected through the OAuth-only `xai-auth` catalog sends Responses traffic through xAI's Grok CLI session endpoint using the same X account OAuth token. When returned, Grok Build and Composer still receive their model-specific compatibility payloads, headers, and local tool shims. `grok-composer-2.5-fast` does not accept configurable reasoning effort. `grok-4.20-0309-reasoning` reasons automatically and does not accept a configurable effort parameter. `grok-4.20-multi-agent-0309` uses `medium` for 4 agents and `high` for 16 agents.
+`grok-4.5` defaults to **high** when no effort is specified; reasoning **cannot be disabled** (`/think off` is not supported for this model). Every model actually returned and selected through the OAuth-only `xai-auth` catalog sends Responses traffic through xAI's Grok CLI session endpoint using the same X account OAuth token. When an entitled `grok-build` entry is selected, it still receives Grok Build compatibility payloads, headers, and local tool shims. The Composer alias (`grok-composer-2.5-fast`) follows the Grok 4.5 tool path instead. `grok-4.20-0309-reasoning` reasons automatically and does not accept a configurable effort parameter. `grok-4.20-multi-agent-0309` uses `medium` for 4 agents and `high` for 16 agents.
 
 ### Grok 4.5 source notes
 
@@ -361,9 +361,11 @@ Official xAI sources used for this catalog update:
 
 No Grok 4.5-specific model card, label card, system card, paper, or official max-output-token limit was found in the xAI docs/news/data sources during this update. The package keeps the existing Grok Responses max-token ceiling as a placeholder until xAI publishes official model metadata for that field.
 
-### Composer / Grok Build Tool Compatibility
+### Grok Build Tool Compatibility
 
-Composer 2.5 and Grok Build are trained against Cursor/Grok CLI-style tool names. When either `grok-composer-2.5-fast` or `grok-build` is selected, this package automatically enables compatibility shims that map those tool calls onto pi's built-in tools:
+Only an entitled `grok-build` catalog entry enables Cursor/Grok CLI-style tool-name shims. The Composer alias of Grok 4.5 uses pi's normal tools (`read`, `write`, `edit`, `bash`, …), matching the default Grok 4.5 path.
+
+When `grok-build` is selected, this package automatically enables compatibility shims that map those tool calls onto pi's built-in tools:
 
 | Cursor/Grok CLI tool | pi tool used underneath |
 |----------------------|-------------------------|
@@ -377,7 +379,7 @@ Composer 2.5 and Grok Build are trained against Cursor/Grok CLI-style tool names
 | `Shell` | `bash` |
 | `WebSearch` | xAI native web search |
 
-The local filesystem and shell shims also normalize common Cursor argument names, such as `file_path`, `contents`, `old_string` / `new_string`, `query`, `include`, `glob_filter`, and `cmd`. They are enabled automatically for eligible Grok CLI models and disabled again when you switch back to models such as `grok-4.5` or `grok-4.3`. `WebSearch` is the exception: it sends an additional xAI request, so it remains inactive until you enable it through `/xai-tools`.
+The local filesystem and shell shims also normalize common Cursor argument names, such as `file_path`, `contents`, `old_string` / `new_string`, `query`, `include`, `glob_filter`, and `cmd`. They are enabled automatically for entitled `grok-build` and disabled again when you switch back to models such as `grok-4.5`, the Composer alias, or `grok-4.3`. `WebSearch` is the exception: it sends an additional xAI request, so it remains inactive until you enable it through `/xai-tools`.
 
 ---
 
@@ -399,11 +401,11 @@ This opt-in boundary applies only to the extra tools below. Normal conversation 
 | `xai_edit_image` | Image editing | Imagine usage for one output conditioned on 1-3 local references |
 | `xai_analyze_image` | Vision | Separate model-token and image-input usage |
 | `xai_critique` | Reasoning | Separate high-reasoning model-token usage |
-| `WebSearch` | Search | Grok Build/Composer model tokens plus native tool usage |
+| `WebSearch` | Search | Entitled Grok Build model tokens plus native tool usage |
 
 **How to use them:** Select an `xai-auth` model, enable only the tool you want through `/xai-tools`, then explicitly request that tool in your prompt or agent workflow. Enabling a tool makes it available; it is not permission for the model to call it without user intent.
 
-Every new session resets all network-backed tools to inactive. Switching to a non-xAI model disables them immediately, and switching back does not restore them. The Grok CLI local filesystem and shell shims are automatic because they do not create a separate xAI API request.
+Every new session resets all network-backed tools to inactive. Switching to a non-xAI model disables them immediately, and switching back does not restore them. Grok Build local filesystem and shell shims are automatic because they do not create a separate xAI API request.
 
 In the pi TUI, select an `xai-auth` model and run:
 
@@ -421,7 +423,7 @@ The picker shows each tool's category and cost-risk context, warns that calls ma
 /xai-tools enable xai_edit_image
 ```
 
-`WebSearch` appears in the picker only for Grok Build and Composer models. `/xai-tools` is owned by this package; it does not depend on pi's optional example `/tools` extension.
+`WebSearch` appears in the picker only for an entitled Grok Build model. `/xai-tools` is owned by this package; it does not depend on pi's optional example `/tools` extension.
 
 > **Tip:** See the ⚠️ warning above about local vs published package conflicts.
 

--- a/extensions/xai/models.ts
+++ b/extensions/xai/models.ts
@@ -321,10 +321,15 @@ export function normalizedXaiModelId(modelId: string): string {
   return (modelId || "").toLowerCase().split("/").pop() || "";
 }
 
-/** Return true for models that need Grok CLI compatibility behavior. */
+/**
+ * Return true for models that still need Cursor/Grok CLI tool-name shims.
+ *
+ * Composer is treated as a Grok 4.5 alias and uses pi's normal tools. Only
+ * an explicitly entitled `grok-build` catalog entry keeps the legacy Cursor
+ * shim surface.
+ */
 export function isGrokCliCompatibilityModel(modelId: string): boolean {
-  const normalized = normalizedXaiModelId(modelId);
-  return normalized === "grok-build" || normalized === "grok-composer-2.5-fast";
+  return normalizedXaiModelId(modelId) === "grok-build";
 }
 
 /** Return true when xAI accepts an explicit Responses reasoning effort. */

--- a/extensions/xai/tools/commands.ts
+++ b/extensions/xai/tools/commands.ts
@@ -27,7 +27,7 @@ const NETWORK_TOOL_OPTIONS: readonly NetworkToolOption[] = [
   { name: "xai_edit_image", category: "image", costRisk: "Imagine usage", summary: "edit 1-3 local image references" },
   { name: "xai_analyze_image", category: "vision", costRisk: "token usage", summary: "analyze an image with Grok" },
   { name: "xai_critique", category: "reasoning", costRisk: "token usage", summary: "separate high-reasoning critique" },
-  { name: "WebSearch", category: "search", costRisk: "token + tool", summary: "Grok Build/Composer native web search" },
+  { name: "WebSearch", category: "search", costRisk: "token + tool", summary: "Grok Build native web search" },
 ];
 
 const XAI_TOOLS_USAGE =

--- a/extensions/xai/tools/cursor-shims.ts
+++ b/extensions/xai/tools/cursor-shims.ts
@@ -546,7 +546,7 @@ export function registerCursorToolShims(pi: ExtensionAPI) {
         const query = firstString(params?.query, params?.search_term, params?.value);
         if (!query) return xaiToolError("Error: WebSearch requires a query.");
         if (ctx?.model?.provider !== XAI_PROVIDER_ID || !isGrokCliCompatibilityModel(ctx.model.id)) {
-          return xaiToolError("Error: WebSearch requires an active xAI Grok Build or Composer model. No xAI request was sent.");
+          return xaiToolError("Error: WebSearch requires an active entitled xAI Grok Build model. No xAI request was sent.");
         }
         if (!isXaiNetworkToolActive(pi, "WebSearch")) {
           return xaiToolError("Error: WebSearch is disabled. Run /xai-tools to enable it and request it explicitly. No xAI request was sent.");

--- a/extensions/xai/tools/model-scope.ts
+++ b/extensions/xai/tools/model-scope.ts
@@ -77,7 +77,7 @@ export function setXaiNetworkToolActive(
     return {
       ok: false,
       active: false,
-      error: "WebSearch is available only with xAI Grok Build or Composer models.",
+      error: "WebSearch is available only with an entitled xAI Grok Build model.",
     };
   }
   if (typeof api?.getActiveTools !== "function" || typeof api?.setActiveTools !== "function") {

--- a/tests/provider/models.test.ts
+++ b/tests/provider/models.test.ts
@@ -21,7 +21,8 @@ describe("model compatibility metadata", () => {
   it("normalizes IDs and detects Grok CLI compatibility models", () => {
     expect(normalizedXaiModelId("xai-auth/GROK-BUILD")).toBe("grok-build");
     expect(isGrokCliCompatibilityModel("grok-build")).toBe(true);
-    expect(isGrokCliCompatibilityModel("grok-composer-2.5-fast")).toBe(true);
+    // Composer is a 4.5 alias and uses pi tools, not Cursor shims.
+    expect(isGrokCliCompatibilityModel("grok-composer-2.5-fast")).toBe(false);
     expect(isGrokCliCompatibilityModel("grok-4.5")).toBe(false);
   });
 

--- a/tests/provider/registration.test.ts
+++ b/tests/provider/registration.test.ts
@@ -161,8 +161,8 @@ describe("provider registration", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await harness.handlers.get("model_select")?.(
-      { model: { ...TEST_MODEL, id: "grok-composer-2.5-fast" } },
-      { model: { ...TEST_MODEL, id: "grok-composer-2.5-fast" } },
+      { model: { ...TEST_MODEL, id: "grok-build" } },
+      { model: { ...TEST_MODEL, id: "grok-build" } },
     );
     expect(harness.getActiveTools()).toContain("Grep");
     expect(harness.getActiveTools()).not.toContain("WebSearch");
@@ -180,12 +180,12 @@ describe("provider registration", () => {
     ).toBe(true);
 
     await harness.handlers.get("model_select")?.(
-      { model: { ...TEST_MODEL, id: "grok-composer-2.5-fast" } },
-      { model: { ...TEST_MODEL, id: "grok-composer-2.5-fast" } },
+      { model: { ...TEST_MODEL, id: "grok-build" } },
+      { model: { ...TEST_MODEL, id: "grok-build" } },
     );
     await harness.handlers.get("before_agent_start")?.(
       {},
-      { model: { ...TEST_MODEL, id: "grok-composer-2.5-fast" } },
+      { model: { ...TEST_MODEL, id: "grok-build" } },
     );
     expect(harness.getActiveTools()).toContain("Grep");
     expect(harness.getActiveTools()).not.toContain("WebSearch");

--- a/tests/responses/payload.test.ts
+++ b/tests/responses/payload.test.ts
@@ -135,7 +135,7 @@ describe("Responses payload normalization", () => {
   });
   it("removes all system and reasoning replay for CLI models", () => {
     setXaiRuntimeModels(KNOWN_XAI_MODEL_METADATA);
-    const model = { ...TEST_MODEL, id: "grok-composer-2.5-fast" } as any;
+    const model = { ...TEST_MODEL, id: "grok-build" } as any;
     const result: any = rewriteXaiResponsesPayload(
       {
         model: model.id,

--- a/tests/tools/commands.test.ts
+++ b/tests/tools/commands.test.ts
@@ -11,7 +11,7 @@ import {
   createExtensionHarness,
 } from "../fixtures/extension-api";
 import { TEST_MODEL } from "../fixtures/models";
-const composer = { ...TEST_MODEL, id: "grok-composer-2.5-fast" } as any;
+const build = { ...TEST_MODEL, id: "grok-build" } as any;
 
 function setup() {
   const h = createExtensionHarness();
@@ -70,9 +70,9 @@ describe("/xai-tools command", () => {
     await run("enable WebSearch");
     expect(isXaiNetworkToolActive(h.api, "WebSearch")).toBe(false);
     expect(notices.at(-1).message).toMatch(
-      /only with xAI Grok Build or Composer/,
+      /only with an entitled xAI Grok Build model/,
     );
-    await run("enable WebSearch", composer);
+    await run("enable WebSearch", build);
     expect(isXaiNetworkToolActive(h.api, "WebSearch")).toBe(true);
   });
   it("fails closed when registry reads or writes fail", async () => {
@@ -212,11 +212,11 @@ describe("/xai-tools command", () => {
     expect(isXaiNetworkToolActive(h.api, "xai_generate_image")).toBe(true);
   });
 
-  it("wraps Page Up and Page Down across the expanded Composer tool catalog", async () => {
+  it("wraps Page Up and Page Down across the expanded Grok Build tool catalog", async () => {
     const { h, notices } = setup();
     let afterPageUp = "";
     let afterPageDown = "";
-    const ctx = commandContext(composer, notices, {
+    const ctx = commandContext(build, notices, {
       ui: {
         notify(message: string, type?: string) {
           notices.push({ message, type });

--- a/tests/tools/cursor-shims.test.ts
+++ b/tests/tools/cursor-shims.test.ts
@@ -210,30 +210,30 @@ describe("Cursor/Grok CLI shims", () => {
       );
     },
   );
-  it("keeps WebSearch disabled until opt-in, routes Composer calls, and blocks stale contexts", async () => {
-    const composer = { ...TEST_MODEL, id: "grok-composer-2.5-fast" } as any;
+  it("keeps WebSearch disabled until opt-in, routes Grok Build calls, and blocks stale contexts", async () => {
+    const build = { ...TEST_MODEL, id: "grok-build" } as any;
     const controller = new AbortController();
     const disabled = await h.tools
       .get("WebSearch")
       .execute("call", { query: "must opt in" }, controller.signal, () => {}, {
         cwd: temp.path,
-        ...authContext(composer),
+        ...authContext(build),
       });
     expect(disabled.content[0].text).toMatch(/WebSearch is disabled/);
     expect(requests).toHaveLength(0);
 
-    expect(setXaiNetworkToolActive(h.api, composer, "WebSearch", true)).toEqual(
+    expect(setXaiNetworkToolActive(h.api, build, "WebSearch", true)).toEqual(
       { ok: true, active: true },
     );
     const enabled = await h.tools
       .get("WebSearch")
       .execute("call", { query: "xAI docs" }, controller.signal, () => {}, {
         cwd: temp.path,
-        ...authContext(composer),
+        ...authContext(build),
       });
     expect(enabled.content[0].text).toBe("OK");
     expect(requests).toHaveLength(1);
-    expect(requests[0].body.model).toBe("grok-composer-2.5-fast");
+    expect(requests[0].body.model).toBe("grok-build");
 
     const stale = await h.tools
       .get("WebSearch")
@@ -247,24 +247,30 @@ describe("Cursor/Grok CLI shims", () => {
           ...authContext({ provider: "anthropic", id: "claude" } as any),
         },
       );
-    expect(stale.content[0].text).toMatch(/requires an active xAI/);
+    expect(stale.content[0].text).toMatch(/requires an active entitled xAI Grok Build model|requires an active xAI/);
     expect(requests).toHaveLength(1);
   });
 
-  it("activates local shims only for Grok CLI models without duplication", () => {
+  it("activates local shims only for Grok Build without duplication", () => {
     h.setActiveTools(["read", "bash", "edit", "write"]);
     syncCursorToolShimsForModel(h.api, {
       ...TEST_MODEL,
-      id: "grok-composer-2.5-fast",
+      id: "grok-build",
     } as any);
     const first = h.getActiveTools();
     expect(first).toContain("Grep");
     expect(first).not.toContain("WebSearch");
     syncCursorToolShimsForModel(h.api, {
       ...TEST_MODEL,
-      id: "grok-composer-2.5-fast",
+      id: "grok-build",
     } as any);
     expect(h.getActiveTools()).toEqual(first);
+    // Composer alias and standard Grok 4.5 stay on pi tools.
+    syncCursorToolShimsForModel(h.api, {
+      ...TEST_MODEL,
+      id: "grok-composer-2.5-fast",
+    } as any);
+    expect(h.getActiveTools()).not.toContain("Grep");
     syncCursorToolShimsForModel(h.api, TEST_MODEL);
     expect(h.getActiveTools()).not.toContain("Grep");
   });

--- a/tests/tools/model-scope.test.ts
+++ b/tests/tools/model-scope.test.ts
@@ -7,10 +7,10 @@ import {
 } from "../../extensions/xai/tools/model-scope";
 import { createExtensionHarness } from "../fixtures/extension-api";
 import { TEST_MODEL } from "../fixtures/models";
-const composer = { ...TEST_MODEL, id: "grok-composer-2.5-fast" } as any;
+const build = { ...TEST_MODEL, id: "grok-build" } as any;
 
 describe("network-tool lifecycle", () => {
-  it("requires an active xAI model and Composer for WebSearch", () => {
+  it("requires an active xAI model and Grok Build for WebSearch", () => {
     const h = createExtensionHarness([...XAI_NETWORK_TOOL_NAMES]);
     expect(
       setXaiNetworkToolActive(h.api, undefined, "xai_web_search", true),
@@ -18,7 +18,7 @@ describe("network-tool lifecycle", () => {
     expect(
       setXaiNetworkToolActive(h.api, TEST_MODEL, "WebSearch", true),
     ).toMatchObject({ ok: false, active: false });
-    expect(setXaiNetworkToolActive(h.api, composer, "WebSearch", true)).toEqual(
+    expect(setXaiNetworkToolActive(h.api, build, "WebSearch", true)).toEqual(
       { ok: true, active: true },
     );
     expect(isXaiNetworkToolActive(h.api, "WebSearch")).toBe(true);


### PR DESCRIPTION
## Summary
- Composer is already a grok-4.5 alias after #97
- Official Grok default tool path is not Cursor-named tools
- Stop enabling Cursor/Grok CLI shims for grok-composer-2.5-fast
- Keep shims only for an entitled grok-build entry
- Docs/tests updated accordingly

## Why
Grok default harness uses native tools. Composer now resolves to grok-4.5-build on the wire, and grok-4.5 already runs on pi normal tools without Cursor shims.

## Test plan
- [x] npm test
- [ ] /model grok-composer-2.5-fast — no Cursor shim tools auto-enabled
- [ ] /model grok-4.5 — unchanged
- [ ] /model grok-build (if entitled) — still gets Cursor shims

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted tool-routing change for one model alias; Grok Build behavior is preserved and covered by updated tests, with a possible behavior shift for users who relied on Composer auto-enabling Cursor-named tools.
> 
> **Overview**
> **`grok-composer-2.5-fast` no longer triggers Cursor/Grok CLI tool shims** — it is documented and treated as a Grok 4.5 alias that uses pi’s normal tools (`read`, `write`, `edit`, `bash`, …), matching the default Grok 4.5 path.
> 
> The gate is **`isGrokCliCompatibilityModel`**, which now returns true only for **`grok-build`** (not Composer). That drives automatic activation of local shims (`Read`, `Grep`, `Shell`, etc.), **`WebSearch`** eligibility in `/xai-tools`, and related error strings. Entitled **`grok-build`** keeps the legacy Cursor compatibility surface and Grok Build–specific Responses payload behavior unchanged.
> 
> README and tests were updated to reflect Composer vs Build split; lifecycle and shim tests now use **`grok-build`** where Composer was previously assumed to need shims.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ad1fd8781fd4647ba7fa504f2bc842265a9e897. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->