### PR TITLE
fix: reject malformed web search model contexts

### DIFF
--- a/extensions/xai/tools/grok-native.ts
+++ b/extensions/xai/tools/grok-native.ts
@@ -43,7 +43,7 @@ import {
   searchReplaceArgsForPi,
   terminalCommandArgsForPi,
 } from "./grok-native-args";
-import { isXaiNetworkToolActive } from "./model-scope";
+import { activeXaiModel, isXaiNetworkToolActive } from "./model-scope";
 
 const DEFAULT_GROK_GREP_LIMIT = 200;
 const MAX_GROK_GREP_LIMIT = 2_000;
@@ -998,7 +998,8 @@ export function registerGrokNativeTools(pi: ExtensionAPI) {
     execute: async (_toolCallId: string, params: any, signal: any, _onUpdate: any, ctx: any) => {
       const { query, allowed_domains: allowedDomains } = prepareWebSearchArgs(params);
       if (!query) return xaiToolError("Error: web_search requires a query.");
-      if (ctx?.model?.provider !== XAI_PROVIDER_ID) {
+      const activeModel = activeXaiModel(ctx);
+      if (!activeModel) {
         return xaiToolError(
           "Error: web_search requires an active xAI/Grok model. No xAI request was sent.",
         );
@@ -1022,7 +1023,7 @@ export function registerGrokNativeTools(pi: ExtensionAPI) {
         const data = await createXaiResponse(
           credential,
           {
-            model: ctx.model.id,
+            model: activeModel.id,
             input: `Search the web for: ${query}\n\nSummarize the key results with sources where available.`,
             tools: [webSearchTool],
           },

--- a/tests/tools/grok-native.test.ts
+++ b/tests/tools/grok-native.test.ts
@@ -511,6 +511,48 @@ describe("Grok-native tools", () => {
     expect(after.subarray(0, "needle".length).toString("utf8")).toBe("needle");
   });
 
+  it.each([
+    ["empty", { ...TEST_MODEL, id: "" }],
+    ["missing", { provider: TEST_MODEL.provider }],
+    ["whitespace-only", { ...TEST_MODEL, id: "   " }],
+    ["non-string", { ...TEST_MODEL, id: 123 }],
+  ] as const)(
+    "rejects a %s web_search model ID before credential or network access",
+    async (_caseName, model) => {
+      expect(
+        setXaiNetworkToolActive(
+          h.api,
+          TEST_MODEL,
+          XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME,
+          true,
+        ),
+      ).toEqual({ ok: true, active: true });
+
+      let credentialTouches = 0;
+      const ctx: any = { cwd: temp.path, model };
+      Object.defineProperty(ctx, "modelRegistry", {
+        get() {
+          credentialTouches++;
+          throw new Error("credential resolution must not be reached");
+        },
+      });
+
+      const result = await h.tools
+        .get(XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME)
+        .execute(
+          "call",
+          { query: "must stay local" },
+          new AbortController().signal,
+          () => {},
+          ctx,
+        );
+
+      expect(result.content[0].text).toMatch(/requires an active xAI\/Grok model/);
+      expect(credentialTouches).toBe(0);
+      expect(requests).toHaveLength(0);
+    },
+  );
+
   it("keeps web_search opt-in, forwards domain filters, and blocks stale contexts", async () => {
     const model = { ...TEST_MODEL, id: "grok-4.5" } as any;
     const controller = new AbortController();


### PR DESCRIPTION
## Summary

- validate Grok-native `web_search` contexts with the shared `activeXaiModel()` guard
- reject missing, empty, whitespace-only, and non-string xAI model IDs before credential or network access
- send nested search requests with the validated active model ID
- add focused fail-closed regression coverage for every malformed model shape

## Validation

- `npm run test:unit -- tests/tools/grok-native.test.ts` — pass (20 tests)
- `npm run test:unit -- tests/tools/model-scope.test.ts tests/tools/custom-tools.test.ts` — pass (40 tests)
- `npm run typecheck` — pass
- `npm test` — pass (43 files, 475 tests, plus real loader smoke)
- `git diff --check` — pass

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to opt-in web_search validation and model ID selection; aligns with existing custom-tools pattern and adds regression tests.
> 
> **Overview**
> Grok-native **`web_search`** now uses the shared **`activeXaiModel()`** helper instead of only checking `ctx.model.provider`, so empty, missing, whitespace-only, and non-string model IDs are rejected with a clear error **before** credential resolution or any xAI network call.
> 
> Successful searches send **`activeModel.id`** to **`createXaiResponse`** rather than **`ctx.model.id`** directly.
> 
> New parameterized tests assert fail-closed behavior for each malformed model shape (no credentials, no HTTP).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b6d45aff3d2f75dea852c7c1ea6100cd87067c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->