### PR TITLE
fix: restore Grok 4.3 OAuth visibility

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,6 +11,7 @@ coverage/
 .omp/
 .pi-subagents/
 .scaffold/
+.claude/
 *.pem
 *.key
 auth.json

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,29 +1,24 @@
-# Implementation Plan — Grok-native tool adapters
+# Implementation Plan — Restore Grok 4.3 OAuth visibility
 
-**Branch:** `feature/grok-native-tools`
+**Branch:** `feature/restore-grok-4-3-oauth`
 
 ## Goal
 
-Replace Cursor-style compatibility shims with collision-free pi dispatchers that expose Grok's official model-facing tool names and argument contracts for every `xai-auth` model, while keeping network search opt-in and entitlement behavior exact.
+Restore `xai-auth/grok-4.3` when the authenticated catalog exposes `grok-4.5`, without mutating the exact `/models-v2` cache or treating Grok 4.3 as a canonical alias of Grok 4.5.
 
 ## Phases
 
-1. [x] Compare the existing shims with the official local Grok implementations under `/Users/justin/Projects/grok`.
-2. [x] Rename the adapter modules and implement official contracts for `read_file`, `search_replace`, `list_dir`, `grep`, `run_terminal_command`, and opt-in `web_search`.
-3. [x] Add strict local safety behavior: workspace containment, symlink checks, grep input/output/time bounds, exact replacement, and explicit unsupported background/PDF paths.
-4. [x] Register collision-free `xai_grok_*` dispatch names and translate only current xAI request definitions to public Grok names.
-5. [x] Make streamed tool-call internalization request-scoped and preserve unrelated extensions' public tool state across lifecycle transitions.
-6. [x] Update focused tests, loader expectations, README, and architecture notes.
-7. [x] Complete independent review and run the full test/typecheck/coverage/compatibility gates.
-8. [x] Perform live `/reload` coexistence verification with `pi-web-access`.
-9. [x] Commit the final branch without `.claude/`, open PR #99, and close superseded PR #98.
+1. [x] Compare pi's normalized cache with the official Grok CLI cache.
+2. [x] Verify current public documentation and run one bounded authenticated route probe.
+3. [x] Add a separate entitlement-compatibility mapping for the distinct `grok-4.3` request slug.
+4. [x] Preserve authenticated modality evidence and conservative source limits while adding Grok 4.3 reasoning levels.
+5. [x] Add focused regressions and update README/AGENTS policy wording.
+6. [x] Run full unit, loader, typecheck, coverage, and compatibility gates.
 
 ## Validation contract
 
-- Successful `/models-v2` results remain exact entitlement state; aliases derive only from entitled canonicals.
-- No public Grok tool name is registered globally by this package.
-- Outbound xAI payloads contain official public names without duplicates; returned calls route privately only for tools exposed by that request.
-- Other extensions' public tool activation is never shadowed, snapshotted, or restored by this package.
-- Local grep remains physically inside the workspace and bounded by file, scan, time, line, and output limits.
-- `background: true` and unsupported PDF reads fail explicitly instead of silently changing semantics.
+- The persisted normalized cache remains the exact successful `/models-v2` result.
+- `grok-4.3` is advertised only while its verified `grok-4.5` entitlement source is present.
+- `resolveXaiCanonicalModelId("grok-4.3")` remains `grok-4.3`.
+- Compatibility expansion is not recursive; unverified Grok 4.3 aliases remain hidden.
 - `.claude/` remains untracked and excluded from commits.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,35 +1,34 @@
-# Execution Progress — Grok-native tool adapters
+# Execution Progress — Restore Grok 4.3 OAuth visibility
 
-**Branch:** `feature/grok-native-tools`
+**Branch:** `feature/restore-grok-4-3-oauth`
 
 ## Completed
 
