### PR TITLE
feat: add opt-in xAI video generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 ### Added
 
 - Added disabled-by-default, session-scoped vision routing for exact authenticated text-only entitlements, with deterministic exact-catalog target selection, a bounded image-only description request, final image-free enforcement, lifecycle invalidation, and `/xai-tools` cost/privacy controls.
+- Added disabled-by-default `xai_image_to_video` with pinned create/status polling, DNS-pinned unauthenticated MP4 download, bounded streamed private storage, and honest remote-job cancellation semantics.
 
 ## 1.3.6 - 2026-07-18
 

--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ This opt-in boundary applies only to the extra tools below. Normal conversation 
 | `xai_code_execution` | Execution | Model tokens plus code-interpreter usage |
 | `xai_generate_image` | Image generation | Charged per generated image; supports 1-4 images |
 | `xai_edit_image` | Image editing | Imagine usage for one output conditioned on 1-3 local references |
+| `xai_image_to_video` | Video generation | High-cost, long-running 6- or 10-second video generation |
 | `xai_analyze_image` | Vision | Separate model-token and image-input usage |
 | `xai_critique` | Reasoning | Separate high-reasoning model-token usage |
 | `web_search` | Search | Model tokens plus native tool usage |
@@ -440,6 +441,7 @@ The picker shows each tool's category and cost-risk context, warns that calls ma
 /xai-tools disable xai_web_search
 /xai-tools enable xai_generate_image
 /xai-tools enable xai_edit_image
+/xai-tools enable xai_image_to_video
 /xai-tools enable vision-routing
 /xai-tools disable vision-routing
 ```
@@ -535,6 +537,23 @@ Reference handling uses the pinned Grok Build policy as its starting point: sour
 Exactly one verified PNG/JPEG output is saved atomically with a collision-resistant name under Pi's session directory at `pi-xai-oauth/<session-hash>/image-edits/`. Directories use mode `0700`, files use `0600`, and the tool returns path/dimension/size metadata instead of raw base64. Prompts, source paths, data URLs, image bytes, credentials, headers, and raw authenticated error bodies are never included in image-edit errors.
 
 Image editing can consume xAI Imagine allowances, credits, or rate limits. Exact pricing and quota behavior are controlled by xAI; see [xAI pricing](https://docs.x.ai/developers/pricing) before enabling the tool.
+
+### `xai_image_to_video`
+
+Opt-in high-cost image-to-video generation through `grok-imagine-video-1.5-preview`. Enable it explicitly, then provide exactly one bounded workspace PNG/JPEG or strict PNG/JPEG data URL. Remote source URLs and multi-reference video generation are intentionally unsupported.
+
+```json
+{
+  "image": { "path": "assets/reference.png" },
+  "prompt": "Slow camera push-in with subtle ambient motion",
+  "duration": 6,
+  "resolution": "480p"
+}
+```
+
+Duration is `6` or `10` seconds (default `6`); resolution is `480p` or `720p` (default `480p`). The client waits five seconds before its first status request, polls every five seconds, and stops local tracking after five minutes. Video generation can be expensive and rate-limited. Cancelling Pi stops local waiting, requests, download, and partial-file writes, but the submitted remote xAI job is **not cancelled** and may continue consuming usage or credits.
+
+Completed MP4s are downloaded without OAuth headers through an HTTPS-only, no-redirect, resolve-once public-IPv4 DNS/IP-pinned transport; IPv6-only download hosts fail closed. Downloads accept only MP4 MIME, are streamed under a 256 MiB limit, require bounded `ftyp` evidence, and are atomically saved under `pi-xai-oauth/<session-hash>/videos/` with private `0700` directories and `0600` files. Signed URLs, request IDs, source data, prompts, credentials, and raw authenticated bodies are not returned or logged.
 
 ### `xai_critique`
 Opt-in structured critique for code, designs, writing, or ideas. Enable it through `/xai-tools` first.

--- a/compatibility/grok-build-wire-protocol.md
+++ b/compatibility/grok-build-wire-protocol.md
@@ -49,6 +49,9 @@ All listed headers are internally owned. Caller/model headers are scrubbed case-
 | OAuth direct Responses | `https://cli-chat-proxy.grok.com/v1/responses` | Same proxy metadata with `Accept: application/json` and redirect rejection | No SSE accept, unsupported identity IDs, or generic SDK affinity IDs |
 | API-key direct Responses | `https://api.x.ai/v1/responses` | Bearer, JSON accept/content, truthful User-Agent, redirect rejection | No CLI-proxy metadata or generic SDK affinity IDs |
 | OAuth or API-key image generation | `https://api.x.ai/v1/images/generations` | Bearer, JSON accept/content, truthful User-Agent, redirect rejection | No CLI-proxy metadata |
+| OAuth or API-key video create | `https://api.x.ai/v1/videos/generations` | Bearer, JSON accept/content, truthful User-Agent, 60-second timeout, bounded response, redirect rejection | No CLI-proxy metadata or retries |
+| OAuth or API-key video status | `https://api.x.ai/v1/videos/<validated-request-id>` | Bearer, JSON accept, truthful User-Agent, fixed 5-second polling, per-request/cumulative bounds | No content type, CLI-proxy metadata, caller URL, or unvalidated path input |
+| Temporary video download | Authenticated status response's validated HTTPS URL | No-auth GET, resolve-once public DNS/IP pinning, TLS hostname verification, redirect rejection, MP4 MIME/evidence, 256 MiB streamed bound | No bearer, cookie, proxy, caller, or xAI affinity headers; URL/query never reflected |
 
 ### Header classification
 

--- a/extensions/xai/constants.ts
+++ b/extensions/xai/constants.ts
@@ -33,6 +33,8 @@ export const XAI_CLI_USER_URL = "https://cli-chat-proxy.grok.com/v1/user";
 export const XAI_CLI_BILLING_URL = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
 export const XAI_IMAGES_GENERATIONS_URL = "https://api.x.ai/v1/images/generations";
 export const XAI_IMAGES_EDITS_URL = "https://api.x.ai/v1/images/edits";
+export const XAI_VIDEOS_GENERATIONS_URL = "https://api.x.ai/v1/videos/generations";
+export const XAI_VIDEOS_STATUS_PREFIX = "https://api.x.ai/v1/videos/";
 
 export const XAI_MODEL_CATALOG_CACHE_SCHEMA = 2;
 export const XAI_MODEL_CATALOG_FRESH_TTL_MS = 15 * 60 * 1000;

