### PR TITLE
feat: replay encrypted xAI reasoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 
 ### Added
 
+- Added encrypted reasoning replay on the pinned OAuth Responses route, including final `store:false` defaults, deduplicated encrypted-content requests, complete inline typed-item persistence/replay, exact provider/API/model isolation, and fixed redacted mismatch guidance.
 - Added a revision-pinned Grok Build wire-protocol matrix, ID-ownership policy, repeatable upstream review procedure, and an explicit encrypted-reasoning handoff to issue #79.
 - Added deterministic streaming/direct Responses, catalog, OAuth form, client-mode, media-boundary, reserved-header, bounded-error, and proxy version-gate request-shape coverage.
 - Added bounded authenticated `acceptsImages` / `inputModalities` normalization with explicit input-capability provenance and redacted schema fixtures.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ node scripts/run-compatibility-matrix.js X.Y.Z --candidate
 
 This changes metadata only inside a temporary extracted tarball. For a patch inside the allowed line, update the policy `latest`, both exact Pi dev dependencies, and `package-lock.json` only after the candidate passes. For a new pre-1.0 minor, keep the existing upper bound during evaluation and widen it only after the exact candidate passes the full packed tests/typecheck and review. If the minimum changes, test the immediately previous published release as unsupported and document the support break.
 
-The xAI wire contract has an independent review process in [`compatibility/grok-build-wire-protocol.md`](compatibility/grok-build-wire-protocol.md). Pin an immutable upstream Grok Build commit, trace header/ID ownership from source, preserve the package's truthful identity and pinned routes, update request-shape/privacy tests, and never copy an official client version merely to bypass a gate. Encrypted reasoning implementation belongs to issue #79.
+The xAI wire contract has an independent review process in [`compatibility/grok-build-wire-protocol.md`](compatibility/grok-build-wire-protocol.md). Pin an immutable upstream Grok Build commit, trace header/ID ownership from source, preserve the package's truthful identity and pinned routes, update request-shape/privacy tests, and never copy an official client version merely to bypass a gate. Encrypted reasoning changes must preserve the documented opaque replay, route/model isolation, local-session privacy, and redacted terminal-error contract.
 
 Every dependency/compatibility PR and release must run:
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,15 @@ The exclusive `<0.81.0` upper bound is deliberate. Pi is pre-1.0, so a new minor
 
 Older `pi-xai-oauth` 1.2.4 builds supported Pi 0.79.8's then-current Responses guard. Current code uses the Pi 0.80 compat dispatcher after the 1.3.2 export migration and 1.3.3 loader-resolution fix, so that historical statement is not the current minimum.
 
-The xAI transport contract is tracked separately from Pi package compatibility. See [Grok Build wire-protocol compatibility](compatibility/grok-build-wire-protocol.md) for the pinned upstream revision, route/header matrix, identity and ID-ownership policy, safe gate errors, and repeatable review procedure. Encrypted reasoning replay is recorded there but remains deferred to issue #79.
+The xAI transport contract is tracked separately from Pi package compatibility. See [Grok Build wire-protocol compatibility](compatibility/grok-build-wire-protocol.md) for the pinned upstream revision, route/header matrix, identity and ID-ownership policy, encrypted-reasoning replay contract, safe errors, and repeatable review procedure.
+
+### Encrypted reasoning replay
+
+On the pinned OAuth Responses route, requests default an absent `store` to `false` and request `reasoning.encrypted_content`. Pi retains completed reasoning output items as opaque state and replays them inline only when the provider, API, and exact model still match. Switching targets drops that replay; compaction may intentionally replace older active context.
+
+`store: false` disables server-side response storage, but it does **not** mean no local sensitive state. Complete encrypted reasoning items are stored in ordinary Pi session JSONL under Pi's normal permissions and retention. This package does not separately encrypt that file, copy reasoning into another cache, or protect it from the user or trusted local extensions.
+
+If xAI reports that encrypted reasoning is incompatible with the selected model, the request is not retried automatically. Start a clean session or turn and keep the same xAI model for subsequent replay.
 
 ---
 

--- a/compatibility/grok-build-wire-protocol.md
+++ b/compatibility/grok-build-wire-protocol.md
@@ -83,17 +83,19 @@ Catalog, OAuth, OIDC, and device paths retain their existing stricter endpoint, 
 
 ## Encrypted reasoning boundary (#79)
 