-- [x] Added entitlement-aware known aliases without expanding the exact persisted catalog.
-- [x] Limited Grok CLI payload compatibility quirks to exact `grok-build`; tool activation is model-independent within `xai-auth`.
-- [x] Replaced Cursor-era adapter modules and tests with Grok-native equivalents.
-- [x] Implemented official model-facing names and argument normalization for local read, exact replace, list, grep, terminal, and opt-in xAI web search.
-- [x] Added integer validation, signed read offsets, PDF field validation with explicit unsupported execution, CRLF/BOM-preserving exact replacement, and exact `allowed_domains` preservation.
-- [x] Added physical workspace containment and bounded local grep behavior, including multiline and hidden output modes.
-- [x] Rejected unsupported managed background terminal calls; retained Grok millisecond timeout semantics while converting to pi seconds.
-- [x] Registered all adapters under private `xai_grok_*` names to avoid extension registry collisions.
-- [x] Added request-scoped public exposure and streamed-call internalization for all Grok-native tools.
-- [x] Removed external public-tool shadow/restoration state; unrelated extension activation now remains untouched.
-- [x] Updated focused tests, loader smoke expectations, README, and AGENTS architecture wording.
-- [x] Passed strict TypeScript, 412 unit tests, loader smoke, V8 coverage floors, `git diff --check`, and exact packed Pi 0.80.1/0.80.10 compatibility boundaries.
-- [x] Added worker-isolated grep matching, mixed-line-ending/BOM replacement regressions, official negative-offset edge coverage, and concurrent streamed route-isolation coverage.
-- [x] Completed fresh independent review with no blocker/high correctness or security findings.
-- [x] Verified live offline `/reload` with `xai-auth/grok-4.5` while `pi-web-access` and the local xAI extension were both loaded; pi reported a successful reload without registration collisions.
-- [x] Addressed Grok PR review findings: phantom-only negative `read_file` offsets now return an empty window, and `search_replace` performs its stale-snapshot compare plus write inside pi's shared file mutation queue.
-- [x] Added deterministic phantom-offset and concurrent-mutation regressions; 413 tests, coverage floors, typecheck, loader smoke, and packed Pi 0.80.1/0.80.10 boundaries pass.
-- [x] Grok re-reviewed both fixes in the right-hand `grok-review` pane and reported no remaining blocker/high/medium issue.
+- [x] Confirmed pi's fresh normalized OAuth cache contains only `grok-4.5`.
+- [x] Confirmed the official Grok CLI's newer authenticated `models_cache.json` also contains only `grok-4.5`.
+- [x] Verified no local normalization or hidden-entry filter dropped Grok 4.3.
+- [x] Reviewed current xAI model documentation: Grok 4.3 remains a distinct public request model.
+- [x] Ran one bounded authenticated OAuth Responses probe without logging credentials or raw bodies; HTTP 200 completed and reported response model `grok-4.3`.
+- [x] Added `XAI_MODEL_ENTITLEMENT_COMPATIBILITY` separately from canonical aliases, mapping the proven Grok 4.3 request route to the present Grok 4.5 entitlement source.
+- [x] Added Grok 4.3 none/low/medium/high reasoning metadata while retaining authenticated modality evidence and conservative source context limits.
+- [x] Added focused expansion, canonicalization, non-recursion, runtime entitlement, and metadata assertions.
+- [x] Confirmed `pi -e . --list-models xai-auth` now lists `grok-4.3` at a conservative 500K context.
+- [x] Updated README and AGENTS policy wording.
 
-## Delivered
+## Validation
 
-- [x] Committed the reviewed implementation without `.claude/`, opened PR #99, and closed superseded PR #98.
+- [x] Focused model suite: 20 tests passed.
+- [x] Primary TypeScript LSP diagnostics: zero findings.
+- [x] `git diff --check`.
+- [x] Full `npm test`: 413 tests plus real loader smoke passed.
+- [x] `npm run typecheck`.
+- [x] `npm run test:coverage`: all configured V8 floors passed.
+- [x] `npm run compatibility:check`: packed manifest and peer policy passed.
+- [x] `npm run compatibility:boundaries`: exact Pi 0.80.1 and 0.80.10 suites/typecheck passed.
 
