### PR TITLE
Use typed model input in vision conversion routing

### DIFF
--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,28 +1,24 @@
-# Implementation Plan — Issue #114: Post-hook vision pruning
+# Implementation Plan — Issue #116: Typed model input
 
-**Branch:** `fix/114-post-hook-vision-pruning`
-**Base:** `origin/main` at `941cb4a`
+**Branch:** `cleanup/116-typed-model-input`
+**Base:** `origin/main` at `67524bb`
 
 ## Goal
 
-Prevent caller payload hooks from reintroducing consumed historical images into the
-vision-routing target request while preserving current images, text-only enforcement,
-screenshot schema, and the original captured grant.
+Use the required `Model.input` type directly in vision conversion routing without
+changing the converter-only synthetic image capability used by enabled routing.
 
 ## Phases
 
-1. [x] Confirm issue scope, clean branch, and current payload/vision flow.
-2. [x] Extract a shared consumed-history payload helper.
-3. [x] Reapply pruning to the canonical post-hook payload before route planning.
-4. [x] Add streaming regressions for hook-returned user images and screenshots.
-5. [x] Document post-hook pruning and update the changelog.
-6. [x] Run full tests, typecheck, compatibility checks, and independent review.
-7. [x] Close adversarial review's recursive historical-image bypass and revalidate PR #120.
+1. [x] Confirm issue scope, branch state, and the supported Pi `Model.input` contract.
+2. [x] Review enabled and disabled vision-routing regressions.
+3. [x] Replace the cast/fallback with a direct defensive copy of `model.input`.
+4. [x] Run focused vision/image tests, typecheck, and the full test gate.
+5. [x] Perform an independent final diff review.
 
 ## Validation Contract
 
-- Historical hook-returned user images never reach the vision target.
-- Current hook-returned images still route when the captured grant is valid.
-- Historical `computer_call_output.output` remains object-shaped and reference-free.
-- Disabled routing still rejects hook-added images rather than silently pruning them.
-- Reset/re-enable cannot authorize a request under a replacement grant.
+- The conversion path reads `model.input` without a broad cast or fallback.
+- Enabled routing still exposes a synthetic image capability only to Pi's converter.
+- Disabled routing still rejects image payloads before transport.
+- No duplicate model-input type is introduced.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,31 +1,22 @@
-# Execution Progress — Issue #114
+# Execution Progress — Issue #116
 
-**Branch:** `fix/114-post-hook-vision-pruning`
-**Started:** 2026-07-19
+**Branch:** `cleanup/116-typed-model-input`
+**Started:** 2026-07-20
 
 ## Completed
 
-- [x] Read issue #114 and audited the pre-hook rewrite / post-hook planning boundary.
-- [x] Ran parallel scout and security/correctness design review.
-- [x] Extracted `omitConsumedXaiResponsesVisionImages` in `payload.ts`.
-- [x] Reused the helper in ordinary payload normalization and after caller hooks.
-- [x] Preserved current images, historical screenshot schema, and captured-grant checks.
-- [x] Added hook-returned historical user-image and computer-screenshot regressions.
-- [x] Updated modality documentation and changelog wording.
-- [x] Focused payload/vision tests passed (36 tests).
+- [x] Read issue #116 and confirmed the branch is based on clean `origin/main`.
+- [x] Audited the vision conversion path and supported Pi `Model.input` contract.
+- [x] Ran parallel scout and independent implementation review.
+- [x] Identified the one-line typed-copy change and focused regression coverage.
+- [x] Replaced the cast/fallback with a direct copy of `model.input`.
+- [x] Focused vision/image tests passed (2 files / 34 tests).
 - [x] Typecheck passed.
-- [x] Full `npm test` passed (43 files / 484 tests plus loader).
-- [x] Compatibility policy/pack checks passed.
-- [x] Exact Pi 0.80.1 and 0.80.10 boundary matrices passed.
-- [x] Initial independent review reported no concrete blocker.
-- [x] Three fresh adversarial reviewers found a recursive nested-image pruning bypass.
-- [x] Recursively stripped every image shape recognized by route planning from consumed items.
-- [x] Added nested historical user/tool screenshot and local-reference streaming coverage.
-- [x] Focused payload/vision tests passed (37 tests) and typecheck passed after the fix.
-- [x] Full `npm test` passed after the fix (43 files / 485 tests plus loader).
-- [x] Compatibility policy/pack checks and exact Pi 0.80.1 / 0.80.10 matrices passed.
-- [x] Final fresh-context adversarial review reported no concrete blocker.
+- [x] Full `npm test` passed (43 files / 485 tests plus loader).
+- [x] Project diagnostics reported zero primary language-server findings in `responses.ts`.
+- [x] Final fresh-context review reported no blocker.
+- [x] Exact Pi 0.80.1 and 0.80.10 compatibility boundaries passed.
 
 ## Delivery
 
-Adversarial blocker is fixed and fully validated; commit and PR #120 update remain.
+Issue #116 is fully validated and ready to commit, open as a PR, and merge.

--- a/extensions/xai/responses.ts
+++ b/extensions/xai/responses.ts
@@ -447,7 +447,7 @@ export function streamSimpleXaiResponses(
   // re-enable cannot authorize an already-started request under a new grant.
   const visionGrantSignal = visionRouting?.signalFor(selectedModelId);
   const visionEnabled = visionGrantSignal !== undefined && !visionGrantSignal.aborted;
-  const modelInputs = Array.isArray((model as any).input) ? [...(model as any).input] : ["text"];
+  const modelInputs = [...model.input];
   const streamModel = {
     ...model,
     id: selectedModelId,


### PR DESCRIPTION
## Summary
- copy the required `Model.input` field directly in the vision conversion path
- remove the broad cast and silent text-only fallback
- preserve converter-only synthetic image capability behavior

## Validation
- `npm run test:unit -- tests/responses/vision-routing.test.ts tests/responses/images.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run compatibility:boundaries`

Closes #116