### PR TITLE
fix: deduplicate xAI web search tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 
 ### Fixed
 
+- Consolidated duplicate `xai_web_search` and Grok-native `web_search` registrations into one collision-safe, opt-in `web_search` picker entry. The old `xai_web_search` command spelling remains an input-only compatibility alias, and the public name is still never registered globally.
 - Contained the direct Grok-native `read_file`, `search_replace`, and `list_dir` adapters to resolved workspace paths, safely limited missing-leaf creation to contained physical parents, and capped package-owned full text reads at 5,000,000 bytes. `run_terminal_command` remains an unrestricted delegation to pi `bash`, so this is direct-adapter defense-in-depth rather than a filesystem sandbox.
 - Restricted legacy local PNG/JPEG inputs across custom tools, Responses payload normalization, and vision routing to byte-bounded, byte-validated regular files inside the active workspace, with sanitized failures for traversal, outward symlinks, special files, MIME spoofing, oversized sources, and pixel bombs.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pi --model grok-4.5:high "Review this architecture for failure modes"
 pi --model grok-4.5:low "Quick status check"   # fast mode
 ```
 
-This package adds xAI's **account-specific OAuth model catalog** to pi, with **Grok 4.5** as the offline fallback/default, proper OAuth login, automatic token refresh, and a suite of custom xAI tools (`xai_generate_text`, `xai_web_search`, `xai_x_search`, etc.). The normalized cache remains exact; registration may additionally expose narrowly verified compatibility routes such as Grok 4.3 and Composer only while their required authenticated entitlement source is present.
+This package adds xAI's **account-specific OAuth model catalog** to pi, with **Grok 4.5** as the offline fallback/default, proper OAuth login, automatic token refresh, and a suite of custom xAI tools (`xai_generate_text`, `web_search`, `xai_x_search`, etc.). The normalized cache remains exact; registration may additionally expose narrowly verified compatibility routes such as Grok 4.3 and Composer only while their required authenticated entitlement source is present.
 
 > **Latest release:** `pi-xai-oauth` **1.3.6** adds authenticated account-specific model discovery, browser and device OAuth, encrypted reasoning replay, Grok-native local tools, bounded image editing, and explicit subscription usage while hardening xAI routing, payloads, headers, redirects, and entitlement enforcement. Existing npm installs should run `pi update npm:pi-xai-oauth`; local checkout installs should keep only one copy with `pi remove npm:pi-xai-oauth && pi install .`.
 >
@@ -87,7 +87,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and
 - **Credential-aware Responses routing** — OAuth/session traffic uses the official `https://cli-chat-proxy.grok.com/v1` endpoint for every Grok model; the public `api.x.ai` Responses endpoint is reserved for a future explicit API-key path
 - **Revision-pinned wire contract** — route-specific headers, truthful package identity, protected request metadata, redirect rejection, and the upstream Grok Build review procedure are documented without impersonating the official client
 
-> **✅ Verified (May 2026)**: All custom xAI tools (`xai_generate_text`, `xai_x_search`, `xai_web_search`, `xai_code_execution`, `xai_critique`, `xai_multi_agent`, `xai_deep_research`, image tools, etc.) have been tested end-to-end after the OAuth + payload repair. The provider now correctly handles mixed-model requests and native xAI tool shapes.
+> **✅ Verified (May 2026)**: All custom xAI tools (`xai_generate_text`, `xai_x_search`, `web_search`, `xai_code_execution`, `xai_critique`, `xai_multi_agent`, `xai_deep_research`, image tools, etc.) have been tested end-to-end after the OAuth + payload repair. The provider now correctly handles mixed-model requests and native xAI tool shapes.
 
 ---
 
@@ -147,7 +147,7 @@ Then optionally configure it as default:
 
 > **⚠️ Important: install only one copy**
 >