-## Residual / intentional adaptations
+## Residual constraints
 
-- Pi does not expose Grok's managed background task lifecycle, so `background: true` fails closed.
-- Pi's text reader cannot render PDF pages, so PDF `read_file` calls fail with guidance instead of pretending support.
-- Local grep uses a conservative workspace-only implementation and bounded file-type subset rather than spawning the full Grok ripgrep environment.
+- The exact cache never stores Grok 4.3 unless xAI itself returns it.
+- Grok 4.3 remains distinct from Grok 4.5 for outbound requests and canonical resolution.
+- Unverified `grok-latest` / `grok-4.3-latest` compatibility is not inferred from the Grok 4.3 probe.
 - `.claude/` is unrelated untracked state and must not be committed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Core flow: `bin/setup.js` → `pi install` → bounded catalog selection in `ext
 - Fetch OAuth-visible models only from the pinned authenticated CLI proxy `/models-v2` endpoint
 - Treat successful catalog responses as exact entitlement state; additions appear and removals disappear
 - Keep the normalized token-free catalog cache atomic and apply the documented TTL/stale/fallback policy
-- Preserve known model metadata and compatibility behavior without inventing unentitled model families; known aliases of already-entitled models may be advertised at registration/runtime only (cache stays exact)
+- Preserve known model metadata and compatibility behavior without inventing unentitled model families; known aliases and independently verified OAuth request slugs may be advertised only while their entitlement source is present at registration/runtime (cache stays exact)
 - Keep both Pi peers aligned to the checked-in bounded range in `compatibility/pi-versions.json`
 - Install/report exact Pi matrix versions from a clean packed package; never reuse the repository lockfile for boundary jobs
 - Keep normal Pi dev dependencies exact at the policy's latest tested release and review candidate releases before widening support

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pi --model grok-4.5:high "Review this architecture for failure modes"
 pi --model grok-4.5:low "Quick status check"   # fast mode
 ```
 
-This package adds xAI's **account-specific OAuth model catalog** to pi, with **Grok 4.5** as the offline fallback/default, proper OAuth login, automatic token refresh, and a suite of custom tools (`xai_generate_text`, `xai_web_search`, `xai_x_search`, etc.). Models such as Grok Build, Composer, Grok 4.3, and Grok 4.20 appear only when xAI returns them for the authenticated account.
+This package adds xAI's **account-specific OAuth model catalog** to pi, with **Grok 4.5** as the offline fallback/default, proper OAuth login, automatic token refresh, and a suite of custom xAI tools (`xai_generate_text`, `xai_web_search`, `xai_x_search`, etc.). The normalized cache remains exact; registration may additionally expose narrowly verified compatibility routes such as Grok 4.3 and Composer only while their required authenticated entitlement source is present.
 
 > **Latest release:** `pi-xai-oauth` **1.3.5** keeps the highlighted `/xai-tools` row in place after toggling, so multiple tools can be configured without repeatedly navigating from the top. Version 1.3.4 made every network-backed xAI helper an explicit, session-scoped opt-in through `/xai-tools`, including paid image generation, and made disabled tools fail before OAuth credential lookup or network access. Existing npm installs should run `pi update npm:pi-xai-oauth`; local checkout installs should keep only one copy with `pi remove npm:pi-xai-oauth && pi install .`.
 >
@@ -76,10 +76,10 @@ See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and
 - **Reuses existing credentials** — auto-detects `~/.grok/auth.json` from the official Grok CLI
 - **Grok 4.5 flagship (default)** — xAI's newest model for coding, agentic tasks, and knowledge work; 500K context, text+image input, high reasoning by default
 - **Grok 4.5 fast mode** — same model with `low` reasoning effort (`/think low` or `grok-4.5:low`); not a separate model ID