--- a/extensions/xai/image-to-video.ts
+++ b/extensions/xai/image-to-video.ts
@@ -1,0 +1,395 @@
+import { defaultImageCodec, prepareImageReferences, type ImageCodec } from "./media/compression";
+import {
+  IMAGE_TO_VIDEO_CREATE_TIMEOUT_MS,
+  IMAGE_TO_VIDEO_DEFAULT_DURATION,
+  IMAGE_TO_VIDEO_DEFAULT_RESOLUTION,
+  IMAGE_TO_VIDEO_DURATIONS,
+  IMAGE_TO_VIDEO_GENERATION_TIMEOUT_MS,
+  IMAGE_TO_VIDEO_MAX_JSON_BYTES,
+  IMAGE_TO_VIDEO_MAX_PROMPT_BYTES,
+  IMAGE_TO_VIDEO_MAX_PROMPT_CHARS,
+  IMAGE_TO_VIDEO_MODEL,
+  IMAGE_TO_VIDEO_POLL_INTERVAL_MS,
+  IMAGE_TO_VIDEO_POLL_TIMEOUT_MS,
+  IMAGE_TO_VIDEO_RESOLUTIONS,
+} from "./media/constants";
+import { parseBoundedImageDataUrl } from "./media/data-url";
+import { videoOutputRoot } from "./media/output-storage";
+import { readBoundedWorkspaceImageFile } from "./media/paths";
+import type { PreparedImageReference, SavedVideoOutput } from "./media/types";
+import { resolveXaiRoute, type XaiCredential } from "./routing";
+import { downloadXaiVideo, type VideoDownloadDependencies } from "./video-download";
+import { xaiDirectMediaJsonGetHeaders, xaiDirectMediaJsonHeaders } from "./wire";
+
+export interface XaiImageToVideoInput {
+  image: { path: string } | { data_url: string };
+  prompt?: string;
+  duration: 6 | 10;
+  resolution: "480p" | "720p";
+}
+
+interface SessionLocation {
+  getSessionDir(): string;
+  getSessionId(): string;
+}
+
+export interface ImageToVideoDependencies {
+  fetch?: typeof fetch;
+  codec?: ImageCodec;
+  now?: () => number;
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+  createTimeoutMs?: number;
+  pollTimeoutMs?: number;
+  pollIntervalMs?: number;
+  generationTimeoutMs?: number;
+  maxJsonBytes?: number;
+  videoDownload?: VideoDownloadDependencies;
+}
+
+export class ImageToVideoOperationError extends Error {
+  constructor(
+    message: string,
+    readonly code:
+      | "invalid_input"
+      | "cancelled"
+      | "timeout"
+      | "network_failure"
+      | "http_failure"
+      | "invalid_response"
+      | "remote_failure"
+      | "output_failure",
+    readonly status?: number,
+  ) {
+    super(message);
+    this.name = "ImageToVideoOperationError";
+  }
+}
+
+function invalidInput(message: string): never {
+  throw new ImageToVideoOperationError(message, "invalid_input");
+}
+
+function validateImage(value: unknown): { path: string } | { data_url: string } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return invalidInput("Image-to-video requires exactly one path or data_url image reference.");
+  }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record);
+  if (keys.length !== 1 || (keys[0] !== "path" && keys[0] !== "data_url")) {
+    return invalidInput("Image-to-video requires exactly one path or data_url image reference.");
+  }
+  const key = keys[0] as "path" | "data_url";
+  const source = record[key];
+  if (typeof source !== "string" || !source.trim()) return invalidInput("Image reference must be non-empty.");
+  if (key === "path" && /^[A-Za-z][A-Za-z0-9+.-]*:/.test(source) && !/^[A-Za-z]:[\\/]/.test(source)) {
+    return invalidInput("Image-to-video source paths do not accept URL schemes.");
+  }
+  return key === "path" ? { path: source } : { data_url: source };
+}
+
+/** Validate cheap image-to-video input before credential, media, or network I/O. */
+export function validateXaiImageToVideoInput(value: unknown): XaiImageToVideoInput {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return invalidInput("Image-to-video input must be an object.");
+  }
+  const record = value as Record<string, unknown>;
+  if (Object.keys(record).some((key) => !["image", "prompt", "duration", "resolution"].includes(key))) {
+    return invalidInput("Image-to-video input contains unsupported fields.");
+  }
+  const image = validateImage(record.image);
+  if (record.prompt !== undefined) {
+    if (typeof record.prompt !== "string" || !record.prompt.trim()) {
+      return invalidInput("Image-to-video prompt must be non-empty when supplied.");
+    }
+    if (
+      record.prompt.length > IMAGE_TO_VIDEO_MAX_PROMPT_CHARS ||
+      Buffer.byteLength(record.prompt, "utf8") > IMAGE_TO_VIDEO_MAX_PROMPT_BYTES
+    ) return invalidInput("Image-to-video prompt exceeds the length limit.");
+  }
+  const duration = record.duration ?? IMAGE_TO_VIDEO_DEFAULT_DURATION;
+  if (!IMAGE_TO_VIDEO_DURATIONS.includes(duration as any)) {
+    return invalidInput("Image-to-video duration must be 6 or 10 seconds.");
+  }
+  const resolution = record.resolution ?? IMAGE_TO_VIDEO_DEFAULT_RESOLUTION;
+  if (!IMAGE_TO_VIDEO_RESOLUTIONS.includes(resolution as any)) {
+    return invalidInput("Image-to-video resolution must be 480p or 720p.");
+  }
+  return {
+    image,
+    ...(typeof record.prompt === "string" ? { prompt: record.prompt } : {}),
+    duration: duration as 6 | 10,
+    resolution: resolution as "480p" | "720p",
+  };
+}
+
+export function buildXaiImageToVideoPayload(
+  input: XaiImageToVideoInput,
+  reference: PreparedImageReference,
+): Record<string, unknown> {
+  return {
+    model: IMAGE_TO_VIDEO_MODEL,
+    prompt: input.prompt ?? "",
+    image: { url: reference.dataUrl },
+    duration: input.duration,
+    resolution: input.resolution,
+  };
+}
+
+export function validateVideoRequestId(value: unknown): string {
+  if (typeof value !== "string" || !/^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/.test(value)) {
+    throw new ImageToVideoOperationError("xAI video generation returned an invalid request identifier.", "invalid_response");
+  }
+  return value;
+}
+
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.reject(new DOMException("Cancelled", "AbortError"));
+  return new Promise((resolve, reject) => {
+    const cleanup = () => signal?.removeEventListener("abort", abort);
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    const abort = () => {
+      clearTimeout(timer);
+      cleanup();
+      reject(new DOMException("Cancelled", "AbortError"));
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+  });
+}
+
+async function readBoundedJson(
+  response: Response,
+  maxBytes: number,
+  signal: AbortSignal,
+  timeoutMs: number,
+): Promise<any> {
+  const mime = response.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
+  if (mime !== "application/json" && !mime?.endsWith("+json")) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new ImageToVideoOperationError("xAI video generation returned an invalid response type.", "invalid_response");
+  }
+  if (!response.body) throw new ImageToVideoOperationError("xAI video generation returned an empty response.", "invalid_response");
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  const controller = new AbortController();
+  let timedOut = false;
+  const forward = () => controller.abort();
+  signal.addEventListener("abort", forward, { once: true });
+  if (signal.aborted) controller.abort();
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
+  const aborted = new Promise<never>((_resolve, reject) => controller.signal.addEventListener(
+    "abort",
+    () => reject(new DOMException("Cancelled", "AbortError")),
+    { once: true },
+  ));
+  try {
+    while (true) {
+      const { value, done } = await Promise.race([reader.read(), aborted]);
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > maxBytes) throw new ImageToVideoOperationError("xAI video response exceeded the byte limit.", "invalid_response");
+      chunks.push(value);
+    }
+  } catch (error) {
+    await reader.cancel().catch(() => undefined);
+    if (signal.aborted) throw new ImageToVideoOperationError("Local video generation tracking was cancelled.", "cancelled");
+    if (timedOut) throw new ImageToVideoOperationError("xAI video response timed out.", "timeout");
+    throw error;
+  } finally {
+    clearTimeout(timer);
+    signal.removeEventListener("abort", forward);
+    reader.releaseLock();
+  }
+  try {
+    const parsed = JSON.parse(Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)), total).toString("utf8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error();
+    return parsed;
+  } catch {
+    throw new ImageToVideoOperationError("xAI video generation returned invalid JSON.", "invalid_response");
+  }
+}
+
+async function fetchTimed(options: {
+  url: string;
+  init: RequestInit;
+  callerSignal?: AbortSignal;
+  timeoutMs: number;
+  fetch: typeof fetch;
+}): Promise<Response> {
+  const controller = new AbortController();
+  let timedOut = false;
+  const forward = () => controller.abort();
+  options.callerSignal?.addEventListener("abort", forward, { once: true });
+  if (options.callerSignal?.aborted) controller.abort();
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, options.timeoutMs);
+  try {
+    return await options.fetch(options.url, { ...options.init, signal: controller.signal, redirect: "error" });
+  } catch {
+    if (options.callerSignal?.aborted) throw new ImageToVideoOperationError("Local video generation tracking was cancelled.", "cancelled");
+    if (timedOut) throw new ImageToVideoOperationError("xAI video request timed out.", "timeout");
+    throw new ImageToVideoOperationError("xAI video request failed. Check the network and try again.", "network_failure");
+  } finally {
+    clearTimeout(timer);
+    options.callerSignal?.removeEventListener("abort", forward);
+  }
+}
+
+function transientStatus(status: number): boolean {
+  return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+/** Execute the pinned asynchronous image-to-video workflow and save one private MP4. */
+export async function executeXaiImageToVideo(options: {
+  credential: XaiCredential;
+  input: XaiImageToVideoInput;
+  workspaceRoot: string;
+  sessionManager: SessionLocation;
+  signal?: AbortSignal;
+}, dependencies: ImageToVideoDependencies = {}): Promise<SavedVideoOutput> {
+  const input = validateXaiImageToVideoInput(options.input);
+  const fetcher = dependencies.fetch ?? fetch;
+  const now = dependencies.now ?? Date.now;
+  const sleep = dependencies.sleep ?? abortableSleep;
+  const deadline = now() + (dependencies.generationTimeoutMs ?? IMAGE_TO_VIDEO_GENERATION_TIMEOUT_MS);
+  let sessionRoot: string;
+  let outputRoot: string;
+  try {
+    sessionRoot = options.sessionManager.getSessionDir();
+    outputRoot = videoOutputRoot(options.sessionManager);
+  } catch {
+    throw new ImageToVideoOperationError("A safe Pi session output directory is unavailable.", "output_failure");
+  }
+  let image;
+  try {
+    image = "path" in input.image
+      ? await readBoundedWorkspaceImageFile(input.image.path, options.workspaceRoot, options.signal)
+      : parseBoundedImageDataUrl(input.image.data_url);
+  } catch (error) {
+    if (options.signal?.aborted) throw new ImageToVideoOperationError("Local video generation was cancelled.", "cancelled");
+    throw new ImageToVideoOperationError(error instanceof Error ? error.message : "Image reference is invalid.", "invalid_input");
+  }
+  let references: PreparedImageReference[];
+  try {
+    references = await prepareImageReferences([image], {
+      codec: dependencies.codec ?? defaultImageCodec(),
+      signal: options.signal,
+    });
+  } catch {
+    if (options.signal?.aborted) {
+      throw new ImageToVideoOperationError("Local video generation was cancelled before submission.", "cancelled");
+    }
+    throw new ImageToVideoOperationError("Image reference could not be verified or compressed safely.", "invalid_input");
+  }
+  const payload = buildXaiImageToVideoPayload(input, references[0]);
+  const createRoute = resolveXaiRoute(options.credential.kind, "video-generation-create");
+  const createExchangeDeadline = now() + Math.min(
+    dependencies.createTimeoutMs ?? IMAGE_TO_VIDEO_CREATE_TIMEOUT_MS,
+    Math.max(1, deadline - now()),
+  );
+  const create = await fetchTimed({
+    url: createRoute.url,
+    init: {
+      method: "POST",
+      headers: xaiDirectMediaJsonHeaders(options.credential.token),
+      body: JSON.stringify(payload),
+    },
+    callerSignal: options.signal,
+    timeoutMs: Math.max(1, createExchangeDeadline - now()),
+    fetch: fetcher,
+  });
+  if (!create.ok) {
+    await create.body?.cancel().catch(() => undefined);
+    throw new ImageToVideoOperationError(`xAI video generation failed with HTTP ${create.status}.`, "http_failure", create.status);
+  }
+  const created = await readBoundedJson(
+    create,
+    dependencies.maxJsonBytes ?? IMAGE_TO_VIDEO_MAX_JSON_BYTES,
+    options.signal ?? new AbortController().signal,
+    Math.max(1, createExchangeDeadline - now()),
+  );
+  const requestId = validateVideoRequestId(created.request_id);
+  const statusBase = resolveXaiRoute(options.credential.kind, "video-generation-status").url;
+  let transientFailures = 0;
+  while (now() < deadline) {
+    const remaining = deadline - now();
+    if (remaining <= 0) break;
+    try {
+      await sleep(Math.min(dependencies.pollIntervalMs ?? IMAGE_TO_VIDEO_POLL_INTERVAL_MS, remaining), options.signal);
+    } catch {
+      throw new ImageToVideoOperationError("Local waiting was cancelled; the remote xAI video job was not cancelled and may continue consuming usage or credits.", "cancelled");
+    }
+    if (now() >= deadline) break;
+    let statusResponse: Response;
+    const pollExchangeDeadline = now() + Math.min(
+      dependencies.pollTimeoutMs ?? IMAGE_TO_VIDEO_POLL_TIMEOUT_MS,
+      Math.max(1, deadline - now()),
+    );
+    try {
+      statusResponse = await fetchTimed({
+        url: `${statusBase}${encodeURIComponent(requestId)}`,
+        init: {
+          method: "GET",
+          headers: xaiDirectMediaJsonGetHeaders(options.credential.token),
+        },
+        callerSignal: options.signal,
+        timeoutMs: Math.max(1, pollExchangeDeadline - now()),
+        fetch: fetcher,
+      });
+    } catch (error) {
+      if (error instanceof ImageToVideoOperationError && error.code === "cancelled") {
+        throw new ImageToVideoOperationError("Local waiting was cancelled; the remote xAI video job was not cancelled and may continue consuming usage or credits.", "cancelled");
+      }
+      if (++transientFailures > 3) throw error;
+      continue;
+    }
+    if (statusResponse.status !== 200 && statusResponse.status !== 202) {
+      await statusResponse.body?.cancel().catch(() => undefined);
+      if (transientStatus(statusResponse.status) && ++transientFailures <= 3) continue;
+      throw new ImageToVideoOperationError(`xAI video status failed with HTTP ${statusResponse.status}.`, "http_failure", statusResponse.status);
+    }
+    const statusData = await readBoundedJson(
+      statusResponse,
+      dependencies.maxJsonBytes ?? IMAGE_TO_VIDEO_MAX_JSON_BYTES,
+      options.signal ?? new AbortController().signal,
+      Math.max(1, pollExchangeDeadline - now()),
+    );
+    transientFailures = 0;
+    const status = statusData.status;
+    if (typeof status !== "string" || !/^[a-z][a-z0-9_]{0,31}$/.test(status)) {
+      throw new ImageToVideoOperationError("xAI video status response was invalid.", "invalid_response");
+    }
+    if (status === "failed" || status === "expired") {
+      throw new ImageToVideoOperationError(`xAI video generation ${status}.`, "remote_failure");
+    }
+    if (status !== "done") continue;
+    if (!statusData.video || typeof statusData.video !== "object" || typeof statusData.video.url !== "string") {
+      throw new ImageToVideoOperationError("xAI video generation completed without a valid download.", "invalid_response");
+    }
+    try {
+      return await downloadXaiVideo({
+        url: statusData.video.url,
+        outputRoot,
+        sessionRoot,
+        duration: input.duration,
+        resolution: input.resolution,
+        signal: options.signal,
+      }, dependencies.videoDownload);
+    } catch (error) {
+      if (options.signal?.aborted) {
+        throw new ImageToVideoOperationError("Local download was cancelled; the remote xAI video job was not cancelled and may continue consuming usage or credits.", "cancelled");
+      }
+      throw new ImageToVideoOperationError(error instanceof Error ? error.message : "Video output failed safely.", "output_failure");
+    }
+  }
+  throw new ImageToVideoOperationError("xAI video generation exceeded the five-minute deadline; the remote job may still continue.", "timeout");
+}

--- a/extensions/xai/media/constants.ts
+++ b/extensions/xai/media/constants.ts
@@ -32,6 +32,24 @@ export const IMAGE_EDIT_RESOLUTION = "1k";
 export const IMAGE_EDIT_RESPONSE_FORMAT = "b64_json";
 export const IMAGE_EDIT_OUTPUT_COUNT = 1;
 
+/** Source-backed image-to-video request and transport limits. */
+export const IMAGE_TO_VIDEO_MODEL = "grok-imagine-video-1.5-preview";
+export const IMAGE_TO_VIDEO_DURATIONS = [6, 10] as const;
+export const IMAGE_TO_VIDEO_RESOLUTIONS = ["480p", "720p"] as const;
+export const IMAGE_TO_VIDEO_DEFAULT_DURATION = 6;
+export const IMAGE_TO_VIDEO_DEFAULT_RESOLUTION = "480p";
+export const IMAGE_TO_VIDEO_MAX_PROMPT_CHARS = 4_000;
+export const IMAGE_TO_VIDEO_MAX_PROMPT_BYTES = 16 * 1024;
+export const IMAGE_TO_VIDEO_MAX_JSON_BYTES = 64 * 1024;
+export const IMAGE_TO_VIDEO_CREATE_TIMEOUT_MS = 60_000;
+export const IMAGE_TO_VIDEO_POLL_TIMEOUT_MS = 30_000;
+export const IMAGE_TO_VIDEO_POLL_INTERVAL_MS = 5_000;
+export const IMAGE_TO_VIDEO_GENERATION_TIMEOUT_MS = 300_000;
+export const IMAGE_TO_VIDEO_DOWNLOAD_TIMEOUT_MS = 120_000;
+export const IMAGE_TO_VIDEO_MAX_OUTPUT_BYTES = 256 * 1024 * 1024;
+export const IMAGE_TO_VIDEO_MAX_DOWNLOAD_URL_CHARS = 8 * 1024;
+export const IMAGE_TO_VIDEO_MP4_PREFIX_BYTES = 4 * 1024;
+
 /** Safe output permissions. */
 export const IMAGE_EDIT_OUTPUT_DIRECTORY_MODE = 0o700;
 export const IMAGE_EDIT_OUTPUT_FILE_MODE = 0o600;

--- a/extensions/xai/media/output-storage.ts
+++ b/extensions/xai/media/output-storage.ts
@@ -65,14 +65,83 @@ async function ensurePrivateOutputDirectory(outputRoot: string, sessionRoot: str
 }
 
 /** Derive a package-owned, session-specific image-edit output directory. */
-export function imageEditOutputRoot(sessionManager: ReadonlySessionLocation): string {
+function sessionOutputRoot(sessionManager: ReadonlySessionLocation, category: string): string {
   const sessionDir = sessionManager?.getSessionDir?.();
   const sessionId = sessionManager?.getSessionId?.();
   if (typeof sessionDir !== "string" || !isAbsolute(sessionDir) || typeof sessionId !== "string" || !sessionId) {
     throw new Error("A safe Pi session output directory is unavailable.");
   }
   const sessionKey = createHash("sha256").update(sessionId).digest("hex").slice(0, 32);
-  return join(sessionDir, "pi-xai-oauth", sessionKey, "image-edits");
+  return join(sessionDir, "pi-xai-oauth", sessionKey, category);
+}
+
+/** Derive a package-owned, session-specific image-edit output directory. */
+export function imageEditOutputRoot(sessionManager: ReadonlySessionLocation): string {
+  return sessionOutputRoot(sessionManager, "image-edits");
+}
+
+/** Derive a package-owned, session-specific video output directory. */
+export function videoOutputRoot(sessionManager: ReadonlySessionLocation): string {
+  return sessionOutputRoot(sessionManager, "videos");
+}
+
+/** Atomically save a verified image to controlled session storage with 0700/0600 modes. */
+export interface PrivateOutputWriter {
+  write(chunk: Uint8Array): Promise<void>;
+}
+
+/** Stream one verified output into a private temporary file and atomically publish it. */
+export async function savePrivateStreamedOutput<T>(options: {
+  outputRoot: string;
+  sessionRoot: string;
+  extension: string;
+  stemPrefix: string;
+  signal?: AbortSignal;
+  write: (writer: PrivateOutputWriter) => Promise<T>;
+}): Promise<{ path: string; value: T }> {
+  throwIfAborted(options.signal);
+  if (!isAbsolute(options.outputRoot) || !isAbsolute(options.sessionRoot)) {
+    throw new Error("Output path is invalid.");
+  }
+  const realOutputRoot = await ensurePrivateOutputDirectory(options.outputRoot, options.sessionRoot);
+  const stem = `${options.stemPrefix}-${Date.now()}-${randomUUID()}`;
+  const finalPath = join(realOutputRoot, `${stem}.${options.extension}`);
+  const temporaryPath = join(realOutputRoot, `.${stem}.${options.extension}.tmp`);
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  let finalCreated = false;
+  try {
+    handle = await open(temporaryPath, "wx", IMAGE_EDIT_OUTPUT_FILE_MODE);
+    const currentHandle = handle;
+    const value = await options.write({
+      async write(chunk) {
+        throwIfAborted(options.signal);
+        let offset = 0;
+        while (offset < chunk.byteLength) {
+          const { bytesWritten } = await currentHandle.write(
+            chunk,
+            offset,
+            chunk.byteLength - offset,
+          );
+          if (bytesWritten <= 0) throw new Error("Private output write made no progress.");
+          offset += bytesWritten;
+        }
+      },
+    });
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    throwIfAborted(options.signal);
+    await rename(temporaryPath, finalPath);
+    finalCreated = true;
+    await chmod(finalPath, IMAGE_EDIT_OUTPUT_FILE_MODE);
+    throwIfAborted(options.signal);
+    return { path: finalPath, value };
+  } catch (error) {
+    await handle?.close().catch(() => undefined);
+    await rm(temporaryPath, { force: true }).catch(() => undefined);
+    if (finalCreated) await rm(finalPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
 }
 
 /** Atomically save a verified image to controlled session storage with 0700/0600 modes. */

--- a/extensions/xai/media/types.ts
+++ b/extensions/xai/media/types.ts
@@ -26,3 +26,11 @@ export interface SavedImageOutput {
   height: number;
   byteLength: number;
 }
+
+export interface SavedVideoOutput {
+  path: string;
+  mimeType: "video/mp4" | "application/mp4";
+  byteLength: number;
+  duration: 6 | 10;
+  resolution: "480p" | "720p";
+}

--- a/extensions/xai/media/video-info.ts
+++ b/extensions/xai/media/video-info.ts
@@ -1,0 +1,107 @@
+import { IMAGE_TO_VIDEO_MP4_PREFIX_BYTES } from "./constants";
+
+const ALLOWED_MP4_BRANDS = new Set([
+  "isom",
+  "iso2",
+  "iso3",
+  "iso4",
+  "iso5",
+  "iso6",
+  "iso7",
+  "iso8",
+  "iso9",
+  "mp41",
+  "mp42",
+  "avc1",
+  "M4V ",
+]);
+
+/** Validate bounded ISO-BMFF evidence from the beginning of an MP4 stream. */
+export function validateMp4Prefix(prefix: Buffer): void {
+  if (prefix.length < 16) throw new Error("Video output is not a valid bounded MP4.");
+  const size32 = prefix.readUInt32BE(0);
+  const extended = size32 === 1;
+  if (prefix.toString("ascii", 4, 8) !== "ftyp" || (extended && prefix.length < 24)) {
+    throw new Error("Video output is not a valid bounded MP4.");
+  }
+  const size = extended ? Number(prefix.readBigUInt64BE(8)) : size32;
+  const contentOffset = extended ? 16 : 8;
+  if (size < contentOffset + 8 || size > IMAGE_TO_VIDEO_MP4_PREFIX_BYTES || size > prefix.length) {
+    throw new Error("Video output is not a valid bounded MP4.");
+  }
+  const brands = [prefix.toString("ascii", contentOffset, contentOffset + 4)];
+  for (let offset = contentOffset + 8; offset + 4 <= size; offset += 4) {
+    brands.push(prefix.toString("ascii", offset, offset + 4));
+  }
+  if (!brands.some((brand) => ALLOWED_MP4_BRANDS.has(brand))) {
+    throw new Error("Video output uses an unsupported MP4 brand.");
+  }
+}
+
+export class Mp4StreamInspector {
+  private header = Buffer.alloc(0);
+  private remaining = 0;
+  private openEndedMdat = false;
+  private extendedType = "";
+  private hasMoov = false;
+  private hasMdat = false;
+
+  push(chunk: Buffer): void {
+    let offset = 0;
+    while (offset < chunk.length) {
+      if (this.openEndedMdat) return;
+      if (this.remaining > 0) {
+        const consumed = Math.min(this.remaining, chunk.length - offset);
+        this.remaining -= consumed;
+        offset += consumed;
+        continue;
+      }
+      const headerSize = this.extendedType ? 8 : 8;
+      const needed = headerSize - this.header.length;
+      const consumed = Math.min(needed, chunk.length - offset);
+      this.header = Buffer.concat([this.header, chunk.subarray(offset, offset + consumed)]);
+      offset += consumed;
+      if (this.header.length < headerSize) continue;
+      if (this.extendedType) {
+        const largeSize = this.header.readBigUInt64BE(0);
+        const type = this.extendedType;
+        this.extendedType = "";
+        this.header = Buffer.alloc(0);
+        if (largeSize < 16n || largeSize > BigInt(Number.MAX_SAFE_INTEGER)) {
+          throw new Error("Video output has malformed MP4 box structure.");
+        }
+        if (type === "moov") this.hasMoov = true;
+        if (type === "mdat") this.hasMdat = true;
+        this.remaining = Number(largeSize) - 16;
+        continue;
+      }
+      const size = this.header.readUInt32BE(0);
+      const type = this.header.toString("ascii", 4, 8);
+      this.header = Buffer.alloc(0);
+      if (size === 1) {
+        this.extendedType = type;
+        continue;
+      }
+      if (size !== 0 && size < 8) {
+        throw new Error("Video output has malformed MP4 box structure.");
+      }
+      if (type === "moov") this.hasMoov = true;
+      if (type === "mdat") {
+        this.hasMdat = true;
+        if (size === 0) {
+          this.openEndedMdat = true;
+          return;
+        }
+      } else if (size === 0) {
+        throw new Error("Video output has malformed MP4 box structure.");
+      }
+      this.remaining = size === 0 ? 0 : size - 8;
+    }
+  }
+
+  finish(): void {
+    if (this.header.length > 0 || this.extendedType || this.remaining > 0 || !this.hasMoov || !this.hasMdat) {
+      throw new Error("Video output lacks required MP4 movie/media structure.");
+    }
+  }
+}

--- a/extensions/xai/routing.ts
+++ b/extensions/xai/routing.ts
@@ -5,6 +5,8 @@ import {
   XAI_IMAGES_EDITS_URL,
   XAI_IMAGES_GENERATIONS_URL,
   XAI_RESPONSES_URL,
+  XAI_VIDEOS_GENERATIONS_URL,
+  XAI_VIDEOS_STATUS_PREFIX,
 } from "./constants";
 
 export type XaiCredentialKind = "oauth-session" | "api-key";
@@ -14,7 +16,12 @@ export interface XaiCredential {
   token: string;
 }
 
-export type XaiRequestKind = "responses" | "image-generation" | "image-edit";
+export type XaiRequestKind =
+  | "responses"
+  | "image-generation"
+  | "image-edit"
+  | "video-generation-create"
+  | "video-generation-status";
 
 export interface XaiRoute {
   baseUrl: string;
@@ -28,11 +35,15 @@ const XAI_ROUTES: Record<XaiCredentialKind, Record<XaiRequestKind, XaiRoute>> = 
     // both OAuth sessions and BYOK credentials rather than via the chat proxy.
     "image-generation": { baseUrl: XAI_API_BASE_URL, url: XAI_IMAGES_GENERATIONS_URL },
     "image-edit": { baseUrl: XAI_API_BASE_URL, url: XAI_IMAGES_EDITS_URL },
+    "video-generation-create": { baseUrl: XAI_API_BASE_URL, url: XAI_VIDEOS_GENERATIONS_URL },
+    "video-generation-status": { baseUrl: XAI_API_BASE_URL, url: XAI_VIDEOS_STATUS_PREFIX },
   },
   "api-key": {
     responses: { baseUrl: XAI_API_BASE_URL, url: XAI_RESPONSES_URL },
     "image-generation": { baseUrl: XAI_API_BASE_URL, url: XAI_IMAGES_GENERATIONS_URL },
     "image-edit": { baseUrl: XAI_API_BASE_URL, url: XAI_IMAGES_EDITS_URL },
+    "video-generation-create": { baseUrl: XAI_API_BASE_URL, url: XAI_VIDEOS_GENERATIONS_URL },
+    "video-generation-status": { baseUrl: XAI_API_BASE_URL, url: XAI_VIDEOS_STATUS_PREFIX },
   },
 };
 

--- a/extensions/xai/tools/commands.ts
+++ b/extensions/xai/tools/commands.ts
@@ -32,6 +32,7 @@ const NETWORK_TOOL_OPTIONS: readonly NetworkToolOption[] = [
   { name: "xai_code_execution", category: "execution", costRisk: "token + tool", summary: "xAI code interpreter" },
   { name: "xai_generate_image", category: "image", costRisk: "per image", summary: "generate 1-4 images" },
   { name: "xai_edit_image", category: "image", costRisk: "Imagine usage", summary: "edit 1-3 local image references" },
+  { name: "xai_image_to_video", category: "video", costRisk: "high; long-running", summary: "animate one local image; remote job survives local cancellation" },
   { name: "xai_analyze_image", category: "vision", costRisk: "token usage", summary: "analyze an image with Grok" },
   { name: "xai_critique", category: "reasoning", costRisk: "token usage", summary: "separate high-reasoning critique" },
   {
@@ -101,9 +102,12 @@ function notifyUpdate(
     return;
   }
   const displayName = networkToolDisplayName(toolName);
+  const enabledMessage = toolName === "xai_image_to_video"
+    ? `Enabled ${displayName} for this xAI session. Video generation can be high-cost and take up to five minutes; local cancellation does not cancel a submitted remote job.`
+    : `Enabled ${displayName} for this xAI session. Calls may use xAI credits.`;
   ctx.ui.notify(
     active
-      ? `Enabled ${displayName} for this xAI session. Calls may use xAI credits.`
+      ? enabledMessage
       : `Disabled ${displayName}.`,
     active ? "warning" : "info",
   );

--- a/extensions/xai/tools/custom-tools.ts
+++ b/extensions/xai/tools/custom-tools.ts
@@ -6,7 +6,16 @@ import {
   ImageEditOperationError,
   validateXaiEditImageInput,
 } from "../image-edit";
-import { IMAGE_EDIT_MAX_PROMPT_CHARS, IMAGE_EDIT_MAX_REFERENCES } from "../media/constants";
+import {
+  executeXaiImageToVideo,
+  ImageToVideoOperationError,
+  validateXaiImageToVideoInput,
+} from "../image-to-video";
+import {
+  IMAGE_EDIT_MAX_PROMPT_CHARS,
+  IMAGE_EDIT_MAX_REFERENCES,
+  IMAGE_TO_VIDEO_MAX_PROMPT_CHARS,
+} from "../media/constants";
 import { normalizeXaiImageInput } from "../images";
 import { defaultXaiRuntimeModelId, grokSupportsReasoningEffort, normalizedXaiModelId } from "../models";
 import { createXaiResponse, postXaiJson } from "../responses";
@@ -460,6 +469,94 @@ Be specific and cite examples where helpful.`;
           const operationError = error instanceof ImageEditOperationError ? error : undefined;
           return xaiToolError(
             `Error: ${operationError?.message ?? "xAI image edit failed safely."}`,
+            {
+              error: true,
+              code: operationError?.code ?? "output_failure",
+              ...(operationError?.status ? { status: operationError.status } : {}),
+            },
+          );
+        }
+      },
+    } as any);
+
+    pi.registerTool({
+      name: "xai_image_to_video",
+      label: "xAI Image to Video",
+      description:
+        "Opt-in high-cost image-to-video generation using one bounded PNG/JPEG workspace file or data URL. Enable via /xai-tools and call only when explicitly requested.",
+      promptGuidelines: [
+        "Call xai_image_to_video only when the user explicitly asks to animate or turn a supplied image into a video with xAI.",
+        "Use only a user-supplied workspace path or strict PNG/JPEG data URL; never invent paths or use remote source URLs.",
+        "Warn that generation may take up to five minutes and local cancellation does not cancel a submitted remote xAI job.",
+      ],
+      executionMode: "sequential",
+      parameters: {
+        type: "object",
+        properties: {
+          image: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { path: { type: "string", description: "PNG/JPEG path inside the current workspace" } },
+                required: ["path"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: { data_url: { type: "string", description: "Strict bounded PNG/JPEG base64 data URL" } },
+                required: ["data_url"],
+                additionalProperties: false,
+              },
+            ],
+          },
+          prompt: {
+            type: "string",
+            minLength: 1,
+            maxLength: IMAGE_TO_VIDEO_MAX_PROMPT_CHARS,
+            description: "Optional motion or animation guidance",
+          },
+          duration: { type: "number", enum: [6, 10], default: 6 },
+          resolution: { type: "string", enum: ["480p", "720p"], default: "480p" },
+        },
+        required: ["image"],
+        additionalProperties: false,
+      },
+      execute: async (_toolCallId: string, params: unknown, signal: AbortSignal | undefined, _onUpdate: any, ctx: any) => {
+        if (!activeModelForXaiTool(pi, ctx, "xai_image_to_video")) {
+          return xaiToolDisabledError("xai_image_to_video");
+        }
+        let input;
+        try {
+          input = validateXaiImageToVideoInput(params);
+        } catch (error) {
+          const message = error instanceof ImageToVideoOperationError
+            ? error.message
+            : "Image-to-video input is invalid.";
+          return xaiToolError(`Error: ${message}`, { error: true, code: "invalid_input" });
+        }
+        const credential = await resolveXaiCredential(ctx);
+        if (!credential) {
+          return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { error: true });
+        }
+        try {
+          const output = await executeXaiImageToVideo({
+            credential,
+            input,
+            workspaceRoot: ctx?.cwd,
+            sessionManager: ctx?.sessionManager,
+            signal,
+          });
+          return {
+            content: [{
+              type: "text",
+              text: `Video saved to ${output.path} (${output.mimeType}, ${output.duration}s, ${output.resolution}, ${output.byteLength} bytes).`,
+            }],
+            details: output,
+          };
+        } catch (error) {
+          const operationError = error instanceof ImageToVideoOperationError ? error : undefined;
+          return xaiToolError(
+            `Error: ${operationError?.message ?? "xAI image-to-video generation failed safely."}`,
             {
               error: true,
               code: operationError?.code ?? "output_failure",

--- a/extensions/xai/tools/model-scope.ts
+++ b/extensions/xai/tools/model-scope.ts
@@ -15,6 +15,7 @@ export const XAI_NETWORK_TOOL_NAMES = [
   "xai_code_execution",
   "xai_generate_image",
   "xai_edit_image",
+  "xai_image_to_video",
   "xai_analyze_image",
   "xai_critique",
   XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME,

--- a/extensions/xai/video-download.ts
+++ b/extensions/xai/video-download.ts
@@ -1,0 +1,216 @@
+import { lookup as dnsLookup } from "node:dns/promises";
+import { request as httpsRequest, type RequestOptions } from "node:https";
+import { isIP } from "node:net";
+import { XAI_USER_AGENT } from "./constants";
+import {
+  IMAGE_TO_VIDEO_DOWNLOAD_TIMEOUT_MS,
+  IMAGE_TO_VIDEO_MAX_DOWNLOAD_URL_CHARS,
+  IMAGE_TO_VIDEO_MAX_OUTPUT_BYTES,
+  IMAGE_TO_VIDEO_MP4_PREFIX_BYTES,
+} from "./media/constants";
+import { savePrivateStreamedOutput } from "./media/output-storage";
+import type { SavedVideoOutput } from "./media/types";
+import { Mp4StreamInspector, validateMp4Prefix } from "./media/video-info";
+
+export class VideoDownloadError extends Error {
+  constructor(message = "xAI video download failed safely.") {
+    super(message);
+    this.name = "VideoDownloadError";
+  }
+}
+
+interface AddressRecord {
+  address: string;
+  family: number;
+}
+
+export interface VideoDownloadDependencies {
+  lookup?: typeof dnsLookup;
+  request?: typeof httpsRequest;
+  timeoutMs?: number;
+  maxBytes?: number;
+}
+
+function normalizedIp(value: string): string {
+  return value.toLowerCase().replace(/^::ffff:/, "");
+}
+
+function blockedIpv4(address: string): boolean {
+  const parts = address.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return true;
+  const [a, b] = parts;
+  const [, , c] = parts;
+  return a === 0 || a === 10 || a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 0) ||
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    (a === 198 && b === 51 && c === 100) ||
+    (a === 203 && b === 0 && c === 113) ||
+    a >= 224;
+}
+
+export function isPublicVideoDownloadAddress(address: string): boolean {
+  const normalized = normalizedIp(address);
+  const compatibleIpv4 = /^::(\d{1,3}(?:\.\d{1,3}){3})$/.exec(normalized)?.[1];
+  if (compatibleIpv4) return !blockedIpv4(compatibleIpv4);
+  const family = isIP(normalized);
+  if (family === 4) return !blockedIpv4(normalized);
+  // Fail closed on IPv6 DNS answers. Correctly classifying every IANA special-
+  // purpose and IPv4-transition range without a reviewed IP parser is unsafe;
+  // public IPv4 CDN answers remain supported and connection-pinned.
+  if (family === 6) return false;
+  return false;
+}
+
+function safeVideoUrl(value: string): URL {
+  if (typeof value !== "string" || !value || value.length > IMAGE_TO_VIDEO_MAX_DOWNLOAD_URL_CHARS) {
+    throw new VideoDownloadError();
+  }
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new VideoDownloadError();
+  }
+  if (
+    url.protocol !== "https:" || url.username || url.password || url.hash ||
+    (url.port && url.port !== "443") || !url.hostname || isIP(url.hostname)
+  ) throw new VideoDownloadError();
+  return url;
+}
+
+function acceptedMime(value: string | undefined): "video/mp4" | "application/mp4" {
+  const mime = value?.split(";", 1)[0]?.trim().toLowerCase();
+  if (mime === "video/mp4" || mime === "application/mp4") return mime;
+  throw new VideoDownloadError("xAI video download returned an unsupported media type.");
+}
+
+/** Download one temporary video URL without auth and atomically store a bounded MP4. */
+export async function downloadXaiVideo(options: {
+  url: string;
+  outputRoot: string;
+  sessionRoot: string;
+  duration: 6 | 10;
+  resolution: "480p" | "720p";
+  signal?: AbortSignal;
+}, dependencies: VideoDownloadDependencies = {}): Promise<SavedVideoOutput> {
+  const url = safeVideoUrl(options.url);
+  const lookup = dependencies.lookup ?? dnsLookup;
+  const request = dependencies.request ?? httpsRequest;
+  const controller = new AbortController();
+  const forwardAbort = () => controller.abort();
+  options.signal?.addEventListener("abort", forwardAbort, { once: true });
+  if (options.signal?.aborted) controller.abort();
+  const timeout = setTimeout(() => controller.abort(), dependencies.timeoutMs ?? IMAGE_TO_VIDEO_DOWNLOAD_TIMEOUT_MS);
+  try {
+    const addresses = await Promise.race([
+      lookup(url.hostname, { all: true, verbatim: true }) as Promise<AddressRecord[]>,
+      new Promise<never>((_resolve, reject) => controller.signal.addEventListener(
+        "abort",
+        () => reject(new DOMException("Cancelled", "AbortError")),
+        { once: true },
+      )),
+    ]);
+    if (addresses.length === 0 || addresses.some(({ address }) => !isPublicVideoDownloadAddress(address))) {
+      throw new VideoDownloadError();
+    }
+    const selected = addresses[0];
+    const response = await new Promise<import("node:http").IncomingMessage>((resolve, reject) => {
+      const requestOptions: RequestOptions = {
+        protocol: "https:",
+        hostname: url.hostname,
+        port: 443,
+        path: `${url.pathname}${url.search}`,
+        method: "GET",
+        headers: {
+          Accept: "video/mp4, application/mp4",
+          "User-Agent": XAI_USER_AGENT,
+        },
+        servername: url.hostname,
+        signal: controller.signal,
+        lookup(_hostname, _options, callback) {
+          callback(null, selected.address, selected.family);
+        },
+      };
+      const req = request(requestOptions, (res) => resolve(res));
+      req.once("socket", (socket) => {
+        socket.once("secureConnect", () => {
+          if (normalizedIp(socket.remoteAddress ?? "") !== normalizedIp(selected.address)) {
+            req.destroy(new VideoDownloadError());
+          }
+        });
+      });
+      req.once("error", reject);
+      req.end();
+    });
+    if ((response.statusCode ?? 0) < 200 || (response.statusCode ?? 0) >= 300) {
+      response.destroy();
+      throw new VideoDownloadError();
+    }
+    let mimeType: "video/mp4" | "application/mp4";
+    try {
+      mimeType = acceptedMime(Array.isArray(response.headers["content-type"])
+        ? response.headers["content-type"][0]
+        : response.headers["content-type"]);
+    } catch (error) {
+      response.destroy();
+      throw error;
+    }
+    const maxBytes = dependencies.maxBytes ?? IMAGE_TO_VIDEO_MAX_OUTPUT_BYTES;
+    const declared = Number(response.headers["content-length"]);
+    if (Number.isFinite(declared) && (declared <= 0 || declared > maxBytes)) {
+      response.destroy();
+      throw new VideoDownloadError("xAI video download exceeded the byte limit.");
+    }
+    const saved = await savePrivateStreamedOutput({
+      outputRoot: options.outputRoot,
+      sessionRoot: options.sessionRoot,
+      extension: "mp4",
+      stemPrefix: "xai-video",
+      signal: controller.signal,
+      async write(writer) {
+        let total = 0;
+        let prefix = Buffer.alloc(0);
+        const structure = new Mp4StreamInspector();
+        for await (const chunk of response) {
+          if (controller.signal.aborted) throw new DOMException("Cancelled", "AbortError");
+          const bytes = Buffer.from(chunk);
+          total += bytes.length;
+          if (total > maxBytes) {
+            response.destroy();
+            throw new VideoDownloadError("xAI video download exceeded the byte limit.");
+          }
+          if (prefix.length < IMAGE_TO_VIDEO_MP4_PREFIX_BYTES) {
+            prefix = Buffer.concat([
+              prefix,
+              bytes.subarray(0, IMAGE_TO_VIDEO_MP4_PREFIX_BYTES - prefix.length),
+            ]);
+          }
+          structure.push(bytes);
+          await writer.write(bytes);
+        }
+        if (total === 0) throw new VideoDownloadError();
+        validateMp4Prefix(prefix);
+        structure.finish();
+        return total;
+      },
+    });
+    return {
+      path: saved.path,
+      mimeType,
+      byteLength: saved.value,
+      duration: options.duration,
+      resolution: options.resolution,
+    };
+  } catch (error) {
+    if (options.signal?.aborted) throw new VideoDownloadError("Local video download was cancelled; the remote xAI video job may continue consuming usage or credits.");
+    if (controller.signal.aborted) throw new VideoDownloadError("xAI video download timed out.");
+    throw error instanceof VideoDownloadError ? error : new VideoDownloadError();
+  } finally {
+    clearTimeout(timeout);
+    options.signal?.removeEventListener("abort", forwardAbort);
+  }
+}

--- a/extensions/xai/wire.ts
+++ b/extensions/xai/wire.ts
@@ -7,6 +7,8 @@ import {
   XAI_PROXY_CLIENT_VERSION,
   XAI_RESPONSES_URL,
   XAI_USER_AGENT,
+  XAI_VIDEOS_GENERATIONS_URL,
+  XAI_VIDEOS_STATUS_PREFIX,
 } from "./constants";
 import type { XaiCredentialKind } from "./routing";
 
@@ -48,6 +50,8 @@ export type XaiHttpRouteKind =
   | "responses-direct"
   | "image-generation"
   | "image-edit"
+  | "video-generation-create"
+  | "video-generation-status"
   | "unknown";
 
 export interface XaiProxyRequestMetadata {
@@ -197,11 +201,22 @@ export function xaiDirectMediaJsonHeaders(authToken: string): Record<string, str
   return xaiJsonPostHeaders(authToken);
 }
 
+/** Build protected JSON GET headers for direct public media status requests. */
+export function xaiDirectMediaJsonGetHeaders(authToken: string): Record<string, string> {
+  return {
+    Accept: "application/json",
+    Authorization: `Bearer ${authToken}`,
+    "User-Agent": XAI_USER_AGENT,
+  };
+}
+
 function routeKindForUrl(url: string): XaiHttpRouteKind {
   if (url === XAI_CLI_RESPONSES_URL) return "responses-proxy";
   if (url === XAI_RESPONSES_URL) return "responses-direct";
   if (url === XAI_IMAGES_GENERATIONS_URL) return "image-generation";
   if (url === XAI_IMAGES_EDITS_URL) return "image-edit";
+  if (url === XAI_VIDEOS_GENERATIONS_URL) return "video-generation-create";
+  if (url.startsWith(XAI_VIDEOS_STATUS_PREFIX)) return "video-generation-status";
   return "unknown";
 }
 
@@ -231,6 +246,8 @@ function routeLabel(routeKind: XaiHttpRouteKind): string {
   if (routeKind === "responses-proxy" || routeKind === "responses-direct") return "Responses";
   if (routeKind === "image-generation") return "image generation";
   if (routeKind === "image-edit") return "image editing";
+  if (routeKind === "video-generation-create") return "video generation";
+  if (routeKind === "video-generation-status") return "video status";
   return "request";
 }
 

--- a/scripts/verify-extension-loader.mjs
+++ b/scripts/verify-extension-loader.mjs
@@ -23,6 +23,7 @@ try {
   const loaded = result.extensions[0];
   assert.ok(loaded.tools.has("xai_generate_text"), "representative xAI tool should be registered");
   assert.ok(loaded.tools.has("xai_edit_image"), "bounded xAI image-edit tool should be registered");
+  assert.ok(loaded.tools.has("xai_image_to_video"), "bounded xAI image-to-video tool should be registered");
   assert.ok(
     loaded.tools.has("xai_grok_grep"),
     "collision-free Grok grep dispatcher should be registered",

--- a/tests/provider/registration.test.ts
+++ b/tests/provider/registration.test.ts
@@ -41,8 +41,9 @@ describe("provider registration", () => {
       cost: { input: 2, cacheRead: 0.5, output: 6 },
       thinkingLevelMap: { off: null },
     });
-    expect(harness.tools.size).toBe(16);
+    expect(harness.tools.size).toBe(17);
     expect(harness.tools.has("xai_edit_image")).toBe(true);
+    expect(harness.tools.has("xai_image_to_video")).toBe(true);
     expect(harness.commands.has("xai-tools")).toBe(true);
     expect(harness.commands.has("xai-usage")).toBe(true);
     expect([...harness.handlers.keys()]).toEqual(

--- a/tests/provider/routing.test.ts
+++ b/tests/provider/routing.test.ts
@@ -23,6 +23,20 @@ describe("credential-aware xAI routing", () => {
   );
 
   it.each(["oauth-session", "api-key"] as const)(
+    "keeps %s video creation and status on pinned public routes",
+    (kind) => {
+      expect(resolveXaiRoute(kind, "video-generation-create")).toEqual({
+        baseUrl: "https://api.x.ai/v1",
+        url: "https://api.x.ai/v1/videos/generations",
+      });
+      expect(resolveXaiRoute(kind, "video-generation-status")).toEqual({
+        baseUrl: "https://api.x.ai/v1",
+        url: "https://api.x.ai/v1/videos/",
+      });
+    },
+  );
+
+  it.each(["oauth-session", "api-key"] as const)(
     "keeps %s image editing on the distinct pinned public route",
     (kind) => {
       expect(resolveXaiRoute(kind, "image-edit")).toEqual({

--- a/tests/tools/commands.test.ts
+++ b/tests/tools/commands.test.ts
@@ -248,8 +248,8 @@ describe("/xai-tools command", () => {
       },
     });
     await h.commands.get("xai-tools").handler("", ctx);
-    // Full catalog includes web_search for every xAI model; page-up wraps to the last entry.
-    expect(selected[0]).toMatch(/web_search/);
+    // Page movement uses the ten-row viewport across the full tool catalog.
+    expect(selected[0]).toMatch(/xai_x_search/);
     expect(selected[1]).toMatch(/\[ \] xai_generate_image/);
     expect(selected[2]).toMatch(/\[x\] xai_generate_image/);
     expect(closed).toBe(true);
@@ -298,7 +298,7 @@ describe("/xai-tools command", () => {
     });
 
     await h.commands.get("xai-tools").handler("", ctx);
-    expect(afterPageUp).toMatch(/xai_web_search/);
+    expect(afterPageUp).toMatch(/xai_x_search/);
     expect(afterPageDown).toMatch(/xai_generate_text/);
   });
 });

--- a/tests/tools/custom-tools.test.ts
+++ b/tests/tools/custom-tools.test.ts
@@ -61,6 +61,7 @@ describe("custom xAI tools", () => {
     ["xai_code_execution", { code: "print(1)" }],
     ["xai_generate_image", { prompt: "guard" }],
     ["xai_edit_image", { prompt: "guard", image: [{ path: "secret.png" }] }],
+    ["xai_image_to_video", { image: { path: "secret.png" } }],
     ["xai_analyze_image", { image: "https://example.test/a.png" }],
     ["xai_critique", { content: "guard" }],
   ])(
@@ -83,13 +84,15 @@ describe("custom xAI tools", () => {
       expect(requests).toHaveLength(0);
     },
   );
-  it("blocks disabled image editing without touching params, credentials, filesystem context, or network", async () => {
+  it.each(["xai_edit_image", "xai_image_to_video"] as const)(
+    "blocks disabled %s without touching params, credentials, filesystem context, or network",
+    async (toolName) => {
     const params = new Proxy({}, {
       get() {
         throw new Error("disabled tool must not inspect inputs");
       },
     });
-    const result = await h.tools.get("xai_edit_image").execute(
+    const result = await h.tools.get(toolName).execute(
       "call",
       params,
       undefined,
@@ -109,9 +112,10 @@ describe("custom xAI tools", () => {
         },
       },
     );
-    expect(result.content[0].text).toMatch(/xai_edit_image is disabled/);
+    expect(result.content[0].text).toContain(`${toolName} is disabled`);
     expect(requests).toHaveLength(0);
-  });
+    },
+  );
   it("does not fall back to an API-key environment variable", async () => {
     vi.stubEnv("XAI_API_KEY", "must-not-use");
     setXaiNetworkToolActive(h.api, TEST_MODEL, "xai_generate_text", true);

--- a/tests/videos/image-to-video.test.ts
+++ b/tests/videos/image-to-video.test.ts
@@ -1,0 +1,176 @@
+import { mkdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildXaiImageToVideoPayload,
+  executeXaiImageToVideo,
+  validateVideoRequestId,
+  validateXaiImageToVideoInput,
+} from "../../extensions/xai/image-to-video";
+import { createTempDir } from "../fixtures/temp";
+import { tinyPngBytes } from "../fixtures/images";
+import { jsonResponse, requestBody } from "../fixtures/http";
+
+function mp4(): Buffer {
+  return Buffer.from([
+    0, 0, 0, 24, 0x66, 0x74, 0x79, 0x70,
+    0x69, 0x73, 0x6f, 0x6d, 0, 0, 0, 0,
+    0x69, 0x73, 0x6f, 0x32, 0x6d, 0x70, 0x34, 0x32,
+    0, 0, 0, 8, 0x6d, 0x6f, 0x6f, 0x76,
+    0, 0, 0, 9, 0x6d, 0x64, 0x61, 0x74, 1,
+  ]);
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("xAI image-to-video", () => {
+  it("validates input defaults and exact payload", () => {
+    const dataUrl = `data:image/png;base64,${tinyPngBytes().toString("base64")}`;
+    const input = validateXaiImageToVideoInput({ image: { data_url: dataUrl } });
+    expect(input).toMatchObject({ duration: 6, resolution: "480p" });
+    expect(buildXaiImageToVideoPayload(input, {
+      dataUrl,
+      mimeType: "image/png",
+      byteLength: tinyPngBytes().length,
+      width: 1,
+      height: 1,
+      wasCompressed: false,
+    })).toEqual({
+      model: "grok-imagine-video-1.5-preview",
+      prompt: "",
+      image: { url: dataUrl },
+      duration: 6,
+      resolution: "480p",
+    });
+  });
+
+  it("rejects unsupported fields, remote paths, and unsafe request IDs", () => {
+    expect(() => validateXaiImageToVideoInput({ image: { path: "https://example.test/a.png" } }))
+      .toThrow(/do not accept URL schemes/);
+    expect(() => validateXaiImageToVideoInput({ image: { data_url: "x" }, aspect_ratio: "16:9" }))
+      .toThrow(/unsupported fields/);
+    for (const id of ["", "a/b", "a.b", "a%2fb", " a", "a?b"]) {
+      expect(() => validateVideoRequestId(id)).toThrow(/invalid request identifier/);
+    }
+  });
+
+  it("runs create, wait, poll, unauthenticated download, and private storage", async () => {
+    const temp = await createTempDir("pi-xai-video-");
+    const workspace = join(temp.path, "workspace");
+    const sessions = join(temp.path, "sessions");
+    await Promise.all([mkdir(workspace), mkdir(sessions)]);
+    const dataUrl = `data:image/png;base64,${tinyPngBytes().toString("base64")}`;
+    const calls: any[] = [];
+    const fetchMock = vi.fn(async (url: any, init: RequestInit = {}) => {
+      calls.push({ url: String(url), init, body: requestBody(init) });
+      if (String(url).endsWith("/videos/generations")) return jsonResponse({ request_id: "job_1" });
+      return jsonResponse({ status: "done", video: { url: "https://cdn.example.test/output.mp4?signature=secret" } });
+    });
+    const request = vi.fn((_options: any, callback: any) => {
+      const { EventEmitter } = require("node:events");
+      const response = new (require("node:stream").Readable)({ read() {} });
+      response.statusCode = 200;
+      response.headers = { "content-type": "video/mp4", "content-length": String(mp4().length) };
+      const req = new EventEmitter();
+      req.end = () => {
+        callback(response);
+        response.push(mp4());
+        response.push(null);
+      };
+      req.destroy = (error: any) => req.emit("error", error);
+      req.once = req.once.bind(req);
+      process.nextTick(() => {
+        const socket = new EventEmitter();
+        socket.remoteAddress = "93.184.216.34";
+        req.emit("socket", socket);
+        process.nextTick(() => socket.emit("secureConnect"));
+      });
+      return req;
+    });
+    const output = await executeXaiImageToVideo({
+      credential: { kind: "oauth-session", token: "oauth-token" },
+      input: validateXaiImageToVideoInput({ image: { data_url: dataUrl }, duration: 10, resolution: "720p" }),
+      workspaceRoot: workspace,
+      sessionManager: { getSessionDir: () => sessions, getSessionId: () => "private-session-id" },
+    }, {
+      fetch: fetchMock as any,
+      sleep: async () => {},
+      videoDownload: {
+        lookup: vi.fn(async () => [{ address: "93.184.216.34", family: 4 }]) as any,
+        request: request as any,
+      },
+    });
+    expect(calls).toHaveLength(2);
+    expect(calls[0].init.headers.Authorization).toBe("Bearer oauth-token");
+    expect(calls[1].init.method).toBe("GET");
+    expect(calls[1].init.headers).not.toHaveProperty("Content-Type");
+    expect(request.mock.calls[0][0].headers).not.toHaveProperty("Authorization");
+    expect(output).toMatchObject({ mimeType: "video/mp4", duration: 10, resolution: "720p", byteLength: 41 });
+    expect(output.path).not.toContain("private-session-id");
+    expect((await stat(output.path)).mode & 0o777).toBe(0o600);
+    await temp.cleanup();
+  });
+
+  it("continues through 202 and transient poll failures before terminal failure", async () => {
+    const dataUrl = `data:image/png;base64,${tinyPngBytes().toString("base64")}`;
+    const responses = [
+      jsonResponse({ request_id: "job_1" }),
+      jsonResponse({ status: "queued" }, 202),
+      jsonResponse({}, 429),
+      jsonResponse({ status: "failed" }),
+    ];
+    const fetchMock = vi.fn(async () => responses.shift()!);
+    await expect(executeXaiImageToVideo({
+      credential: { kind: "oauth-session", token: "token" },
+      input: validateXaiImageToVideoInput({ image: { data_url: dataUrl } }),
+      workspaceRoot: process.cwd(),
+      sessionManager: { getSessionDir: () => process.cwd(), getSessionId: () => "session" },
+    }, {
+      fetch: fetchMock as any,
+      sleep: async () => {},
+    })).rejects.toThrow(/generation failed/);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("enforces the cumulative generation deadline", async () => {
+    const dataUrl = `data:image/png;base64,${tinyPngBytes().toString("base64")}`;
+    let now = 0;
+    const fetchMock = vi.fn(async (url: any) =>
+      String(url).endsWith("/generations")
+        ? jsonResponse({ request_id: "job_1" })
+        : jsonResponse({ status: "queued" }));
+    await expect(executeXaiImageToVideo({
+      credential: { kind: "oauth-session", token: "token" },
+      input: validateXaiImageToVideoInput({ image: { data_url: dataUrl } }),
+      workspaceRoot: process.cwd(),
+      sessionManager: { getSessionDir: () => process.cwd(), getSessionId: () => "session" },
+    }, {
+      fetch: fetchMock as any,
+      generationTimeoutMs: 10_000,
+      now: () => now,
+      sleep: async (ms) => { now += ms; },
+    })).rejects.toThrow(/five-minute deadline/);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("waits before polling and reports local cancellation honestly", async () => {
+    const controller = new AbortController();
+    const dataUrl = `data:image/png;base64,${tinyPngBytes().toString("base64")}`;
+    let sleeps = 0;
+    await expect(executeXaiImageToVideo({
+      credential: { kind: "oauth-session", token: "token" },
+      input: validateXaiImageToVideoInput({ image: { data_url: dataUrl } }),
+      workspaceRoot: process.cwd(),
+      sessionManager: { getSessionDir: () => process.cwd(), getSessionId: () => "session" },
+      signal: controller.signal,
+    }, {
+      fetch: vi.fn(async () => jsonResponse({ request_id: "job_1" })) as any,
+      sleep: async () => {
+        sleeps++;
+        controller.abort();
+        throw new DOMException("Cancelled", "AbortError");
+      },
+    })).rejects.toThrow(/remote xAI video job was not cancelled/);
+    expect(sleeps).toBe(1);
+  });
+});

--- a/tests/videos/video-download.test.ts
+++ b/tests/videos/video-download.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  downloadXaiVideo,
+  isPublicVideoDownloadAddress,
+} from "../../extensions/xai/video-download";
+import { validateMp4Prefix } from "../../extensions/xai/media/video-info";
+
+describe("video download safety", () => {
+  it("accepts public addresses and rejects special-use ranges", () => {
+    expect(isPublicVideoDownloadAddress("93.184.216.34")).toBe(true);
+    for (const address of [
+      "127.0.0.1",
+      "10.0.0.1",
+      "172.16.0.1",
+      "192.168.1.1",
+      "169.254.1.1",
+      "100.64.0.1",
+      "198.18.0.1",
+      "203.0.113.1",
+      "::1",
+      "fc00::1",
+      "fe80::1",
+      "ff02::1",
+      "2001:db8::1",
+      "2606:2800:220:1:248:1893:25c8:1946",
+      "::ffff:127.0.0.1",
+    ]) expect(isPublicVideoDownloadAddress(address)).toBe(false);
+  });
+
+  it("validates bounded MP4 ftyp evidence", () => {
+    const valid = Buffer.from([
+      0, 0, 0, 24, 0x66, 0x74, 0x79, 0x70,
+      0x69, 0x73, 0x6f, 0x6d, 0, 0, 0, 0,
+      0x69, 0x73, 0x6f, 0x32, 0x6d, 0x70, 0x34, 0x32,
+    ]);
+    expect(() => validateMp4Prefix(valid)).not.toThrow();
+    expect(() => validateMp4Prefix(Buffer.alloc(24))).toThrow(/valid bounded MP4/);
+    const badBrand = Buffer.from(valid);
+    badBrand.write("nope", 8, "ascii");
+    badBrand.write("bad!", 16, "ascii");
+    badBrand.write("bad?", 20, "ascii");
+    expect(() => validateMp4Prefix(badBrand)).toThrow(/unsupported MP4 brand/);
+  });
+
+  it("rejects unsafe URLs and mixed public/private DNS before HTTPS", async () => {
+    const request = vi.fn();
+    const base = {
+      outputRoot: process.cwd(),
+      sessionRoot: process.cwd(),
+      duration: 6 as const,
+      resolution: "480p" as const,
+    };
+    await expect(downloadXaiVideo({ ...base, url: "http://example.test/video.mp4" }))
+      .rejects.toThrow(/failed safely/);
+    await expect(downloadXaiVideo({ ...base, url: "https://cdn.example.test/video.mp4" }, {
+      lookup: vi.fn(async () => [
+        { address: "93.184.216.34", family: 4 },
+        { address: "127.0.0.1", family: 4 },
+      ]) as any,
+      request: request as any,
+    })).rejects.toThrow(/failed safely/);
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("cancels a stalled DNS lookup without issuing HTTPS", async () => {
+    const controller = new AbortController();
+    const request = vi.fn();
+    const pending = downloadXaiVideo({
+      url: "https://cdn.example.test/video.mp4",
+      outputRoot: process.cwd(),
+      sessionRoot: process.cwd(),
+      duration: 6,
+      resolution: "480p",
+      signal: controller.signal,
+    }, {
+      lookup: vi.fn(() => new Promise(() => {})) as any,
+      request: request as any,
+      timeoutMs: 10_000,
+    });
+    controller.abort();
+    await expect(pending).rejects.toThrow(/cancelled/);
+    expect(request).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- add disabled-by-default `xai_image_to_video` with bounded local/data-URL image input
- implement pinned asynchronous create/status polling with cancellation and cumulative deadlines
- download MP4 output without auth through DNS/IP-pinned HTTPS and atomically store verified bounded output
- add high-cost/latency warnings, lifecycle authorization, tests, loader coverage, and documentation

Closes #84

## Validation

- `NODE_OPTIONS=--unhandled-rejections=strict npm test` (444 tests and loader smoke)
- `npm run test:coverage`
- `npm run typecheck`
- `npm run compatibility:check`
- `npm run compatibility:boundaries` (Pi 0.80.1 and 0.80.10)
- `npm pack --dry-run --json`
- `git diff --check`
- real Pi TUI tool-registration and unavailable-state verification

No live paid xAI video request was made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a high-cost, long-running paid API path with unauthenticated downloads and custom SSRF pinning; mitigations mirror existing image media bounds but expand attack surface and billing exposure if mis-enabled.
> 
> **Overview**
> Introduces **opt-in `xai_image_to_video`** for `grok-imagine-video-1.5-preview`: one bounded workspace PNG/JPEG or data URL, optional prompt, and **6s/10s** duration with **480p/720p** resolution. Like other network tools it stays off until `/xai-tools enable`, with extra UI warnings about cost, latency, and **remote jobs continuing after local cancellation**.
> 
> The implementation posts to pinned **`/v1/videos/generations`**, polls **`/v1/videos/<request_id>`** on a five-second interval with a five-minute cumulative deadline, then downloads the signed URL **without OAuth** using HTTPS-only, no-redirect, **resolve-once public-IPv4 DNS/IP pinning** (IPv6 download hosts fail closed). MP4 output is streamed under **256 MiB**, validated for MIME and **`ftyp`/box structure**, and saved atomically under `pi-xai-oauth/<session-hash>/videos/` via a new **`savePrivateStreamedOutput`** helper shared with refactored session output paths.
> 
> Routing, wire headers, Grok Build compatibility matrix, README/CHANGELOG, registration/loader tests, and focused Vitest suites for orchestration and download safety are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd841b33121390dca3d74ebe7a913b62deeb2a88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->