-> `pi-xai-oauth` registers fixed tool names such as `xai_generate_text`, `xai_web_search`, and `xai_x_search`. If you install more than one copy — for example `npm:pi-xai-oauth` plus a local checkout, or two different local checkouts — pi will fail to start with `Tool "xai_generate_text" conflicts with ...` errors.
+> `pi-xai-oauth` registers fixed private tool names such as `xai_generate_text`, `xai_grok_web_search`, and `xai_x_search`. If you install more than one copy — for example `npm:pi-xai-oauth` plus a local checkout, or two different local checkouts — pi will fail to start with `Tool "xai_generate_text" conflicts with ...` errors.
 >
 > Check with:
 > ```bash
@@ -426,7 +426,6 @@ This opt-in boundary applies only to the extra tools below. Normal conversation 
 | Tool | Category | Additional usage / cost risk |
 |------|----------|------------------------------|
 | `xai_generate_text` | Generation | Separate model-token usage |
-| `xai_web_search` | Search | Model tokens plus native tool usage |
 | `xai_x_search` | Search | Model tokens plus native tool usage |
 | `xai_multi_agent` | Research | High/variable: 4 or 16 agents plus web/X tools |
 | `xai_deep_research` | Research | High/variable model and web/X tool usage |
@@ -452,8 +451,8 @@ The picker shows each tool's category and cost-risk context, warns that calls ma
 
 ```text
 /xai-tools status
-/xai-tools enable xai_web_search
-/xai-tools disable xai_web_search
+/xai-tools enable web_search
+/xai-tools disable web_search
 /xai-tools enable xai_generate_image
 /xai-tools enable xai_edit_image
 /xai-tools enable xai_image_to_video
@@ -461,7 +460,7 @@ The picker shows each tool's category and cost-risk context, warns that calls ma
 /xai-tools disable vision-routing
 ```
 
-`vision-routing` is transport policy rather than a callable model tool, so it never enters Pi's active-tool registry. It appears only when exact authenticated capability evidence supports a text-only source and a separate text-and-image target. `web_search` appears in the picker for any active xAI model (still opt-in). `/xai-tools` is owned by this package; it does not depend on pi's optional example `/tools` extension.
+`vision-routing` is transport policy rather than a callable model tool, so it never enters Pi's active-tool registry. It appears only when exact authenticated capability evidence supports a text-only source and a separate text-and-image target. `web_search` appears once in the picker for any active xAI model (still opt-in); the older `xai_web_search` spelling remains accepted only as a backward-compatible `/xai-tools enable` or `disable` argument. `/xai-tools` is owned by this package; it does not depend on pi's optional example `/tools` extension.
 
 > **Tip:** See the ⚠️ warning above about local vs published package conflicts.
 
@@ -487,12 +486,13 @@ Opt-in deep multi-agent research using Grok's multi-agent model plus native web 
 }
 ```
 
-### `xai_web_search`
-Opt-in search using xAI's native `web_search` tool and the active xAI model. Enable it through `/xai-tools` first.
+### `web_search`
+Opt-in search using xAI's native `web_search` tool and the active xAI model. Enable it through `/xai-tools` first. The optional `allowed_domains` list is forwarded unchanged.
 
 ```json
 {
-  "query": "Rust vs Go performance 2026"
+  "query": "Rust vs Go performance 2026",
+  "allowed_domains": ["rust-lang.org", "go.dev"]
 }
 ```
 