-- **Long-context metadata when entitled** — known Grok 4.3 behavior is preserved when xAI returns it, with authenticated limits taking precedence
+- **Grok 4.3 OAuth compatibility** — advertises the independently verified `grok-4.3` request route only when `grok-4.5` is entitled, retaining authenticated input evidence and conservative limits
 - **Authenticated model catalog** — fetches the OAuth-visible `/models-v2` list from the official CLI proxy, so additions and removals track the signed-in account
 - **Explicit subscription usage** — `/xai-usage` performs a bounded, identity-first lookup against the revision-pinned unofficial Grok billing surface without retaining account identity
-- **Coding models when entitled** — Grok Build, Composer, and other models appear only when xAI includes them in the account catalog
+- **Coding models when entitled** — directly advertised Grok Build variants track the account catalog; the Composer compatibility alias appears only while its verified `grok-4.5` entitlement source is present
 - **Reasoning support** — parses supplied reasoning capability and thinking levels while preserving known model compatibility
 - **Bounded last-known-good cache** — avoids routine startup delay and falls back safely when discovery is offline or unavailable
 - **Custom xAI tools** — generate text, web search, X/Twitter search, multi-agent research, code analysis
@@ -263,14 +263,14 @@ Enabling status performs one immediate lookup. Later refreshes are event-driven 
 
 ### Switching Models
 
-`/model` shows the current authenticated account's xAI catalog. A successful refresh is authoritative: newly returned models appear, removed models disappear, hidden entries are omitted, and known API-key-only models such as `grok-build-0.1` are never advertised through `xai-auth`.
+`/model` shows the current authenticated account's xAI catalog plus narrowly scoped compatibility routes whose entitlement source is present. A successful refresh remains authoritative: newly returned entitlement sources appear, removed sources and their compatibility routes disappear, hidden entries are omitted, and known API-key-only models such as `grok-build-0.1` are never advertised through `xai-auth`.
 
 Common catalog entries include:
 
 | Model ID | Description |
 |----------|-------------|
 | `grok-4.5` | **Default and curated offline fallback.** xAI flagship; reasoning low (**fast**) / medium / high (default), 500K context, text+image. |
-| `grok-4.3` | When entitled: full reasoning, with limits taken from the authenticated catalog. |
+| `grok-4.3` | OAuth-compatible request model when `grok-4.5` is entitled; keeps authenticated input evidence and conservative catalog-derived limits. |
 | `grok-build` | When entitled: Grok Build coding model (same Grok-native tools as other xai-auth models). |
 | `grok-composer-2.5-fast` | Compatibility alias of entitled `grok-4.5`; uses the same Grok-native pi tool adapters and no Cursor-named shims. |
 | `grok-4.20-0309-reasoning` | When entitled: Grok 4.20 with automatic reasoning. |
@@ -292,7 +292,7 @@ From the command line:
 
 ```bash
 pi --model grok-4.5 "Your prompt here"
-pi --model grok-4.3 "Use the 1M-context model"
+pi --model grok-4.3 "Use Grok 4.3"
 pi --model grok-build "Implement this feature"
 pi --model grok-composer-2.5-fast "Refactor this module"
 pi --model grok-4.20-0309-non-reasoning "Quick answer"
@@ -326,7 +326,7 @@ The cache stores only normalized model definitions, bounded input-capability pro
 
 ### Reasoning / Thinking Levels
 
-Grok 4.5, and Grok 4.3 when returned with reasoning support, expose configurable thinking levels via pi's `/think` command or `model:effort` syntax. There is **no separate `grok-4.5-fast` model** — on Grok 4.5, “fast mode” is **`reasoning_effort: "low"`** on the same model ID.
+Grok 4.5 and the entitlement-gated Grok 4.3 compatibility route expose configurable thinking levels via pi's `/think` command or `model:effort` syntax. There is **no separate `grok-4.5-fast` model** — on Grok 4.5, “fast mode” is **`reasoning_effort: "low"`** on the same model ID.
 
 ```
 /think high
@@ -348,7 +348,7 @@ pi --model grok-4.5:low "What's the weather?"   # fast / latency-sensitive
 | **`medium`** | Balanced thinking vs latency | Analysis and longer-context work |
 | **`low`** (**fast mode**) | Some reasoning, still fast | Latency-sensitive agents and simple tool calling |
 
