### PR TITLE
test: assert mixed historical image pruning preserves user text

### DIFF
--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,22 +1,19 @@
-# Execution Progress — Issue #112
+# Execution Progress — Issue #117
 
-**Branch:** `fix/112-empty-web-search-response`
+**Branch:** `test/117-historical-image-text`
 **Started:** 2026-07-20
 
 ## Completed
 
-- [x] Read issue #112 and confirmed a clean issue branch based on `origin/main`.
-- [x] Audited the Grok-native web-search dispatcher and response-text helpers.
-- [x] Ran parallel scout and independent acceptance review.
-- [x] Switched the dispatcher to strict assistant-text extraction with `No results for: <query>` fallback.
-- [x] Added a successful empty-response regression that preserves `details.response_id`.
-- [x] Focused Grok-native tests passed (21 tests).
+- [x] Read issue #117 and confirmed the mixed historical-user-image test gap.
+- [x] Audited `omitConsumedXaiResponsesVisionImages` and `withHistoricalUserImagePlaceholder` to confirm ordinary user text survives while the historical image is replaced by the bounded placeholder.
+- [x] Exported `HISTORICAL_USER_IMAGE_PLACEHOLDER` from `extensions/xai/payload.ts` so the mixed-content invariant can be asserted exactly.
+- [x] Split the shared parameterized user-image test: kept the image-only case with its existing assertions and added a dedicated mixed-content test asserting the distinct invariant (text survives, image replaced by placeholder).
+- [x] Focused payload tests passed (21 tests).
 - [x] Typecheck passed.
 - [x] Full `npm test` passed (43 files / 486 tests plus loader).
-- [x] Pi Lens reported no error findings in the changed TypeScript files.
-- [x] Final fresh-context review found no blocker and confirmed issue acceptance.
-- [x] Exact Pi 0.80.1 and 0.80.10 compatibility boundaries passed.
+- [x] Pi Lens reported no primary LSP errors in the changed TypeScript files (only pre-existing project-wide style warnings).
 
 ## Delivery
 
-Issue #112 is implemented and validated, ready to commit or open as a PR.
+Issue #117 is implemented and validated, ready to commit or open as a PR.

--- a/extensions/xai/payload.ts
+++ b/extensions/xai/payload.ts
@@ -211,7 +211,7 @@ function isResponsesInputImagePart(value: unknown): value is Record<string, any>
 }
 
 type ToolImageDisposition = "attached" | "omitted";
-const HISTORICAL_USER_IMAGE_PLACEHOLDER =
+export const HISTORICAL_USER_IMAGE_PLACEHOLDER =
   "(historical user image omitted after a later assistant response)";
 const HISTORICAL_COMPUTER_SCREENSHOT_PLACEHOLDER =
   "[historical computer screenshot omitted after a later assistant response]";

--- a/tests/responses/payload.test.ts
+++ b/tests/responses/payload.test.ts
@@ -8,6 +8,7 @@ import {
   XAI_GROK_NATIVE_WEB_SEARCH_NAME,
 } from "../../extensions/xai/constants";
 import {
+  HISTORICAL_USER_IMAGE_PLACEHOLDER,
   applyXaiOAuthResponsesPolicy,
   canonicalizeXaiResponsesPayload,
   exposeGrokNativeToolNames,
@@ -143,19 +144,8 @@ describe("Responses payload normalization", () => {
     expect(inlineImages(result)).toHaveLength(0);
     expect(JSON.stringify(result)).toMatch(/historical tool image.*omitted/);
   });
-  it.each([
-    {
-      name: "image-only",
-      content: [{ type: "input_image", image_url: tiny, detail: "auto" }],
-    },
-    {
-      name: "text-and-image",
-      content: [
-        { type: "input_text", text: "describe" },
-        { type: "input_image", image_url: tiny, detail: "auto" },
-      ],
-    },
-  ])("omits consumed $name user images only when explicitly requested", ({ content }) => {
+  it("omits consumed image-only user images only when explicitly requested", () => {
+    const content = [{ type: "input_image", image_url: tiny, detail: "auto" }];
     const payload = {
       model: TEST_MODEL.id,
       input: [
@@ -168,6 +158,35 @@ describe("Responses payload normalization", () => {
     expect(inlineImages(routed)).toHaveLength(0);
     expect(JSON.stringify(routed)).toMatch(/historical user image omitted/);
     expect(inlineImages(rewriteXaiResponsesPayload(payload, TEST_MODEL))).toHaveLength(1);
+  });
+  it("retains non-image user text while replacing a consumed mixed-content historical image", () => {
+    const payload = {
+      model: TEST_MODEL.id,
+      input: [
+        {
+          role: "user",
+          content: [
+            { type: "input_text", text: "describe" },
+            { type: "input_image", image_url: tiny, detail: "auto" },
+          ],
+        },
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: "done" }] },
+        { role: "user", content: "next" },
+      ],
+    };
+    const routed = rewriteXaiResponsesPayload(payload, TEST_MODEL, {
+      omitConsumedVisionImages: true,
+    }) as { input: Array<Record<string, unknown>> };
+
+    // Distinct mixed-content invariant: the ordinary user text survives
+    // while only the historical image is replaced by the bounded placeholder.
+    expect(inlineImages(routed)).toHaveLength(0);
+    const firstUser = routed.input[0];
+    expect(firstUser).toMatchObject({ role: "user" });
+    expect(firstUser.content).toEqual([
+      { type: "input_text", text: "describe" },
+      { type: "input_text", text: HISTORICAL_USER_IMAGE_PLACEHOLDER },
+    ]);
   });
   it("omits consumed computer screenshots only when explicitly requested", () => {
     const payload = {


### PR DESCRIPTION
## Problem

The parameterized historical-user-image test ran image-only and mixed text/image cases with the same assertions. It proved image removal but did **not** prove the distinct mixed-content invariant: ordinary user text survives pruning. Closes #117.

## Changes

- **`extensions/xai/payload.ts`** — Export `HISTORICAL_USER_IMAGE_PLACEHOLDER` so the mixed-content replacement can be asserted exactly (was a private module constant).
- **`tests/responses/payload.test.ts`** — Split the shared parameterized test:
  - **Image-only case** kept as a plain `it` with its original assertions (image removed, placeholder present, default keeps image) — unchanged behavior, no duplication.
  - **New dedicated mixed-content test** asserts the distinct invariant: `inlineImages(routed)` → 0 and `firstUser.content` equals exactly `[ { input_text: "describe" }, { input_text: HISTORICAL_USER_IMAGE_PLACEHOLDER } ]` — ordinary user text survives while the historical image is replaced by the bounded placeholder.

This distinguishes the mixed-content invariant from image-only behavior without re-asserting what the image-only case already covers.

## Acceptance criteria (#117)

- [x] Mixed historical content retains its non-image text.
- [x] The historical image is absent and the bounded placeholder is present.
- [x] The test clearly distinguishes the mixed-content invariant from image-only behavior.
- [x] Focused payload tests pass.

## Validation

- Focused `tests/responses/payload.test.ts`: 21 passed
- `npm run typecheck`: clean
- Full `npm test`: 43 files / 486 tests + real Pi loader smoke
- Pi Lens: 0 primary LSP errors in changed files