### PR TITLE
chore: consolidate vision-routing scaffold progress

### DIFF
--- a/.scaffold/constraints.md
+++ b/.scaffold/constraints.md
@@ -1,22 +1,21 @@
-# Constraints & Safety Rules — Issue #114
+# Constraints & Safety Rules — Issue #118
 
-## Vision-routing policy
+## Scaffold-only scope
 
-- Reapply consumed historical-image pruning after caller payload hooks.
-- Preserve current unconsumed user and tool images when routing is authorized.
-- Preserve truthful text-only source metadata and final image-free enforcement.
-- Keep historical `computer_call_output.output` object-shaped while removing references.
-- Keep every routed request bound to the exact grant captured at stream start.
+- Touch only `.scaffold/*` for this issue.
+- Do not change production code, tests, modality docs, changelog, package version, or OAuth behavior.
+- Do not invent unmerged work or restate closed issues as open.
 
-## Security boundaries
+## Progress content rules
 
-- Do not resolve, fetch, log, or reflect historical image references during pruning.
-- Do not silently strip hook-added images when vision routing was not captured as enabled.
-- Do not send conversation history, tools, or encrypted reasoning to the vision target.
-- Keep placeholders fixed and bounded.
+- Keep security-relevant vision-routing decisions: converter-only image advertisement, truthful text-only metadata elsewhere, grant capture/invalidation, consumed historical-image pruning (including post-hook recursive scrubbing), current-unconsumed image routing, and no history/tools/ciphertext on the vision target.
+- Keep final validation evidence (test counts, typecheck, exact Pi boundaries, independent review outcome).
+- Remove transient execution narration and duplicate converter/metadata/historical-image/validation bullets.
+- Never leave completed work under `In Progress`.
+- Keep branch and delivery state aligned with post-merge `origin/main`.
 
 ## Non-goals
 
-- Do not introduce immutable provenance for hook-reordered history.
-- Do not change entitlement selection, OAuth credentials, or package version.
-- Do not touch unrelated extensions or tools.
+- Do not re-open or re-implement vision-routing, pruning, or modality-doc work.
+- Do not treat `.scaffold/` as an authoritative security control.
+- Do not rewrite git history of earlier PRs.

--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -1,27 +1,28 @@
-# Shared Agent Context — Issue #114
+# Shared Agent Context — Issue #118
 
-**Issue:** https://github.com/BlockedPath/pi-xai-oauth/issues/114
-**Branch:** `fix/114-post-hook-vision-pruning`
-**Base:** `origin/main` at `941cb4a`
+**Issue:** <https://github.com/BlockedPath/pi-xai-oauth/issues/118>
+**Branch:** `chore/118-scaffold-progress`
+**Base:** `origin/main` at `24df74a`
 
-## Root Cause
+## Why this exists
 