-`grok-4.5` defaults to **high** when no effort is specified; reasoning **cannot be disabled** (`/think off` is not supported for this model). Every model actually returned and selected through the OAuth-only `xai-auth` catalog sends Responses traffic through xAI's Grok CLI session endpoint using the same X account OAuth token. An entitled `grok-build` entry still receives its legacy Responses payload/header compatibility behavior, while every `xai-auth` model uses the same Grok-native local tool adapters. The Composer alias (`grok-composer-2.5-fast`) follows the Grok 4.5 payload path. `grok-4.20-0309-reasoning` reasons automatically and does not accept a configurable effort parameter. `grok-4.20-multi-agent-0309` uses `medium` for 4 agents and `high` for 16 agents.
+`grok-4.5` defaults to **high** when no effort is specified; reasoning **cannot be disabled** (`/think off` is not supported for this model). Every model selected through the OAuth-only `xai-auth` runtime catalog sends Responses traffic through xAI's Grok CLI session endpoint using the same X account OAuth token. An entitled `grok-build` entry still receives its legacy Responses payload/header compatibility behavior, while every `xai-auth` model uses the same Grok-native local tool adapters. The Composer alias (`grok-composer-2.5-fast`) follows the Grok 4.5 payload path. `grok-4.20-0309-reasoning` reasons automatically and does not accept a configurable effort parameter. `grok-4.20-multi-agent-0309` uses `medium` for 4 agents and `high` for 16 agents.
 
 ### Grok 4.5 source notes
 