-Issue [#79](https://github.com/BlockedPath/pi-xai-oauth/issues/79) owns implementation of encrypted reasoning. The reviewed contract area is:
+Issue [#79](https://github.com/BlockedPath/pi-xai-oauth/issues/79) implements the reviewed contract on the pinned OAuth streaming and direct Responses routes:
 
-- default `store` to `false` when the verified Responses policy permits it;
-- request `reasoning.encrypted_content` exactly once;
-- retain the complete typed reasoning item, including its opaque encrypted content;
-- replay that item verbatim and inline at its original conversation position;
-- preserve stable serialized prefixes across later turns;
-- never render, inspect, transform, log, cache outside the Pi session, or send encrypted content across provider/endpoint/model-family boundaries;
-- treat encrypted-content/model-family mismatch as terminal and actionable.
+- absent `store` defaults to `false`, while an explicit value is preserved;
+- final `include` retains compatible string entries in first-occurrence order and contains `reasoning.encrypted_content` exactly once, even after caller payload hooks;
+- complete completed reasoning items, including encrypted-only and additive fields, use Pi's opaque `thinkingSignature` carrier and replay inline at their original conversation position;
+- active, uncompacted multi-turn input keeps a stable serialized prefix;
+- Pi permits replay only when provider, API, and exact model match, and omits failed or aborted assistant turns;
+- API-key direct Responses, media, catalog, usage, auth, and non-Responses routes do not receive this package policy;
+- a proxy HTTP 400 containing the narrow `encrypted_content` marker produces fixed clean-session/model guidance, is redacted, and is not automatically retried.
 
-Issue #78 does not change payload include handling, conversation persistence, typed reasoning retention, replay ordering, or mismatch retry behavior. Those changes and their persistence/provider-switching fixtures remain deferred to #79.
+Encrypted content is ordinary local Pi session state. `store:false` disables server-side response storage but does not prevent Pi from writing the complete item to its session JSONL under normal permissions and retention. This package does not separately encrypt, duplicate, inspect, render, or log it. Compaction may intentionally replace older active context, and trusted local extensions or users with file access can inspect session state.
+
+Pi's delegated SSE error shape does not preserve an HTTP status for failures that arrive after a successful stream connection. The narrow HTTP 400 classifier therefore applies to initial Responses HTTP failures; later in-stream failures remain generic and redacted rather than being guessed from message text.
 
 ## Repeatable upstream review procedure
 

--- a/docs/testing/assertion-parity.md
+++ b/docs/testing/assertion-parity.md
@@ -93,7 +93,7 @@ replacement tests pass alongside the legacy verifier.
 | `verify-extension.js:1058-1124` | direct and stream payloads compact before transport, including in-place `onPayload` mutation | `tests/responses/images.test.ts` | [x] |
 | `verify-extension.js:1126-1150` | delegated error prefix is xAI, never OpenAI; terminal result extraction | `tests/responses/streaming.test.ts` | [x] |
 | `verify-extension.js:1152-1217` | real Pi OpenAI Responses transport reaches configured endpoint; xAI transport bypasses conflicting compat registration and returns terminal result | real loader registration in `scripts/verify-extension-loader.mjs`; compat forwarding details in `tests/responses/streaming.test.ts` | [x] |
-| payload behavior currently exercised indirectly throughout verifier | developer/system instructions, CLI reasoning/include cleanup, response format, cache retention/key, image normalization | `tests/responses/payload.test.ts` | [x] |
+| payload behavior currently exercised indirectly throughout verifier | developer/system instructions, CLI reasoning retention and OAuth include policy, response format, cache retention/key, image normalization | `tests/responses/payload.test.ts`, `tests/responses/reasoning-replay.test.ts` | [x] |
 | `verify-extension.js:2519-2532` | provider error is one request, translated with status, and keeps active model | `tests/responses/streaming.test.ts`, `tests/tools/custom-tools.test.ts` | [x] |
 
 ### Images — codec, replay, transport, and Images API

--- a/extensions/xai/payload.ts
+++ b/extensions/xai/payload.ts
@@ -28,6 +28,28 @@ export function canonicalizeXaiResponsesPayload(payload: unknown): Record<string
 
 export type GrokNativeToolRoutes = Readonly<Record<string, string>>;
 
+const XAI_ENCRYPTED_REASONING_INCLUDE = "reasoning.encrypted_content";
+
+/** Apply the final request policy for the pinned OAuth Responses route. */
+export function applyXaiOAuthResponsesPolicy(payload: Record<string, unknown>): Record<string, unknown> {
+  const include = Array.isArray(payload.include) ? payload.include : [];
+  const normalizedInclude: string[] = [];
+  const seen = new Set<string>();
+  for (const value of include) {
+    if (typeof value !== "string" || seen.has(value)) continue;
+    seen.add(value);
+    normalizedInclude.push(value);
+  }
+  if (!seen.has(XAI_ENCRYPTED_REASONING_INCLUDE)) {
+    normalizedInclude.push(XAI_ENCRYPTED_REASONING_INCLUDE);
+  }
+  return {
+    ...payload,
+    ...(payload.store === undefined ? { store: false } : {}),
+    include: normalizedInclude,
+  };
+}
+
 function rewriteGrokDispatchObject(value: unknown, expectedType: string): unknown {
   if (!value || typeof value !== "object" || Array.isArray(value)) return value;
   const item = value as Record<string, unknown>;
@@ -301,7 +323,6 @@ export function rewriteXaiResponsesPayload(payload: unknown, model: Model<Api>, 
     if (usesGrokCliCompatibility) {
       input = input.filter((item) => {
         if (!item || typeof item !== "object") return true;
-        if (item.type === "reasoning") return false;
         if (typeof item.content === "string" && item.content.length === 0) return false;
         if (item.role !== "developer" && item.role !== "system") return true;
         const text = textFromResponsesContent(item.content).trim();
@@ -338,11 +359,6 @@ export function rewriteXaiResponsesPayload(payload: unknown, model: Model<Api>, 
     } else {
       delete body.reasoning;
     }
-  }
-
-  if (usesGrokCliCompatibility && Array.isArray(body.include)) {
-    body.include = body.include.filter((item: unknown) => item !== "reasoning.encrypted_content");
-    if (body.include.length === 0) delete body.include;
   }
 
   // xAI doesn't implement OpenAI's prompt_cache_retention knobs. Keep the

--- a/extensions/xai/responses.ts
+++ b/extensions/xai/responses.ts
@@ -9,6 +9,7 @@ import {
   xaiModelForRequest,
 } from "./models";
 import {
+  applyXaiOAuthResponsesPolicy,
   canonicalizeXaiResponsesPayload,
   exposeGrokNativeToolNames,
   internalizeGrokNativeToolCalls,
@@ -47,13 +48,26 @@ function acquireRedirectGuard(url: string): () => void {
   if (!redirectGuardFetch) {
     unguardedFetch = globalThis.fetch;
     const baseFetch = unguardedFetch;
-    redirectGuardFetch = (input, init) =>
-      baseFetch(
+    redirectGuardFetch = async (input, init) => {
+      const url = fetchRequestUrl(input);
+      const guarded = guardedRedirectUrls.has(url);
+      const response = await baseFetch(
         input,
-        guardedRedirectUrls.has(fetchRequestUrl(input))
-          ? { ...init, redirect: "error" }
-          : init,
+        guarded ? { ...init, redirect: "error" } : init,
       );
+      if (!guarded || response.ok) return response;
+      const error = await xaiHttpErrorFromResponse(response, url);
+      const marker = error.code === "encrypted-content-mismatch"
+        ? "encrypted_content"
+        : error.code === "proxy-version-gate"
+          ? "update_required"
+          : "request failed";
+      return new Response(JSON.stringify({ error: { message: marker } }), {
+        status: response.status,
+        statusText: response.statusText,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
     globalThis.fetch = redirectGuardFetch;
   }
   guardedRedirectUrls.set(url, (guardedRedirectUrls.get(url) ?? 0) + 1);
@@ -87,16 +101,37 @@ function normalizeXaiErrorText(value: string): string {
     : value;
 }
 
+function restoreXaiMessageIdentity(value: unknown, model: Model<Api>): unknown {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+  const message = value as Record<string, unknown>;
+  if (message.role !== "assistant") return value;
+  return {
+    ...message,
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+  };
+}
+
 function normalizeXaiStreamEvent(
   event: AssistantStreamEvent,
   grokNativeToolRoutes: GrokNativeToolRoutes,
+  model: Model<Api>,
 ): AssistantStreamEvent {
-  const partial = internalizeGrokNativeToolCalls(event.partial, grokNativeToolRoutes);
+  const partial = internalizeGrokNativeToolCalls(
+    restoreXaiMessageIdentity(event.partial, model),
+    grokNativeToolRoutes,
+  );
   const toolCall = internalizeGrokNativeToolCalls(event.toolCall, grokNativeToolRoutes);
-  const message = internalizeGrokNativeToolCalls(event.message, grokNativeToolRoutes);
+  const message = internalizeGrokNativeToolCalls(
+    restoreXaiMessageIdentity(event.message, model),
+    grokNativeToolRoutes,
+  );
+  const restoredError = restoreXaiMessageIdentity(event.error, model);
   const internalized =
-    partial !== event.partial || toolCall !== event.toolCall || message !== event.message
-      ? { ...event, partial, toolCall, message }
+    partial !== event.partial || toolCall !== event.toolCall ||
+      message !== event.message || restoredError !== event.error
+      ? { ...event, partial, toolCall, message, error: restoredError }
       : event;
   if (internalized.type !== "error" || !internalized.error || typeof internalized.error !== "object") {
     return internalized;
@@ -269,11 +304,14 @@ export async function createXaiResponse(
   const requestModel = selectedModelId === model.id ? model : { ...model, id: selectedModelId };
   const route = resolveXaiRoute(credential.kind, "responses");
   const rewritten = rewriteXaiResponsesPayload(canonicalBody, requestModel);
-  pinXaiPayloadModel(selectedModelId, rewritten);
+  const policyPayload = credential.kind === "oauth-session"
+    ? applyXaiOAuthResponsesPolicy(rewritten as Record<string, unknown>)
+    : rewritten;
+  pinXaiPayloadModel(selectedModelId, policyPayload);
   if (credential.kind === "oauth-session") {
-    assertXaiRuntimeModelAcceptsPayload(selectedModelId, rewritten);
+    assertXaiRuntimeModelAcceptsPayload(selectedModelId, policyPayload);
   }
-  const payload = (await compactXaiInlineImages(rewritten)) as Record<string, any>;
+  const payload = (await compactXaiInlineImages(policyPayload)) as Record<string, any>;
   if (credential.kind === "oauth-session") {
     assertXaiRuntimeModelAcceptsPayload(selectedModelId, payload);
   }
@@ -385,8 +423,9 @@ export function streamSimpleXaiResponses(model: Model<Api>, context: Context, op
             const canonicalPayload = canonicalizeXaiResponsesPayload(
               userRewritten === undefined ? rewritten : userRewritten,
             );
-            grokNativeToolRoutes = xaiPayloadGrokNativeToolRoutes(canonicalPayload);
-            const exposedPayload = exposeGrokNativeToolNames(canonicalPayload);
+            const policyPayload = applyXaiOAuthResponsesPolicy(canonicalPayload);
+            grokNativeToolRoutes = xaiPayloadGrokNativeToolRoutes(policyPayload);
+            const exposedPayload = exposeGrokNativeToolNames(policyPayload);
             pinXaiPayloadModel(selectedModelId, exposedPayload);
             assertXaiRuntimeModelAcceptsPayload(selectedModelId, exposedPayload);
             const finalPayload = await compactXaiInlineImages(
@@ -399,7 +438,7 @@ export function streamSimpleXaiResponses(model: Model<Api>, context: Context, op
       );
       for await (const event of inner as AsyncIterable<AssistantStreamEvent>) {
         if (event.type === "done" || event.type === "error") releaseRedirectGuard();
-        stream.push(normalizeXaiStreamEvent(event, grokNativeToolRoutes));
+        stream.push(normalizeXaiStreamEvent(event, grokNativeToolRoutes, model));
       }
       releaseRedirectGuard();
       stream.end();

--- a/extensions/xai/wire.ts
+++ b/extensions/xai/wire.ts
@@ -37,6 +37,9 @@ const APPROVED_PROXY_HEADER_NAMES = new Set([
 const VERSION_GATE_STATUSES = new Set([400, 401, 403, 426]);
 const VERSION_GATE_PATTERN =
   /\b(?:client[-_ ]?version|minimum[-_ ]?version|outdated[-_ ]?client|unsupported[-_ ]?client|update[-_ ]?required|version[-_ ]?gate)\b/i;
+const ENCRYPTED_CONTENT_MISMATCH_PATTERN = /encrypted_content/;
+const ENCRYPTED_CONTENT_MISMATCH_MESSAGE =
+  "xAI could not replay encrypted reasoning for this model. Start a clean session or turn using the same xAI model.";
 
 export type XaiClientMode = "interactive" | "headless";
 export type XaiOAuthClientSurface = "ui" | "cli" | "headless";
@@ -214,6 +217,16 @@ function isProxyVersionGate(status: number | undefined, detail: string): boolean
   );
 }
 
+function isEncryptedContentMismatch(
+  status: number | undefined,
+  detail: string,
+  routeKind: XaiHttpRouteKind,
+): boolean {
+  return routeKind === "responses-proxy" &&
+    status === 400 &&
+    ENCRYPTED_CONTENT_MISMATCH_PATTERN.test(detail);
+}
+
 function routeLabel(routeKind: XaiHttpRouteKind): string {
   if (routeKind === "responses-proxy" || routeKind === "responses-direct") return "Responses";
   if (routeKind === "image-generation") return "image generation";
@@ -228,6 +241,9 @@ export function safeXaiTransportErrorMessage(
   routeKind: XaiHttpRouteKind = "unknown",
 ): string {
   const resolvedStatus = status ?? statusFromTransportText(detail);
+  if (isEncryptedContentMismatch(resolvedStatus, detail, routeKind)) {
+    return ENCRYPTED_CONTENT_MISMATCH_MESSAGE;
+  }
   if (routeKind === "responses-proxy" && isProxyVersionGate(resolvedStatus, detail)) {
     const statusText = resolvedStatus ? ` (HTTP ${resolvedStatus})` : "";
     return `xAI proxy rejected ${XAI_CLIENT_IDENTIFIER}'s reviewed client/version contract${statusText}. Update ${XAI_CLIENT_IDENTIFIER}; if already current, open a compatibility issue with the HTTP status only. Last reviewed Grok Build revision: ${XAI_GROK_BUILD_REVIEWED_REVISION}.`;
@@ -271,16 +287,18 @@ async function readBoundedErrorBody(response: Response): Promise<string> {
 export class XaiHttpError extends Error {
   readonly status: number;
   readonly routeKind: XaiHttpRouteKind;
-  readonly code: "proxy-version-gate" | "http";
+  readonly code: "encrypted-content-mismatch" | "proxy-version-gate" | "http";
 
   constructor(status: number, routeKind: XaiHttpRouteKind, detail = "") {
     super(safeXaiTransportErrorMessage(detail, status, routeKind));
     this.name = "XaiHttpError";
     this.status = status;
     this.routeKind = routeKind;
-    this.code = routeKind === "responses-proxy" && isProxyVersionGate(status, detail)
-      ? "proxy-version-gate"
-      : "http";
+    this.code = isEncryptedContentMismatch(status, detail, routeKind)
+      ? "encrypted-content-mismatch"
+      : routeKind === "responses-proxy" && isProxyVersionGate(status, detail)
+        ? "proxy-version-gate"
+        : "http";
   }
 }
 

--- a/tests/responses/payload.test.ts
+++ b/tests/responses/payload.test.ts
@@ -5,6 +5,7 @@ import {
   XAI_GROK_NATIVE_WEB_SEARCH_NAME,
 } from "../../extensions/xai/constants";
 import {
+  applyXaiOAuthResponsesPolicy,
   canonicalizeXaiResponsesPayload,
   exposeGrokNativeToolNames,
   internalizeGrokNativeToolCalls,
@@ -213,16 +214,24 @@ describe("Responses payload normalization", () => {
     expect(result.instructions).toBe("base\n\nsystem\n\ndeveloper");
     expect(result.input).toEqual([{ role: "user", content: "hello" }]);
   });
-  it("removes all system and reasoning replay for CLI models", () => {
+  it("moves system text while preserving complete reasoning replay for CLI models", () => {
     setXaiRuntimeModels(KNOWN_XAI_MODEL_METADATA);
     const model = { ...TEST_MODEL, id: "grok-build" } as any;
+    const reasoning = {
+      id: "reasoning-1",
+      type: "reasoning",
+      summary: [],
+      encrypted_content: "opaque-reasoning",
+      status: "completed",
+      future_field: { preserved: true },
+    };
     const result: any = rewriteXaiResponsesPayload(
       {
         model: model.id,
         input: [
           { role: "user", content: "first" },
           { role: "system", content: "late" },
-          { type: "reasoning", summary: [] },
+          reasoning,
           { role: "user", content: "" },
         ],
         include: ["reasoning.encrypted_content", "other"],
@@ -230,9 +239,28 @@ describe("Responses payload normalization", () => {
       model,
     );
     expect(result.instructions).toBe("late");
-    expect(result.input).toEqual([{ role: "user", content: "first" }]);
-    expect(result.include).toEqual(["other"]);
+    expect(result.input).toEqual([{ role: "user", content: "first" }, reasoning]);
+    expect(result.include).toEqual(["reasoning.encrypted_content", "other"]);
   });
+  it("applies the OAuth Responses store and encrypted include policy immutably", () => {
+    const include = Object.freeze(["other", "reasoning.encrypted_content", "other"]);
+    const payload = Object.freeze({ input: "hello", include });
+    expect(applyXaiOAuthResponsesPolicy(payload)).toEqual({
+      input: "hello",
+      store: false,
+      include: ["other", "reasoning.encrypted_content"],
+    });
+    expect(payload).toEqual({ input: "hello", include });
+    expect(applyXaiOAuthResponsesPolicy({ store: true, include: ["other"] })).toEqual({
+      store: true,
+      include: ["other", "reasoning.encrypted_content"],
+    });
+    expect(applyXaiOAuthResponsesPolicy({ include: "malformed" as any })).toEqual({
+      include: ["reasoning.encrypted_content"],
+      store: false,
+    });
+  });
+
   it("normalizes response format, reasoning effort, and prompt cache fields", () => {
     setXaiRuntimeModels(KNOWN_XAI_MODEL_METADATA);
     const result: any = rewriteXaiResponsesPayload(

--- a/tests/responses/reasoning-replay.test.ts
+++ b/tests/responses/reasoning-replay.test.ts
@@ -1,0 +1,131 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { convertResponsesMessages } from "@earendil-works/pi-ai/api/openai-responses-shared";
+import { describe, expect, it } from "vitest";
+import { TEST_MODEL } from "../fixtures/models";
+
+const encryptedContent = "opaque-π+/=reasoning-state";
+const reasoningItem = {
+  id: "rs_1",
+  type: "reasoning",
+  summary: [],
+  encrypted_content: encryptedContent,
+  status: "completed",
+  future_field: { preserved: true },
+};
+
+function assistantMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    role: "assistant",
+    content: [
+      { type: "thinking", thinking: "", thinkingSignature: JSON.stringify(reasoningItem) },
+      { type: "text", text: "working", textSignature: "msg_1" },
+      {
+        type: "toolCall",
+        id: "call_1|fc_1",
+        name: "read_file",
+        arguments: { path: "README.md" },
+      },
+    ],
+    api: TEST_MODEL.api,
+    provider: TEST_MODEL.provider,
+    model: TEST_MODEL.id,
+    usage: {
+      input: 1,
+      output: 1,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 2,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "toolUse",
+    timestamp: 2,
+    ...overrides,
+  } as any;
+}
+
+function convert(messages: any[], model = TEST_MODEL as any) {
+  return convertResponsesMessages(model, { messages } as any, new Set([model.provider]));
+}
+
+describe("encrypted reasoning replay", () => {
+  it("replays the complete item inline with messages, tools, outputs, and later users", () => {
+    const messages = [
+      { role: "user", content: "first", timestamp: 1 },
+      assistantMessage(),
+      {
+        role: "toolResult",
+        toolCallId: "call_1|fc_1",
+        toolName: "read_file",
+        content: [{ type: "text", text: "result" }],
+        isError: false,
+        timestamp: 3,
+      },
+      { role: "user", content: "next", timestamp: 4 },
+    ];
+    const input = convert(messages) as any[];
+
+    expect(input.map((item) => item.type ?? item.role)).toEqual([
+      "user",
+      "reasoning",
+      "message",
+      "function_call",
+      "function_call_output",
+      "user",
+    ]);
+    expect(input[1]).toEqual(reasoningItem);
+    expect(input[1].encrypted_content).toBe(encryptedContent);
+  });
+
+  it("preserves serialized prefixes across active conversation turns", () => {
+    const first = [{ role: "user", content: "first", timestamp: 1 }, assistantMessage()];
+    const inputN = convert(first) as any[];
+    const inputN1 = convert([...first, { role: "user", content: "next", timestamp: 3 }]) as any[];
+    const inputN2 = convert([
+      ...first,
+      { role: "user", content: "next", timestamp: 3 },
+      assistantMessage({ content: [{ type: "text", text: "done", textSignature: "msg_2" }], timestamp: 4 }),
+      { role: "user", content: "again", timestamp: 5 },
+    ]) as any[];
+
+    expect(JSON.stringify(inputN1.slice(0, inputN.length))).toBe(JSON.stringify(inputN));
+    expect(JSON.stringify(inputN2.slice(0, inputN1.length))).toBe(JSON.stringify(inputN1));
+  });
+
+  it("persists and reloads the opaque signature through ordinary Pi session JSONL", () => {
+    const root = mkdtempSync(join(tmpdir(), "pi-xai-reasoning-"));
+    try {
+      const manager = SessionManager.create(root, root);
+      manager.appendMessage({ role: "user", content: "first", timestamp: 1 } as any);
+      manager.appendMessage(assistantMessage());
+      const sessionFile = manager.getSessionFile()!;
+      const reopened = SessionManager.open(sessionFile, root, root);
+      const messages = reopened.buildSessionContext().messages as any[];
+      const signature = messages[1].content[0].thinkingSignature;
+      const replay = convert(messages) as any[];
+
+      expect(signature).toBe(JSON.stringify(reasoningItem));
+      expect(replay[1]).toEqual(reasoningItem);
+      expect(readFileSync(sessionFile, "utf8")).toContain(encryptedContent);
+      expect(messages[1].content[0].thinking).toBe("");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("drops replay for a different exact provider, API, or model and failed turns", () => {
+    const source = assistantMessage();
+    const differentModel = { ...TEST_MODEL, id: `${TEST_MODEL.id}-other` } as any;
+    const differentProvider = { ...TEST_MODEL, provider: "other-provider" } as any;
+    const differentApi = { ...TEST_MODEL, api: "other-api" } as any;
+
+    expect(convert([source], TEST_MODEL as any).some((item: any) => item.type === "reasoning")).toBe(true);
+    expect(convert([source], differentModel).some((item: any) => item.type === "reasoning")).toBe(false);
+    expect(convert([source], differentProvider).some((item: any) => item.type === "reasoning")).toBe(false);
+    expect(convert([source], differentApi).some((item: any) => item.type === "reasoning")).toBe(false);
+    expect(convert([assistantMessage({ stopReason: "error" })]).some((item: any) => item.type === "reasoning")).toBe(false);
+    expect(convert([assistantMessage({ stopReason: "aborted" })]).some((item: any) => item.type === "reasoning")).toBe(false);
+  });
+});

--- a/tests/responses/routing.test.ts
+++ b/tests/responses/routing.test.ts
@@ -149,6 +149,8 @@ describe("Responses routing and protected metadata", () => {
         "text/event-stream",
       );
       expect(streamRequest.body.prompt_cache_key).toBe(sessionId);
+      expect(streamRequest.body.store).toBe(false);
+      expect(streamRequest.body.include).toEqual(["reasoning.encrypted_content"]);
       if (modelId === "grok-composer-2.5-fast") {
         expect(streamRequest.body.reasoning).toBeUndefined();
       }
@@ -178,6 +180,8 @@ describe("Responses routing and protected metadata", () => {
         "application/json",
       );
       expect(directRequestId).not.toBe(streamRequestId);
+      expect(directRequest.body.store).toBe(false);
+      expect(directRequest.body.include).toEqual(["reasoning.encrypted_content"]);
     },
   );
 
@@ -318,6 +322,8 @@ describe("Responses routing and protected metadata", () => {
       XAI_USER_AGENT,
     );
     expect(proxyHeaders(request)).toEqual({});
+    expect(request.body.store).toBeUndefined();
+    expect(request.body.include).toBeUndefined();
     for (const name of unsupportedProxyHeaderNames) {
       expect(headerValue(request.init.headers, name)).toBeUndefined();
     }
@@ -408,6 +414,63 @@ describe("Responses routing and protected metadata", () => {
     expect(error.message).toMatch(/Update pi-xai-oauth/);
     expect(error.message).toContain(XAI_GROK_BUILD_REVIEWED_REVISION);
     expect(error.message).not.toMatch(/TOKEN_SECRET|unsupported_client_version/);
+  });
+
+  it("classifies encrypted reasoning mismatch without reflecting raw bodies", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            error: "invalid_request",
+            message: "RAW_MISMATCH_SECRET encrypted_content belongs to another model",
+          }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+    const error = await postXaiJson(
+      "OAUTH_TOKEN_SECRET",
+      XAI_CLI_RESPONSES_URL,
+      {},
+    ).catch((value) => value as any);
+    expect(error).toMatchObject({
+      status: 400,
+      routeKind: "responses-proxy",
+      code: "encrypted-content-mismatch",
+    });
+    expect(error.message).toMatch(/Start a clean session or turn using the same xAI model/);
+    expect(error.message).not.toMatch(/RAW_MISMATCH_SECRET|encrypted_content|invalid_request/);
+  });
+
+  it("keeps encrypted-content markers generic outside the narrow proxy 400 case", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("encrypted_content RAW_SECRET", { status: 400 })),
+    );
+    const direct = await postXaiJson("token", XAI_RESPONSES_URL, {}).catch((value) => value as any);
+    expect(direct).toMatchObject({ code: "http", routeKind: "responses-direct", status: 400 });
+    expect(direct.message).toBe("xAI API error: Responses failed with status 400");
+    expect(direct.message).not.toContain("RAW_SECRET");
+  });
+
+  it("surfaces encrypted reasoning mismatch guidance for streaming with one attempt", async () => {
+    const mismatchFetch = vi.fn(async () =>
+      new Response(
+        JSON.stringify({ message: "STREAM_SECRET encrypted_content is incompatible" }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", mismatchFetch);
+    const stream = streamSimpleXaiResponses(
+      TEST_MODEL,
+      { messages: [{ role: "user", content: "hello", timestamp: 1 }] } as any,
+      { apiKey: "oauth-token", sessionId: "session" } as any,
+    );
+    const result = await stream.result();
+    expect(mismatchFetch).toHaveBeenCalledTimes(1);
+    expect(result.errorMessage).toMatch(/Start a clean session or turn using the same xAI model/);
+    expect(result.errorMessage).not.toMatch(/STREAM_SECRET|encrypted_content/);
   });
 
   it("surfaces the same safe proxy gate guidance for streaming", async () => {

--- a/tests/responses/streaming.test.ts
+++ b/tests/responses/streaming.test.ts
@@ -75,7 +75,38 @@ describe("xAI streaming adapter", () => {
     const result = await stream.result();
     expect(called).toBe(false);
     expect(result).toBeDefined();
+    expect(result).toMatchObject({
+      api: TEST_MODEL.api,
+      provider: TEST_MODEL.provider,
+      model: TEST_MODEL.id,
+    });
     expect(globalThis.fetch).toHaveBeenCalled();
+  });
+
+  it("enforces the OAuth Responses policy after caller payload hooks", async () => {
+    let sent: any;
+    vi.stubGlobal("fetch", vi.fn(async (_url: any, init: RequestInit = {}) => {
+      sent = JSON.parse(String(init.body));
+      return jsonResponse({ id: "resp", output_text: "OK" });
+    }));
+    const stream = streamSimpleXaiResponses(
+      TEST_MODEL,
+      { messages: [{ role: "user", content: "hello", timestamp: Date.now() }] } as any,
+      {
+        apiKey: "oauth-token",
+        onPayload(payload: any) {
+          return {
+            ...payload,
+            store: true,
+            include: ["other", "reasoning.encrypted_content", "other", "reasoning.encrypted_content"],
+          };
+        },
+      } as any,
+    );
+    await stream.result();
+
+    expect(sent.store).toBe(true);
+    expect(sent.include).toEqual(["other", "reasoning.encrypted_content"]);
   });
 
   it("resolves Grok-native name collisions after caller payload hooks", async () => {


### PR DESCRIPTION
## Summary
- enforce the encrypted-reasoning request policy on pinned OAuth Responses routes after payload hooks
- preserve complete reasoning items through Pi replay and session persistence with exact provider/API/model isolation
- add redacted terminal mismatch handling, regression coverage, and privacy/compatibility documentation

## Validation
- `npm run test:unit -- tests/responses/reasoning-replay.test.ts tests/responses/payload.test.ts tests/responses/streaming.test.ts tests/responses/routing.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run test:coverage`
- `npm run compatibility:check`
- `npm run compatibility:boundaries`
- `git diff --check`

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core OAuth Responses payload and multi-turn conversation contract; encrypted reasoning persists in Pi session files locally, and misclassified proxy errors could affect user-facing failure guidance.
> 
> **Overview**
> Implements **encrypted reasoning replay** for pinned **OAuth** Responses traffic (closes #79): multi-turn conversations can carry opaque reasoning state across turns when provider, API, and exact model stay aligned.
> 
> **OAuth request policy** (`applyXaiOAuthResponsesPolicy`) runs after payload hooks on stream and direct paths: absent `store` becomes `false`, `include` is deduplicated, and `reasoning.encrypted_content` is added exactly once. **API-key** direct Responses are unchanged (no `store`/`include` injection).
> 
> **Payload rewriting** no longer strips `reasoning` items or removes `reasoning.encrypted_content` from `include` for Grok CLI–compatible models, so completed reasoning items (including `encrypted_content`) stay in `input` for Pi to replay via `thinkingSignature`.
> 
> **Transport/errors**: proxy HTTP 400 bodies mentioning `encrypted_content` map to a fixed, redacted user message (`encrypted-content-mismatch`) with no auto-retry; the redirect guard synthesizes minimal JSON errors so Pi’s delegate can surface the same guidance on streaming. Stream events restore assistant `api`/`provider`/`model` for replay isolation.
> 
> **Tests and docs** add `reasoning-replay.test.ts`, extend routing/streaming/payload coverage, and document local session JSONL privacy and mismatch handling in README and `grok-build-wire-protocol.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5da0840cbf80c952cdb0dfe46e0309df494f2e96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->