### PR TITLE
Return explicit message for empty web search responses

### DIFF
--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,24 +1,23 @@
-# Implementation Plan — Issue #116: Typed model input
+# Implementation Plan — Issue #112: Empty web-search response
 
-**Branch:** `cleanup/116-typed-model-input`
-**Base:** `origin/main` at `67524bb`
+**Branch:** `fix/112-empty-web-search-response`
+**Base:** `origin/main`
 
 ## Goal
 
-Use the required `Model.input` type directly in vision conversion routing without
-changing the converter-only synthetic image capability used by enabled routing.
+Return a clear non-empty Grok-native `web_search` result when xAI succeeds without assistant text, while preserving response IDs and existing error behavior.
 
 ## Phases
 
-1. [x] Confirm issue scope, branch state, and the supported Pi `Model.input` contract.
-2. [x] Review enabled and disabled vision-routing regressions.
-3. [x] Replace the cast/fallback with a direct defensive copy of `model.input`.
-4. [x] Run focused vision/image tests, typecheck, and the full test gate.
+1. [x] Confirm issue scope, branch state, and current dispatcher behavior.
+2. [x] Review strict versus display response-text extraction and existing web-search tests.
+3. [x] Add the explicit `No results for: <query>` fallback and focused regression coverage.
+4. [x] Run focused tests, diagnostics, typecheck, and the full project gate.
 5. [x] Perform an independent final diff review.
 
 ## Validation Contract
 
-- The conversion path reads `model.input` without a broad cast or fallback.
-- Enabled routing still exposes a synthetic image capability only to Pi's converter.
-- Disabled routing still rejects image payloads before transport.
-- No duplicate model-input type is introduced.
+- Successful responses with assistant text remain unchanged.
+- Successful responses without assistant text return `No results for: <query>`.
+- Successful response IDs remain available in `details.response_id`.
+- Opt-in, model, credential, domain-filter, and error paths remain unchanged.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,22 +1,22 @@
-# Execution Progress — Issue #116
+# Execution Progress — Issue #112
 
-**Branch:** `cleanup/116-typed-model-input`
+**Branch:** `fix/112-empty-web-search-response`
 **Started:** 2026-07-20
 
 ## Completed
 
-- [x] Read issue #116 and confirmed the branch is based on clean `origin/main`.
-- [x] Audited the vision conversion path and supported Pi `Model.input` contract.
-- [x] Ran parallel scout and independent implementation review.
-- [x] Identified the one-line typed-copy change and focused regression coverage.
-- [x] Replaced the cast/fallback with a direct copy of `model.input`.
-- [x] Focused vision/image tests passed (2 files / 34 tests).
+- [x] Read issue #112 and confirmed a clean issue branch based on `origin/main`.
+- [x] Audited the Grok-native web-search dispatcher and response-text helpers.
+- [x] Ran parallel scout and independent acceptance review.
+- [x] Switched the dispatcher to strict assistant-text extraction with `No results for: <query>` fallback.
+- [x] Added a successful empty-response regression that preserves `details.response_id`.
+- [x] Focused Grok-native tests passed (21 tests).
 - [x] Typecheck passed.
-- [x] Full `npm test` passed (43 files / 485 tests plus loader).
-- [x] Project diagnostics reported zero primary language-server findings in `responses.ts`.
-- [x] Final fresh-context review reported no blocker.
+- [x] Full `npm test` passed (43 files / 486 tests plus loader).
+- [x] Pi Lens reported no error findings in the changed TypeScript files.
+- [x] Final fresh-context review found no blocker and confirmed issue acceptance.
 - [x] Exact Pi 0.80.1 and 0.80.10 compatibility boundaries passed.
 
 ## Delivery
 
-Issue #116 is fully validated and ready to commit, open as a PR, and merge.
+Issue #112 is implemented and validated, ready to commit or open as a PR.

--- a/extensions/xai/tools/grok-native.ts
+++ b/extensions/xai/tools/grok-native.ts
@@ -27,7 +27,7 @@ import {
   XAI_PROVIDER_ID,
 } from "../constants";
 import { createXaiResponse } from "../responses";
-import { extractResponsesText, messageFromError, statusFromError } from "../text";
+import { extractStrictResponsesText, messageFromError, statusFromError } from "../text";
 import { xaiToolError } from "./common";
 import {
   grepArgsForLocalSearch,
@@ -1029,8 +1029,9 @@ export function registerGrokNativeTools(pi: ExtensionAPI) {
           },
           signal,
         );
+        const text = extractStrictResponsesText(data) || `No results for: ${query}`;
         return {
-          content: [{ type: "text", text: extractResponsesText(data) }],
+          content: [{ type: "text", text }],
           details: { response_id: data.id },
         };
       } catch (error) {

--- a/tests/tools/grok-native.test.ts
+++ b/tests/tools/grok-native.test.ts
@@ -608,6 +608,35 @@ describe("Grok-native tools", () => {
     expect(requests).toHaveLength(1);
   });
 
+  it("returns an explicit fallback for a successful web_search response without text", async () => {
+    const model = { ...TEST_MODEL, id: "grok-4.5" };
+    expect(
+      setXaiNetworkToolActive(
+        h.api,
+        model,
+        XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME,
+        true,
+      ),
+    ).toEqual({ ok: true, active: true });
+
+    const fetchMock = vi.fn(async () => jsonResponse({ id: "resp-empty", output: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await h.tools
+      .get(XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME)
+      .execute(
+        "call",
+        { query: "unfindable topic" },
+        new AbortController().signal,
+        () => {},
+        { cwd: temp.path, ...authContext(model) },
+      );
+
+    expect(result.content[0].text).toBe("No results for: unfindable topic");
+    expect(result.details).toEqual({ response_id: "resp-empty" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("activates native local tools without mutating unrelated public tools", () => {
     const foreignNames = Object.values(XAI_GROK_NATIVE_TOOL_NAME_MAP);
     h.setActiveTools(["read", "bash", ...foreignNames]);


### PR DESCRIPTION
## Summary
- use strict Responses text extraction for the Grok-native `web_search` dispatcher
- return `No results for: <query>` when xAI succeeds without assistant text
- preserve successful response ID details and existing error behavior
- add focused regression coverage for an empty successful response

## Validation
- `npm run test:unit -- tests/tools/grok-native.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run compatibility:boundaries`

Closes #112
