### PR TITLE
fix: pin public IPv4 for dual-stack xAI video downloads

### DIFF
--- a/extensions/xai/video-download.ts
+++ b/extensions/xai/video-download.ts
@@ -52,6 +52,13 @@ function blockedIpv4(address: string): boolean {
     a >= 224;
 }
 
+function isBlockedVideoDownloadIpv4(address: string): boolean {
+  const normalized = normalizedIp(address);
+  const compatibleIpv4 = /^::(\d{1,3}(?:\.\d{1,3}){3})$/.exec(normalized)?.[1];
+  if (compatibleIpv4) return blockedIpv4(compatibleIpv4);
+  return isIP(normalized) === 4 && blockedIpv4(normalized);
+}
+
 export function isPublicVideoDownloadAddress(address: string): boolean {
   const normalized = normalizedIp(address);
   const compatibleIpv4 = /^::(\d{1,3}(?:\.\d{1,3}){3})$/.exec(normalized)?.[1];
@@ -114,12 +121,20 @@ export async function downloadXaiVideo(options: {
         { once: true },
       )),
     ]);
-    if (addresses.length === 0 || addresses.some(({ address }) => !isPublicVideoDownloadAddress(address))) {
+    // IPv6 answers are intentionally non-public, but dual-stack CDNs almost always
+    // return mixed A/AAAA records. Select only public IPv4 pins and still fail closed
+    // when any private/special-use IPv4 answer is present (DNS rebinding defense).
+    const publicAddresses = addresses.filter(({ address }) => isPublicVideoDownloadAddress(address));
+    const hasBlockedIpv4 = addresses.some(({ address }) => isBlockedVideoDownloadIpv4(address));
+    if (publicAddresses.length === 0 || hasBlockedIpv4) {
       throw new VideoDownloadError();
     }
-    const selected = addresses[0];
+    const selected = publicAddresses[0];
     const response = await new Promise<import("node:http").IncomingMessage>((resolve, reject) => {
-      const requestOptions: RequestOptions = {
+      // Node 24 enables Happy Eyeballs by default; pin family 4 and supply both
+      // single-address and { all: true } lookup callback shapes so the custom pin
+      // is honored without re-resolving dual-stack DNS.
+      const requestOptions = {
         protocol: "https:",
         hostname: url.hostname,
         port: 443,
@@ -130,11 +145,18 @@ export async function downloadXaiVideo(options: {
           "User-Agent": XAI_USER_AGENT,
         },
         servername: url.hostname,
+        family: 4,
+        autoSelectFamily: false,
         signal: controller.signal,
-        lookup(_hostname, _options, callback) {
+        lookup(_hostname: string, options: unknown, callback: (...args: any[]) => void) {
+          const opts = typeof options === "object" && options ? options as { all?: boolean } : {};
+          if (opts.all) {
+            callback(null, [{ address: selected.address, family: selected.family }]);
+            return;
+          }
           callback(null, selected.address, selected.family);
         },
-      };
+      } as RequestOptions & { autoSelectFamily?: boolean };
       const req = request(requestOptions, (res) => resolve(res));
       req.once("socket", (socket) => {
         socket.once("secureConnect", () => {

--- a/tests/videos/video-download.test.ts
+++ b/tests/videos/video-download.test.ts
@@ -62,6 +62,67 @@ describe("video download safety", () => {
     expect(request).not.toHaveBeenCalled();
   });
 
+  it("pins public IPv4 when dual-stack DNS also returns non-public IPv6", async () => {
+    const request = vi.fn();
+    await expect(downloadXaiVideo({
+      url: "https://cdn.example.test/video.mp4",
+      outputRoot: process.cwd(),
+      sessionRoot: process.cwd(),
+      duration: 6,
+      resolution: "480p",
+    }, {
+      lookup: vi.fn(async () => [
+        { address: "2606:4700::6812:1350", family: 6 },
+        { address: "93.184.216.34", family: 4 },
+        { address: "10.0.0.1", family: 4 },
+      ]) as any,
+      request: request as any,
+    })).rejects.toThrow(/failed safely/);
+    expect(request).not.toHaveBeenCalled();
+
+    // Mixed public IPv4 + IPv6 must not be rejected solely because IPv6 is non-public.
+    // Request is issued with the public IPv4 pin; the mocked request never completes HTTPS.
+    const dualStackRequest = vi.fn((_options: any, _callback: any) => {
+      const req = {
+        once(event: string, handler: (...args: any[]) => void) {
+          if (event === "error") queueMicrotask(() => handler(new Error("boom")));
+          return this;
+        },
+        end() {},
+        destroy() {},
+      };
+      return req;
+    });
+    await expect(downloadXaiVideo({
+      url: "https://cdn.example.test/video.mp4",
+      outputRoot: process.cwd(),
+      sessionRoot: process.cwd(),
+      duration: 6,
+      resolution: "480p",
+    }, {
+      lookup: vi.fn(async () => [
+        { address: "2606:4700::6812:1350", family: 6 },
+        { address: "93.184.216.34", family: 4 },
+      ]) as any,
+      request: dualStackRequest as any,
+    })).rejects.toThrow(/failed safely/);
+    expect(dualStackRequest).toHaveBeenCalled();
+    const pinned = dualStackRequest.mock.calls[0][0];
+    expect(pinned.lookup).toEqual(expect.any(Function));
+    await new Promise<void>((resolve, reject) => {
+      pinned.lookup("cdn.example.test", {}, (err: Error | null, address: string, family: number) => {
+        try {
+          expect(err).toBeNull();
+          expect(address).toBe("93.184.216.34");
+          expect(family).toBe(4);
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+  });
+
   it("cancels a stalled DNS lookup without issuing HTTPS", async () => {
     const controller = new AbortController();
     const request = vi.fn();


### PR DESCRIPTION
## Summary
- Select public IPv4 pins from dual-stack CDN DNS instead of rejecting hosts that also return non-public IPv6 (e.g. `vidgen.x.ai`).
- Keep DNS-rebinding defense by still failing closed when any private/special-use IPv4 answer is present.
- Disable Happy Eyeballs / pin family 4 and honor both single-address and `{ all: true }` custom-lookup callback shapes so Node 24 does not turn the pin into `undefined` (`ERR_INVALID_IP_ADDRESS`).

## Why
Image-to-video generation completed remotely, but every local download failed with `xAI video download failed safely.` Real download diagnostics showed:
1. dual-stack DNS with public IPv4 present
2. HTTPS request started
3. `TypeError: Invalid IP address: undefined` from the custom lookup path

## Test plan
- [x] `npm run test:unit -- tests/videos/video-download.test.ts tests/videos/image-to-video.test.ts`
- [x] `npx tsc --noEmit -p tsconfig.json`
- [x] Live image-to-video create/poll/download against `vidgen.x.ai` after the fix (succeeded; ~1.3MB MP4)
- [ ] Restart Pi (or start a new session) so jiti reloads the local package before relying on the tool path

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SSRF/DNS-rebinding defenses and connection pinning for outbound HTTPS; behavior is intentionally conservative but changes which dual-stack hosts are allowed to download.
> 
> **Overview**
> Fixes **xAI image-to-video local downloads** failing on dual-stack CDNs (e.g. `vidgen.x.ai`) when DNS returns both public IPv4 and non-public IPv6.
> 
> **DNS handling** in `downloadXaiVideo` now keeps only **public IPv4** pins instead of treating every address as public-or-bust, while still **failing closed** if any private/special-use IPv4 appears in the full answer set (`isBlockedVideoDownloadIpv4`). IPv6 remains non-public by design.
> 
> **HTTPS** requests set **`family: 4`** and **`autoSelectFamily: false`** so Node 24’s Happy Eyeballs path doesn’t bypass the pin. The custom **`lookup`** callback now supports both single-address and `{ all: true }` shapes so the pinned address isn’t returned as `undefined`.
> 
> Tests cover mixed IPv6 + public IPv4 (request issued with pin) and mixed answers that include blocked IPv4 (no HTTPS).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbc61d9beb17d26767b4a03d110774b846f04931. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->