@@ -634,7 +634,7 @@ If you have the official Grok CLI installed and authenticated (`~/.grok/auth.jso
 
 ### "Why is a model missing or still cached?"
 
-The xAI model list is entitlement-aware. If a model is missing, the authenticated `/models-v2` response did not include a usable OAuth Responses entry, or discovery fell back to the curated offline catalog. Run `/login xai-auth` to force an account-bound refresh. `/reload` reloads the extension but intentionally reuses a cache younger than 15 minutes; after the TTL it performs a bounded refresh. Known renames such as `grok-composer-2.5-fast` and `grok-build-latest` are advertised only as aliases of an already-entitled canonical model (currently `grok-4.5`), so settings patterns keep matching without inventing unentitled catalog entries.
+The xAI model list is entitlement-aware. If a model is missing, the authenticated `/models-v2` response did not include a usable OAuth Responses entry or a required entitlement source, or discovery fell back to the curated offline catalog. Run `/login xai-auth` to force an account-bound refresh. `/reload` reloads the extension but intentionally reuses a cache younger than 15 minutes; after the TTL it performs a bounded refresh. Known renames such as `grok-composer-2.5-fast` and `grok-build-latest` are advertised only as aliases of an already-entitled canonical model. The distinct `grok-4.3` request route is likewise advertised only when its independently verified OAuth entitlement source (`grok-4.5`) is present; none of these compatibility entries are persisted into the exact catalog cache.
 
 A one-shot `pi --list-models` cannot refresh an already-expired pi-stored OAuth token before the model registry is bound. It can still use a fresh official Grok CLI bearer when available; otherwise it uses fresh cache or the curated fallback. Starting a normal session lets pi refresh its stored credential under the credential-store lock and then revalidate the catalog.
 

--- a/extensions/xai/models.ts
+++ b/extensions/xai/models.ts
@@ -69,6 +69,14 @@ export const KNOWN_XAI_MODEL_METADATA: readonly XaiCatalogModel[] = [
     cost: { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 0 },
     contextWindow: 1_000_000,
     maxTokens: 131_072,
+    thinkingLevelMap: {
+      off: "none",
+      minimal: "low",
+      low: "low",
+      medium: "medium",
+      high: "high",
+      xhigh: null,
+    },
   },
   {
     id: "grok-build",
@@ -169,13 +177,32 @@ export const XAI_MODEL_ALIASES: Readonly<Record<string, string>> = {
   "grok-4.20-multi-agent-latest": "grok-4.20-multi-agent-0309",
 };
 
-const XAI_ALIASES_BY_CANONICAL = (() => {
+/**
+ * Additional model slugs proven usable through the OAuth Responses proxy even
+ * when `/models-v2` advertises only the model that grants the route entitlement.
+ *
+ * Keep this separate from `XAI_MODEL_ALIASES`: these slugs remain distinct
+ * request models and must not canonicalize to their entitlement source.
+ *
+ * Evidence (2026-07-18): the same session catalog contained only `grok-4.5`,
+ * while a bounded `grok-4.3` Responses probe completed successfully and reported
+ * `grok-4.3` as the response model.
+ */
+export const XAI_MODEL_ENTITLEMENT_COMPATIBILITY: Readonly<Record<string, string>> = {
+  "grok-4.3": "grok-4.5",
+};
+
+const XAI_ADVERTISEMENTS_BY_ENTITLEMENT = (() => {
   const map = new Map<string, string[]>();
-  for (const [alias, canonical] of Object.entries(XAI_MODEL_ALIASES)) {
-    const key = canonical.toLowerCase();
+  const advertisements = [
+    ...Object.entries(XAI_MODEL_ALIASES),
+    ...Object.entries(XAI_MODEL_ENTITLEMENT_COMPATIBILITY),
+  ];
+  for (const [advertised, entitlementSource] of advertisements) {
+    const key = entitlementSource.toLowerCase();
     const list = map.get(key);
-    if (list) list.push(alias);
-    else map.set(key, [alias]);
+    if (list) list.push(advertised);
+    else map.set(key, [advertised]);
   }
   for (const list of map.values()) list.sort();
   return map;
@@ -246,9 +273,9 @@ export function resolveXaiCanonicalModelId(modelId: string): string {
 }
 
 /**
- * Expand an exact entitlement snapshot with known aliases of currently entitled
- * models. The remote/cache catalog stays exact; only the advertised runtime
- * provider list gains compatibility aliases.
+ * Expand an exact entitlement snapshot with known aliases and proven compatible
+ * OAuth request models. The remote/cache catalog stays exact; only the advertised
+ * runtime provider list gains compatibility entries.
  */
 export function expandXaiCatalogWithAliases(
   models: readonly XaiCatalogModel[],
@@ -266,7 +293,7 @@ export function expandXaiCatalogWithAliases(
   const expanded: XaiCatalogModel[] = [...entitled.values()];
   const aliasEntries: Array<[string, XaiCatalogModel]> = [];
   for (const [canonical, base] of entitled) {
-    const aliases = XAI_ALIASES_BY_CANONICAL.get(canonical) ?? [];
+    const aliases = XAI_ADVERTISEMENTS_BY_ENTITLEMENT.get(canonical) ?? [];
     for (const alias of aliases) {
       if (entitled.has(alias)) continue;
       aliasEntries.push([alias, materializeAliasModel(alias, base)]);

--- a/scripts/verify-extension-loader.mjs
+++ b/scripts/verify-extension-loader.mjs
@@ -48,7 +48,8 @@ try {
   assert.ok(modelIds.includes("grok-composer-2.5-fast"), "known aliases of entitled fallback models should be advertised");
   assert.ok(modelIds.includes("grok-build-latest"));
   assert.ok(modelIds.includes("grok-4.5-latest"));
-  assert.equal(modelIds.length, 4, "fallback should advertise grok-4.5 plus its known aliases only");
+  assert.ok(modelIds.includes("grok-4.3"), "proven OAuth routes of present entitlement sources should be advertised");
+  assert.equal(modelIds.length, 5, "fallback should advertise grok-4.5 plus bounded compatibility entries only");
   console.log("verify-extension-loader: ok");
 } finally {
   if (previousHome === undefined) delete process.env.HOME;

--- a/tests/provider/catalog-lifecycle.test.ts
+++ b/tests/provider/catalog-lifecycle.test.ts
@@ -27,7 +27,7 @@ async function loadAndLogin(catalog: any) {
   let authUrl: URL | undefined;
   vi.stubGlobal(
     "fetch",
-    vi.fn(async (input: any, init: RequestInit = {}) => {
+    vi.fn(async (input: any) => {
       const url = String(input);
       if (url.endsWith("openid-configuration"))
         return jsonResponse(discovery());
@@ -43,7 +43,7 @@ async function loadAndLogin(catalog: any) {
           }),
         });
       if (url.endsWith("models-v2")) return jsonResponse(catalog);
-      throw new Error(`Unexpected request origin ${new URL(url).origin}`);
+      throw new Error(`Unexpected request origin ${URL.parse(url)?.origin ?? "invalid URL"}`);
     }),
   );
   await extension(h.api);
@@ -55,10 +55,14 @@ async function loadAndLogin(catalog: any) {
     onSelect: async () => "browser",
     onDeviceCode: () => {},
     onAuth(auth: any) {
-      authUrl = new URL(auth.url);
-      const callback = new URL(authUrl.searchParams.get("redirect_uri")!);
+      const parsedAuthUrl = URL.parse(auth.url);
+      const redirectUri = parsedAuthUrl?.searchParams.get("redirect_uri");
+      const callback = redirectUri ? URL.parse(redirectUri) : null;
+      const state = parsedAuthUrl?.searchParams.get("state");
+      if (!parsedAuthUrl || !callback || !state) throw new Error("Invalid test authorization URL");
+      authUrl = parsedAuthUrl;
       callback.searchParams.set("code", "login-code");
-      callback.searchParams.set("state", authUrl.searchParams.get("state")!);
+      callback.searchParams.set("state", state);
       manualCallback = callback.toString();
     },
     onManualCodeInput: async () => manualCallback,
@@ -86,7 +90,8 @@ describe.sequential("authenticated provider catalog lifecycle", () => {
     expect(h.providers.get("xai-auth").models.map(({ id }: any) => id)).toEqual([
       "grok-4.5",
       "new-entitled",
-      // Known aliases of entitled grok-4.5 only — not invented families.
+      // Known aliases and proven OAuth routes of entitled grok-4.5 only — not invented families.
+      "grok-4.3",
       "grok-4.5-latest",
       "grok-build-latest",
       "grok-composer-2.5-fast",

--- a/tests/provider/models.test.ts
+++ b/tests/provider/models.test.ts
@@ -29,6 +29,8 @@ describe("model compatibility metadata", () => {
   it("resolves known renamed model aliases to canonical catalog ids", () => {
     expect(resolveXaiCanonicalModelId("xai-auth/grok-composer-2.5-fast")).toBe("grok-4.5");
     expect(resolveXaiCanonicalModelId("grok-build-latest")).toBe("grok-4.5");
+    // Grok 4.3 is a distinct OAuth request model, not a canonical alias of 4.5.
+    expect(resolveXaiCanonicalModelId("grok-4.3")).toBe("grok-4.3");
     expect(resolveXaiCanonicalModelId("grok-4.20")).toBe("grok-4.20-0309-reasoning");
     expect(resolveXaiCanonicalModelId("grok-4.20-multi-agent")).toBe("grok-4.20-multi-agent-0309");
     expect(resolveXaiCanonicalModelId("grok-4.5")).toBe("grok-4.5");
@@ -46,10 +48,13 @@ describe("model compatibility metadata", () => {
     const ids = expanded.map((model) => model.id);
 
     expect(ids).toContain("grok-4.5");
+    expect(ids).toContain("grok-4.3");
     expect(ids).toContain("grok-composer-2.5-fast");
     expect(ids).toContain("grok-build-latest");
     expect(ids).toContain("grok-4.5-latest");
-    // Unentitled families stay hidden.
+    // Compatibility expansion is intentionally not recursive: unproven 4.3 aliases
+    // and unrelated model families stay hidden.
+    expect(ids).not.toContain("grok-latest");
     expect(ids).not.toContain("grok-4.20-0309-reasoning");
     expect(ids).not.toContain("grok-4.20");
     expect(ids).not.toContain("grok-build");
@@ -63,8 +68,20 @@ describe("model compatibility metadata", () => {
       contextWindow: entitled.contextWindow,
     });
 
+    const fourThree = expanded.find((model) => model.id === "grok-4.3");
+    expect(fourThree).toMatchObject({
+      name: "Grok 4.3",
+      reasoning: true,
+      input: ["text"],
+      inputProvenance: XaiModelInputProvenance.AuthenticatedAcceptsImages,
+      // Keep the authenticated entitlement source's conservative context bound.
+      contextWindow: entitled.contextWindow,
+      thinkingLevelMap: { off: "none", minimal: "low", low: "low", medium: "medium", high: "high" },
+    });
+
     setXaiRuntimeModels(expanded);
     expect(isXaiRuntimeModelEntitled("grok-composer-2.5-fast")).toBe(true);
+    expect(isXaiRuntimeModelEntitled("grok-4.3")).toBe(true);
     expect(isXaiRuntimeModelEntitled("grok-4.20")).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- restore `xai-auth/grok-4.3` when the authenticated runtime catalog contains its verified `grok-4.5` entitlement source
- keep Grok 4.3 as a distinct request model rather than canonicalizing it to Grok 4.5
- preserve the exact token-free `/models-v2` cache while carrying authenticated modality evidence and conservative source limits into the runtime compatibility entry
- add Grok 4.3 reasoning-level metadata, focused lifecycle/model regressions, loader coverage, and updated policy/docs
- exclude unrelated local `.claude/` state from npm packages without staging or modifying that directory

## Evidence

Both pi's normalized cache and the official Grok CLI's newer authenticated model cache contained only `grok-4.5`. A bounded authenticated OAuth Responses probe for `grok-4.3` completed with HTTP 200 and reported `grok-4.3` as the response model. The compatibility mapping is therefore separate from canonical aliases and is enabled only while its entitlement source is present.

`pi -e . --list-models xai-auth` now includes:

```text
xai-auth  grok-4.3  500K  131.1K  yes  yes
```

Unverified `grok-latest` and `grok-4.3-latest` routes are intentionally not inferred.

## Validation

- `npm test` — 413 tests plus real loader smoke
- `npm run typecheck`
- `npm run test:coverage` — configured V8 floors passed
- `npm run compatibility:check`
- `npm run compatibility:boundaries` — exact Pi 0.80.1 and 0.80.10 suites/typecheck passed
- `git diff --check`
- full targeted diagnostics — zero errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model catalog advertisement and entitlement gating for OAuth routing; incorrect mapping could hide models or send wrong model IDs, but scope is narrow and covered by focused tests.
> 
> **Overview**
> Restores **`grok-4.3`** in the `xai-auth` runtime model list when the account catalog only includes **`grok-4.5`**, without writing Grok 4.3 into the normalized `/models-v2` cache.
> 
> Introduces **`XAI_MODEL_ENTITLEMENT_COMPATIBILITY`** (separate from canonical **`XAI_MODEL_ALIASES`**) so `grok-4.3` is advertised only while `grok-4.5` is entitled, yet **`resolveXaiCanonicalModelId("grok-4.3")`** still resolves to **`grok-4.3`** for outbound requests. Runtime expansion merges aliases and entitlement-compat routes via **`XAI_ADVERTISEMENTS_BY_ENTITLEMENT`**; unverified slugs like **`grok-latest`** are not inferred from the 4.3 route.
> 
> Adds Grok 4.3 **reasoning level** metadata, inherits **authenticated input** and **conservative context** from the entitlement source, and updates loader smoke, catalog lifecycle, and model unit tests plus **README** / **AGENTS** policy. **`.npmignore`** now excludes **`.claude/`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 419572c4643abf0de5ccc1c2b301bd7435825c9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->