-`rewriteXaiResponsesPayload` removed consumed historical images before the caller's
-`onPayload` hook, but the canonical hook result went directly to vision planning. A
-hook could therefore reconstruct historical user images or computer screenshots and
-send them to the vision target.
+After the vision-routing series (PR #109, then #114–#117 and #119), `.scaffold/progress.md` still carried intermediate execution narration: repeated converter/metadata/historical-image/validation bullets, completed validation parked under `In Progress`, and a branch name that was no longer current after merge. Later issue branches overwrote the file with their own progress, so the durable series summary was never left in a post-merge form.
 
-## Implementation
+## Scope
 
-- `extensions/xai/payload.ts` exports a focused, structural consumed-history helper.
-- The ordinary rewrite and canonical post-hook boundary share that helper.
-- Post-hook pruning is gated by the grant captured when streaming began.
-- Current images remain available for routing; disabled routing still fails closed.
-- Screenshot output remains `{ type: "computer_screenshot" }` with call identity retained.
-- Consumed items are recursively scrubbed using the same image-shape taxonomy as route planning.
+Scaffold-only consolidation. Production code, tests, and modality documentation are already merged; this issue does not change behavior or policy claims.
 
-## Validation State
+## Series already on main
 
-The recursive fix passes focused and full tests, TypeScript, compatibility policy/pack
-checks, and exact Pi 0.80.1 / 0.80.10 boundary matrices. Final fresh-context review
-is clean.
+| Work | State |
+| --- | --- |
+| PR #109 — Pi converter image advertisement + grant binding + historical pruning | Merged |
+| PR #120 / #114 — post-hook recursive pruning | Merged |
+| PR #122 / #115 — trim duplicated vision assertions | Merged |
+| PR #123 / #116 — typed `model.input` | Merged |
+| PR #126 / #117 — mixed historical text preserved | Merged |
+| #119 modality-doc split (`24df74a`) | On main; issue still open until closed |
+
+## Deliverable
+
+A factual `.scaffold/progress.md` for the series, with matching plan/context/constraints for #118, ready to commit and PR.

--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -21,7 +21,7 @@ Scaffold-only consolidation. Production code, tests, and modality documentation 
 | PR #122 / #115 — trim duplicated vision assertions | Merged |
 | PR #123 / #116 — typed `model.input` | Merged |
 | PR #126 / #117 — mixed historical text preserved | Merged |
-| #119 modality-doc split (`24df74a`) | On main; issue still open until closed |
+| #119 modality-doc split (`24df74a`) | On main; issue closed |
 
 ## Deliverable
 

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,21 +1,24 @@
-# Implementation Plan — Issue #119: Vision-routing modality documentation
+# Implementation Plan — Issue #118: Consolidate vision-routing scaffold progress
 
-**Branch:** `docs/119-vision-routing-modalities`
-**Base:** `origin/main`
+**Branch:** `chore/118-scaffold-progress`
+**Base:** `origin/main` at `24df74a`
 
 ## Goal
 
-Make the explicit vision-routing exception easier to audit by separating conversion, authorization-lifecycle, and request-behavior guarantees without changing policy or behavior claims.
+Replace the repeated vision-routing progress narration with a short post-merge record that keeps security decisions and final validation evidence, and points branch/delivery state at current main.
 
 ## Phases
 
-1. [x] Confirm issue scope, branch state, and the documented/runtime guarantees.
-2. [x] Split the dense exception text and remove duplicated guarantees.
-3. [x] Review the final diff against every acceptance criterion.
+1. [x] Confirm issue scope, blockers, and that the vision-routing series is already on `origin/main`.
+2. [x] Fast-forward `chore/118-scaffold-progress` onto current main.
+3. [x] Rewrite `.scaffold/progress.md` into consolidated completed/delivery entries with no completed work under `In Progress`.
+4. [x] Retarget plan, context, and constraints to issue #118 scaffold-only scope.
+5. [ ] Open a PR that closes #118 (and note #119 already landed on main).
 
 ## Validation Contract
 
-- Converter-only image advertisement is stated once and precisely.
-- Grant capture, invalidation, and current-unconsumed-image handling remain explicit.
-- The target request remains image-only and the final source assertion remains text-only.
-- Privacy, entitlement, and request behavior claims do not change.
+- No completed work remains under `In Progress`.
+- Branch and delivery state match post-merge `origin/main`.
+- Converter, metadata, historical-image, and validation details are not repeated across many bullets.
+- Security-relevant decisions and final validation results remain recorded.
+- Only `.scaffold/*` changes; no production behavior or docs policy changes.

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -13,7 +13,7 @@ Replace the repeated vision-routing progress narration with a short post-merge r
 2. [x] Fast-forward `chore/118-scaffold-progress` onto current main.
 3. [x] Rewrite `.scaffold/progress.md` into consolidated completed/delivery entries with no completed work under `In Progress`.
 4. [x] Retarget plan, context, and constraints to issue #118 scaffold-only scope.
-5. [ ] Open a PR that closes #118 (and note #119 already landed on main).
+5. [x] Open a PR that closes #118 (and note #119 already landed on main).
 
 ## Validation Contract
 

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -26,7 +26,7 @@
 - [x] #115 / PR #122: trim duplicated Pi-converted vision regression assertions.
 - [x] #116 / PR #123: use typed `model.input` in vision conversion routing.
 - [x] #117 / PR #126: assert mixed historical content retains ordinary user text with the bounded placeholder.
-- [x] #119: split vision-routing modality docs into conversion, authorization-lifecycle, and request-behavior paragraphs (on main as `24df74a`).
+- [x] #119: split vision-routing modality docs into conversion, authorization-lifecycle, and request-behavior paragraphs (on main as `24df74a`; issue closed).
 
 ## Final validation (series)
 
@@ -42,3 +42,4 @@
 
 - [x] Vision-routing hardening and follow-ups are merged on `origin/main` (`24df74a`).
 - [x] Scaffold progress consolidated under issue #118; branch and delivery state match post-merge main.
+- [x] Opened PR: <https://github.com/BlockedPath/pi-xai-oauth/pull/127>

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,20 +1,44 @@
-# Execution Progress — Issue #119
+# Execution Progress — Vision-routing hardening series
 
-**Branch:** `docs/119-vision-routing-modalities`
-**Started:** 2026-07-20
+**Branch:** `chore/118-scaffold-progress`
+**Base:** `origin/main` at `24df74a`
+**Series window:** 2026-07-19 → 2026-07-20
 
 ## Completed
 
-- [x] Read issue #119 and confirmed the dedicated issue branch is clean.
-- [x] Audited the current modality documentation and vision-routing implementation outline.
-- [x] Split the vision-routing exception into concise conversion, authorization-lifecycle, and request-behavior paragraphs.
-- [x] Verified every acceptance guarantee appears exactly once where required.
-- [x] Independent fresh-context review confirmed all acceptance criteria pass.
-- [x] Rebased onto `origin/main` and resolved the scaffold progress conflict.
-- [x] Full `npm test` passed after the rebase (43 files / 486 tests plus loader).
-- [x] Typecheck passed.
-- [x] Exact Pi 0.80.1 and 0.80.10 compatibility boundaries passed.
+### Core fix (PR #109)
+
+- [x] Advertise `image` only on Pi's delegated Responses conversion-model copy so vision routing sees real conversation images; catalog metadata, package rewrites, and payload hooks keep truthful text-only source capability.
+- [x] Bind each routed stream to the grant captured at stream start so reset/re-enable cannot authorize an old request.
+- [x] Replace consumed historical user images and computer screenshots with bounded placeholders while preserving current unconsumed user/tool images and the `computer_screenshot` object shape.
+- [x] Keep encrypted reasoning isolated: the vision target request sends no conversation history, tools, or ciphertext.
+- [x] Document the conversion advertisement and lifecycle rules in `docs/model-input-modalities.md` and `CHANGELOG.md`.
+- [x] Merged: <https://github.com/BlockedPath/pi-xai-oauth/pull/109>
+
+### Post-hook recursive pruning (PR #120 / #114)
+
+- [x] Share `omitConsumedXaiResponsesVisionImages` before and after caller payload hooks.
+- [x] Recursively strip every image shape recognized by route planning from consumed history.
+- [x] Merged: <https://github.com/BlockedPath/pi-xai-oauth/pull/120>
+
+### Follow-up cleanup
+
+- [x] #115 / PR #122: trim duplicated Pi-converted vision regression assertions.
+- [x] #116 / PR #123: use typed `model.input` in vision conversion routing.
+- [x] #117 / PR #126: assert mixed historical content retains ordinary user text with the bounded placeholder.
+- [x] #119: split vision-routing modality docs into conversion, authorization-lifecycle, and request-behavior paragraphs (on main as `24df74a`).
+
+## Final validation (series)
+
+- [x] Full `npm test` passed on the series tip (43 files / 486 tests + loader).
+- [x] Typecheck, compatibility policy/pack checks, and exact Pi 0.80.1 / 0.80.10 boundaries passed.
+- [x] Independent/fresh-context reviews of the security fixes reported no remaining blockers.
+
+## In Progress
+
+- None.
 
 ## Delivery
 
-Issue #119 is implemented and validated, ready to commit or open as a PR.
+- [x] Vision-routing hardening and follow-ups are merged on `origin/main` (`24df74a`).
+- [x] Scaffold progress consolidated under issue #118; branch and delivery state match post-merge main.


### PR DESCRIPTION
## Summary

- Rewrites `.scaffold/progress.md` into a post-merge vision-routing series record (PR #109 core fix, #114 recursive post-hook pruning, and #115-#117 / #119 follow-ups).
- Retargets plan, context, and constraints to issue #118 scaffold-only scope.
- Removes completed validation from `In Progress`, drops duplicate converter/metadata/historical-image/validation narration, and points branch/delivery state at current `origin/main`.

Closes #118

## Acceptance criteria (#118)

- [x] No completed work remains under `In Progress`.
- [x] Branch and delivery state are current (`chore/118-scaffold-progress` / `origin/main` at `24df74a`).
- [x] Duplicate implementation and validation bullets are consolidated.
- [x] Security-relevant decisions and final validation results remain recorded.

## Note on #119

#119 modality-doc split is already on main as `24df74a` but was not closed by that commit. This PR does not re-touch `docs/model-input-modalities.md`; #119 can be closed separately as already landed.

## Test plan

- [x] Diff limited to `.scaffold/*` only.
- [x] Manual review against issue #118 acceptance criteria.
- [ ] No production/test/docs behavior change (scaffold-only).