--- a/bin/setup.js
+++ b/bin/setup.js
@@ -220,7 +220,7 @@ function printNextSteps(nonInteractive = false) {
   console.log("Bonus tools available:");
   console.log("   • xai_generate_text     — Generate text with full reasoning");
   console.log("   • xai_multi_agent       — Multi-agent research with web/X tools");
-  console.log("   • xai_web_search        — Native xAI web search");
+  console.log("   • web_search            — Native xAI web search");
   console.log("   • xai_x_search          — Native X/Twitter search");
   console.log("   • xai_code_execution    — Native code interpreter");
   console.log("   • xai_generate_image    — Image generation");

--- a/extensions/xai/tools/commands.ts
+++ b/extensions/xai/tools/commands.ts
@@ -25,7 +25,6 @@ interface NetworkToolOption {
 
 const NETWORK_TOOL_OPTIONS: readonly NetworkToolOption[] = [
   { name: "xai_generate_text", category: "generation", costRisk: "token usage", summary: "separate Grok response" },
-  { name: "xai_web_search", category: "search", costRisk: "token + tool", summary: "native xAI web search" },
   { name: "xai_x_search", category: "search", costRisk: "token + tool", summary: "native xAI X search" },
   { name: "xai_multi_agent", category: "research", costRisk: "high/variable", summary: "4- or 16-agent web/X research" },
   { name: "xai_deep_research", category: "research", costRisk: "high/variable", summary: "multi-step web/X research" },
@@ -50,6 +49,7 @@ const XAI_TOOLS_USAGE =
 function commandToolName(value: string | undefined): XaiNetworkToolName | undefined {
   if (!value) return undefined;
   const normalized = value.toLowerCase();
+  if (normalized === "xai_web_search") return XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME;
   return NETWORK_TOOL_OPTIONS.find(
     ({ name, displayName }) =>
       name.toLowerCase() === normalized || displayName?.toLowerCase() === normalized,

--- a/extensions/xai/tools/custom-tools.ts
+++ b/extensions/xai/tools/custom-tools.ts
@@ -198,41 +198,6 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
 
     // Agentic tools that leverage xAI's native server-side tools.
     pi.registerTool({
-      name: "xai_web_search",
-      label: "xAI Web Search",
-      description: "Opt-in paid search using Grok's native web search. Enable via /xai-tools and call only when the user explicitly requests xAI web search.",
-      promptGuidelines: ["Call xai_web_search only when the user explicitly requests xAI web search."],
-      parameters: {
-        type: "object",
-        properties: { query: { type: "string", description: "Search query" } },
-        required: ["query"],
-      },
-      execute: async (_toolCallId: string, params: { query?: string }, _signal: any, _onUpdate: any, ctx: any) => {
-        const activeModel = activeModelForXaiTool(pi, ctx, "xai_web_search");
-        if (!activeModel) return xaiToolDisabledError("xai_web_search", { query: params?.query });
-        const credential = await resolveXaiCredential(ctx);
-        if (!credential) {
-          return xaiToolError("Error: No xAI OAuth credentials found. Please run the OAuth login first.", { query: params?.query });
-        }
-        const prompt = `Search the web for: ${params.query}. Summarize the top results with sources, key facts, dates, and recent developments. Prioritize authoritative sources.`;
-        let data: any;
-        try {
-          data = await createXaiResponse(credential, {
-            model: activeModel.id,
-            input: xaiTextInput(prompt),
-            reasoning: { effort: "medium" },
-            tools: [{ type: "web_search", enable_image_understanding: true }],
-          }, _signal);
-        } catch (error) {
-          const status = statusFromError(error);
-          return xaiToolError(`xAI API Error${status ? ` ${status}` : ""}: ${messageFromError(error)}`, { error: true, status, query: params.query });
-        }
-        const text = extractResponsesText(data) || `No results for: ${params.query}`;
-        return { content: [{ type: "text", text }], details: { query: params.query } };
-      },
-    } as any);
-
-    pi.registerTool({
       name: "xai_x_search",
       label: "xAI X Search",
       description: "Opt-in paid X search using Grok's native real-time search. Enable via /xai-tools and call only when the user explicitly requests xAI X search.",

--- a/extensions/xai/tools/model-scope.ts
+++ b/extensions/xai/tools/model-scope.ts
@@ -8,7 +8,6 @@ import {
 /** Network-backed xAI tools that make an additional authenticated API request. */
 export const XAI_NETWORK_TOOL_NAMES = [
   "xai_generate_text",
-  "xai_web_search",
   "xai_x_search",
   "xai_multi_agent",
   "xai_deep_research",

--- a/scripts/verify-extension-loader.mjs
+++ b/scripts/verify-extension-loader.mjs
@@ -34,6 +34,10 @@ try {
     "collision-free Grok web-search dispatcher should be registered",
   );
   assert.ok(
+    !loaded.tools.has("xai_web_search"),
+    "legacy xAI web-search wrapper should not be registered alongside the Grok dispatcher",
+  );
+  assert.ok(
     !loaded.tools.has("web_search"),
     "public Grok web-search name must remain free for other extensions",
   );

--- a/tests/provider/registration.test.ts
+++ b/tests/provider/registration.test.ts
@@ -41,9 +41,12 @@ describe("provider registration", () => {
       cost: { input: 2, cacheRead: 0.5, output: 6 },
       thinkingLevelMap: { off: null },
     });
-    expect(harness.tools.size).toBe(17);
+    expect(harness.tools.size).toBe(16);
     expect(harness.tools.has("xai_edit_image")).toBe(true);
     expect(harness.tools.has("xai_image_to_video")).toBe(true);
+    expect(harness.tools.has("xai_grok_web_search")).toBe(true);
+    expect(harness.tools.has("xai_web_search")).toBe(false);
+    expect(harness.tools.has("web_search")).toBe(false);
     expect(harness.commands.has("xai-tools")).toBe(true);
     expect(harness.commands.has("xai-usage")).toBe(true);
     expect([...harness.handlers.keys()]).toEqual(

--- a/tests/tools/commands.test.ts
+++ b/tests/tools/commands.test.ts
@@ -98,17 +98,18 @@ describe("/xai-tools command", () => {
     );
   });
 
-  it("reports every tool status and eligibility", async () => {
+  it("reports every tool status with one web_search entry", async () => {
     const { notices, run } = setup();
     await run("status");
+    const message = notices.at(-1).message;
     for (const name of XAI_NETWORK_TOOL_NAMES) {
       const displayName = name === XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME
         ? XAI_GROK_NATIVE_WEB_SEARCH_NAME
         : name;
-      expect(notices.at(-1).message).toMatch(
-        new RegExp(`${displayName}=(?:enabled|disabled)`),
-      );
+      expect(message).toMatch(new RegExp(`${displayName}=(?:enabled|disabled)`));
     }
+    expect(message.match(/web_search=(?:enabled|disabled)/g)).toHaveLength(1);
+    expect(message).not.toMatch(/xai_web_search=/);
   });
   it("rejects paid tools for non-xAI models and allows web_search for xAI models", async () => {
     const { h, notices, run } = setup();
@@ -117,18 +118,23 @@ describe("/xai-tools command", () => {
     expect(notices.at(-1).message).toMatch(/Select an xAI\/Grok model/);
     await run("enable web_search");
     expect(isXaiNetworkToolActive(h.api, XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME)).toBe(true);
+    await run("disable xai_web_search");
+    expect(isXaiNetworkToolActive(h.api, XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME)).toBe(false);
+    await run("enable xai_web_search");
+    expect(isXaiNetworkToolActive(h.api, XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME)).toBe(true);
+    expect(notices.at(-1).message).toMatch(/Enabled web_search/);
   });
   it("fails closed when registry reads or writes fail", async () => {
     const { h, notices, run } = setup();
     h.failRegistry({ get: true });
     await run("enable xai_web_search");
     h.failRegistry();
-    expect(isXaiNetworkToolActive(h.api, "xai_web_search")).toBe(false);
+    expect(isXaiNetworkToolActive(h.api, XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME)).toBe(false);
     expect(notices.at(-1).message).toMatch(/could not be read/);
     h.failRegistry({ set: true });
     await run("enable xai_web_search");
     h.failRegistry();
-    expect(isXaiNetworkToolActive(h.api, "xai_web_search")).toBe(false);
+    expect(isXaiNetworkToolActive(h.api, XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME)).toBe(false);
     expect(notices.at(-1).message).toMatch(/could not be updated/);
   });
   it("uses the RPC picker to toggle a selection", async () => {
@@ -146,14 +152,16 @@ describe("/xai-tools command", () => {
           title = value;
           options = choices;
           return ++pass === 1
-            ? choices.find((choice) => choice.includes("xai_web_search"))
+            ? choices.find((choice) => choice.includes("web_search"))
             : "Done";
         },
       },
     });
     await h.commands.get("xai-tools").handler("", ctx);
-    expect(isXaiNetworkToolActive(h.api, "xai_web_search")).toBe(true);
+    expect(isXaiNetworkToolActive(h.api, XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME)).toBe(true);
     expect(title).toMatch(/explicit opt-in/);
+    expect(options.filter((value) => value.includes("web_search"))).toHaveLength(1);
+    expect(options.every((value) => !value.includes("xai_web_search"))).toBe(true);
     expect(
       options.some(
         (value) =>
@@ -170,7 +178,7 @@ describe("/xai-tools command", () => {
       id: "claude",
     });
 
-    expect(isXaiNetworkToolActive(h.api, "xai_web_search")).toBe(false);
+    expect(isXaiNetworkToolActive(h.api, XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME)).toBe(false);
     expect(isXaiNetworkToolActive(h.api, "xai_generate_image")).toBe(true);
     syncXaiNetworkToolsForModel(h.api, TEST_MODEL);
     expect(isXaiNetworkToolActive(h.api, "xai_generate_image")).toBe(true);
@@ -191,13 +199,13 @@ describe("/xai-tools command", () => {
       XAI_NETWORK_TOOL_NAMES.filter((name) =>
         h.getActiveTools().includes(name),
       ),
-    ).toEqual(["xai_web_search"]);
+    ).toEqual([XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME]);
     syncXaiNetworkToolsForModel(h.api, TEST_MODEL);
     expect(
       XAI_NETWORK_TOOL_NAMES.filter((name) =>
         h.getActiveTools().includes(name),
       ),
-    ).toEqual(["xai_web_search"]);
+    ).toEqual([XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME]);
   });
 
   it("keeps TUI selection in place, wraps pages, toggles, and closes", async () => {
@@ -250,10 +258,10 @@ describe("/xai-tools command", () => {
     await h.commands.get("xai-tools").handler("", ctx);
     // Page movement uses the ten-row viewport across the full tool catalog.
     expect(selected[0]).toMatch(/xai_x_search/);
-    expect(selected[1]).toMatch(/\[ \] xai_generate_image/);
-    expect(selected[2]).toMatch(/\[x\] xai_generate_image/);
+    expect(selected[1]).toMatch(/\[ \] xai_edit_image/);
+    expect(selected[2]).toMatch(/\[x\] xai_edit_image/);
     expect(closed).toBe(true);
-    expect(isXaiNetworkToolActive(h.api, "xai_generate_image")).toBe(true);
+    expect(isXaiNetworkToolActive(h.api, "xai_edit_image")).toBe(true);
   });
 
   it("wraps Page Up and Page Down across the full xAI tool catalog", async () => {

--- a/tests/tools/custom-tools.test.ts
+++ b/tests/tools/custom-tools.test.ts
@@ -59,7 +59,6 @@ describe("custom xAI tools", () => {
   });
   it.each([
     ["xai_generate_text", { prompt: "guard" }],
-    ["xai_web_search", { query: "guard" }],
     ["xai_x_search", { query: "guard" }],
     ["xai_multi_agent", { query: "guard" }],
     ["xai_deep_research", { topic: "guard" }],
@@ -154,13 +153,6 @@ describe("custom xAI tools", () => {
     expect(
       new Headers(request.init.headers).get("x-grok-conv-id"),
     ).toBeTruthy();
-  });
-  it("uses the active model and native web-search tool", async () => {
-    await run("xai_web_search", { query: "xAI docs" });
-    expect(requests.at(-1)?.body).toMatchObject({
-      model: "grok-4.5",
-      tools: [{ type: "web_search", enable_image_understanding: true }],
-    });
   });
   it("maps X date filters and code interpreter", async () => {
     await run("xai_x_search", {
@@ -379,28 +371,5 @@ describe("custom xAI tools", () => {
       "web_search",
       "x_search",
     ]);
-  });
-  it("translates one provider error without retrying or changing the active model", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: any, init: RequestInit = {}) => {
-        requests.push({ url: String(url), init, body: requestBody(init) });
-        return jsonResponse({ error: "credits" }, 403);
-      }),
-    );
-    const model = { ...TEST_MODEL, id: "grok-4.3" } as any;
-    setXaiNetworkToolActive(h.api, model, "xai_web_search", true);
-    const result = await h.tools
-      .get("xai_web_search")
-      .execute(
-        "call",
-        { query: "one" },
-        undefined,
-        () => {},
-        authContext(model),
-      );
-    expect(result.content[0].text).toMatch(/xAI API Error 403/);
-    expect(requests).toHaveLength(1);
-    expect(requests[0].body.model).toBe("grok-4.3");
   });
 });

--- a/tests/tools/model-scope.test.ts
+++ b/tests/tools/model-scope.test.ts
@@ -16,7 +16,7 @@ describe("network-tool lifecycle", () => {
   it("requires an active xAI model for web_search", () => {
     const h = createExtensionHarness([...XAI_NETWORK_TOOL_NAMES]);
     expect(
-      setXaiNetworkToolActive(h.api, undefined, "xai_web_search", true),
+      setXaiNetworkToolActive(h.api, undefined, XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME, true),
     ).toMatchObject({ ok: false, active: false });
     expect(
       setXaiNetworkToolActive(
@@ -66,7 +66,7 @@ describe("network-tool lifecycle", () => {
     const read = createExtensionHarness();
     read.failRegistry({ get: true });
     expect(
-      setXaiNetworkToolActive(read.api, TEST_MODEL, "xai_web_search", true),
+      setXaiNetworkToolActive(read.api, TEST_MODEL, XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME, true),
     ).toMatchObject({
       ok: false,
       active: false,
@@ -75,23 +75,23 @@ describe("network-tool lifecycle", () => {
     const write = createExtensionHarness();
     write.failRegistry({ set: true });
     expect(
-      setXaiNetworkToolActive(write.api, TEST_MODEL, "xai_web_search", true),
+      setXaiNetworkToolActive(write.api, TEST_MODEL, XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME, true),
     ).toMatchObject({
       ok: false,
       active: false,
       error: expect.stringMatching(/could not be updated/),
     });
     write.failRegistry();
-    expect(isXaiNetworkToolActive(write.api, "xai_web_search")).toBe(false);
+    expect(isXaiNetworkToolActive(write.api, XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME)).toBe(false);
   });
   it("selectively disables one tool while preserving another", () => {
     const h = createExtensionHarness();
-    setXaiNetworkToolActive(h.api, TEST_MODEL, "xai_web_search", true);
+    setXaiNetworkToolActive(h.api, TEST_MODEL, XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME, true);
     setXaiNetworkToolActive(h.api, TEST_MODEL, "xai_generate_image", true);
     expect(
-      setXaiNetworkToolActive(h.api, undefined, "xai_web_search", false),
+      setXaiNetworkToolActive(h.api, undefined, XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME, false),
     ).toEqual({ ok: true, active: false });
-    expect(isXaiNetworkToolActive(h.api, "xai_web_search")).toBe(false);
+    expect(isXaiNetworkToolActive(h.api, XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME)).toBe(false);
     expect(isXaiNetworkToolActive(h.api, "xai_generate_image")).toBe(true);
   });
   it("does not allow direct registry injection to bypass package authorization", () => {


### PR DESCRIPTION
## Summary

- consolidate the legacy `xai_web_search` wrapper and Grok-native search dispatcher into one opt-in `web_search` tool
- retain `xai_web_search` as an input-only `/xai-tools` compatibility alias
- preserve collision-free private registration and request-local public-name routing
- update picker/status behavior, loader assertions, regression coverage, setup output, and documentation

## Validation

- focused web-search regressions — pass (91 tests)
- `npm run test:loader` — pass
- `npm run typecheck` — pass
- `npm test` — pass (43 files, 471 tests)
- `git diff --check` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tool registration and `/xai-tools` UX change only; behavior moves to the existing Grok dispatcher with backward-compatible command spelling and expanded tests.
> 
> **Overview**
> Removes the legacy **`xai_web_search`** custom tool registration so web search is no longer implemented twice alongside the Grok-native **`xai_grok_web_search`** dispatcher.
> 
> **`/xai-tools`** now exposes a single opt-in **`web_search`** row (backed internally by `xai_grok_web_search`); **`xai_web_search`** is accepted only as an enable/disable alias and no longer appears in status or picker lists. The public name **`web_search`** is still not registered globally, preserving collision-free behavior with other extensions.
> 
> Docs, setup output, loader smoke checks, and tests are updated to match (16 registered tools, one `web_search` status line, compatibility alias coverage).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fa4c20ca016a1bf8c48f754e929e2bf2782f5d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->