### PR TITLE
Adopt Pi 0.81.0 compatibility boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,14 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 
 - Added disabled-by-default, session-scoped vision routing for exact authenticated text-only entitlements, with deterministic exact-catalog target selection, a bounded image-only description request, final image-free enforcement, lifecycle invalidation, and `/xai-tools` cost/privacy controls.
 - Added disabled-by-default `xai_image_to_video` with pinned create/status polling, DNS-pinned unauthenticated MP4 download, bounded streamed private storage, and honest remote-job cancellation semantics.
-- Added ModelRuntime re-registration coverage proving a refreshed extension catalog replaces stale registered models, plus registry-facade request-auth projection tests for Pi 0.80.8+ `getApiKeyAndHeaders` / `getProviderAuth`.
+- Added ModelRuntime re-registration and stale `models-store.json` precedence coverage, plus request-auth tests that prefer `ModelRuntime.getAuth` over the legacy `getApiKeyAndHeaders` projection.
 
 ### Changed
 
 - Recorded the package-scope decision to keep provider-neutral goal/plan workflows, autonomous continuation, runtime plan management, and write-restriction policy out of `pi-xai-oauth`; see [ADR 0001](docs/decisions/0001-goal-plan-package-scope.md).
 - Reviewed Pi 0.80.8 through 0.81.0 and adopted 0.81.0 as the latest exact tested boundary after clean packed candidate validation, while preserving the 0.80.1 minimum.
 - Widened aligned Pi peers to `>=0.80.1 <0.82.0` and pinned development metadata exactly to 0.81.0.
-- Centralized extension request-auth resolution through the ModelRegistry facade that projects `ModelRuntime.getAuth`, with a provider-scoped `getProviderAuth` fallback when only a provider id is available.
+- Migrated extension request-auth resolution to prefer `ModelRuntime.getAuth` when the host exposes it, then the ModelRegistry `getApiKeyAndHeaders` / `getProviderAuth` projections for older supported boundaries.
 - Deferred adopting Pi's `refreshModels(context)` provider hook: account-bound `/models-v2` discovery still needs login-generation tracking, force-refresh after credential switch, and package-owned token-free cache TTL/stale policy that the generic hook does not replace.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,15 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 
 - Added disabled-by-default, session-scoped vision routing for exact authenticated text-only entitlements, with deterministic exact-catalog target selection, a bounded image-only description request, final image-free enforcement, lifecycle invalidation, and `/xai-tools` cost/privacy controls.
 - Added disabled-by-default `xai_image_to_video` with pinned create/status polling, DNS-pinned unauthenticated MP4 download, bounded streamed private storage, and honest remote-job cancellation semantics.
+- Added ModelRuntime re-registration coverage proving a refreshed extension catalog replaces stale registered models, plus registry-facade request-auth projection tests for Pi 0.80.8+ `getApiKeyAndHeaders` / `getProviderAuth`.
 
 ### Changed
 
 - Recorded the package-scope decision to keep provider-neutral goal/plan workflows, autonomous continuation, runtime plan management, and write-restriction policy out of `pi-xai-oauth`; see [ADR 0001](docs/decisions/0001-goal-plan-package-scope.md).
+- Reviewed Pi 0.80.8 through 0.81.0 and adopted 0.81.0 as the latest exact tested boundary after clean packed candidate validation, while preserving the 0.80.1 minimum.
+- Widened aligned Pi peers to `>=0.80.1 <0.82.0` and pinned development metadata exactly to 0.81.0.
+- Centralized extension request-auth resolution through the ModelRegistry facade that projects `ModelRuntime.getAuth`, with a provider-scoped `getProviderAuth` fallback when only a provider id is available.
+- Deferred adopting Pi's `refreshModels(context)` provider hook: account-bound `/models-v2` discovery still needs login-generation tracking, force-refresh after credential switch, and package-owned token-free cache TTL/stale policy that the generic hook does not replace.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 
 - Added disabled-by-default, session-scoped vision routing for exact authenticated text-only entitlements, with deterministic exact-catalog target selection, a bounded image-only description request, final image-free enforcement, lifecycle invalidation, and `/xai-tools` cost/privacy controls.
 - Added disabled-by-default `xai_image_to_video` with pinned create/status polling, DNS-pinned unauthenticated MP4 download, bounded streamed private storage, and honest remote-job cancellation semantics.
-- Added ModelRuntime re-registration and stale `models-store.json` precedence coverage, plus request-auth tests that prefer `ModelRuntime.getAuth` over the legacy `getApiKeyAndHeaders` projection.
+- Added ModelRuntime re-registration coverage, a store-backed models-store precedence regression (discard stale overlays when the local catalog is newer), and request-auth tests that prefer `ModelRuntime.getAuth` over the legacy `getApiKeyAndHeaders` projection.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This package adds xAI's **account-specific OAuth model catalog** to pi, with **G
 
 > **Latest release:** `pi-xai-oauth` **1.3.6** adds authenticated account-specific model discovery, browser and device OAuth, encrypted reasoning replay, Grok-native local tools, bounded image editing, and explicit subscription usage while hardening xAI routing, payloads, headers, redirects, and entitlement enforcement. Existing npm installs should run `pi update npm:pi-xai-oauth`; local checkout installs should keep only one copy with `pi remove npm:pi-xai-oauth && pi install .`.
 >
-> **Compatibility:** 1.3.6 supports aligned `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` versions `>=0.80.1 <0.81.0`. The exact tested boundaries are 0.80.1 and 0.80.10.
+> **Compatibility:** 1.3.6 supports aligned `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` versions `>=0.80.1 <0.82.0`. The exact tested boundaries are 0.80.1 and 0.81.0.
 
 See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and fix history.
 
@@ -176,13 +176,13 @@ Then optionally configure it as default:
 Both Pi runtime peers use the same bounded range:
 
 ```text
-@earendil-works/pi-ai:            >=0.80.1 <0.81.0
-@earendil-works/pi-coding-agent:  >=0.80.1 <0.81.0
+@earendil-works/pi-ai:            >=0.80.1 <0.82.0
+@earendil-works/pi-coding-agent:  >=0.80.1 <0.82.0
 ```
 
-The lower boundary is **0.80.1**, the first published Pi 0.80 release. It provides the `@earendil-works/pi-ai/compat` transport used by this extension and the matching Pi 0.80 extension-loader contract. The packed package's complete test and typecheck suites run against exact 0.80.1 in CI. The other matrix boundary is exact **0.80.10**, the latest release inside the allowed line when this policy was reviewed. Pi 0.80.8 introduced the unified `ModelRuntime` credential API and replaced the exported `AuthStorage` surface with `readStoredCredential()` for one-off reads; this package supports both the 0.80.1 legacy surface and the 0.80.10 API through a bounded read-only compatibility path.
+The lower boundary is **0.80.1**, the first published Pi 0.80 release. It provides the `@earendil-works/pi-ai/compat` transport used by this extension and the matching Pi 0.80 extension-loader contract. The packed package's complete test and typecheck suites run against exact 0.80.1 in CI. The other matrix boundary is exact **0.81.0**, the latest release inside the allowed line when this policy was reviewed. Pi 0.80.8 introduced the unified `ModelRuntime` credential API and replaced the exported `AuthStorage` surface with `readStoredCredential()` for one-off reads; this package supports both the 0.80.1 legacy surface and the 0.81.0 ModelRegistry projection of `ModelRuntime.getAuth` through a bounded compatibility path.
 
-The exclusive `<0.81.0` upper bound is deliberate. Pi is pre-1.0, so a new minor line may contain breaking API or loader changes; this project does not claim support until that line passes the packed compatibility suite. npm therefore reports a peer-resolution warning or error during installation for older releases such as 0.79.10 and for the untested 0.81 line, rather than allowing a later runtime loader failure.
+The exclusive `<0.82.0` upper bound is deliberate. Pi is pre-1.0, so a new minor line may contain breaking API or loader changes; this project does not claim support until that line passes the packed compatibility suite. npm therefore reports a peer-resolution warning or error during installation for older releases such as 0.79.10 and for the untested 0.82 line, rather than allowing a later runtime loader failure.
 
 Older `pi-xai-oauth` 1.2.4 builds supported Pi 0.79.8's then-current Responses guard. Current code uses the Pi 0.80 compat dispatcher after the 1.3.2 export migration and 1.3.3 loader-resolution fix, so that historical statement is not the current minimum.
 
@@ -751,7 +751,7 @@ pi update npm:pi-xai-oauth
 
 This pulls the latest version from npm and updates your installed extension.
 
-Version 1.3.6 requires aligned Pi runtime packages in `>=0.80.1 <0.81.0`, with exact packed-package validation at 0.80.1 and 0.80.10. It adds authenticated model discovery, device OAuth, encrypted reasoning replay, Grok-native tools, bounded image editing, and explicit subscription usage, together with extensive transport and entitlement hardening. See [CHANGELOG.md](CHANGELOG.md) for the complete release notes. If you installed the published npm package, update with the command above. If you are testing a local checkout instead, reinstall the checkout:
+Version 1.3.6 requires aligned Pi runtime packages in `>=0.80.1 <0.82.0`, with exact packed-package validation at 0.80.1 and 0.81.0. It adds authenticated model discovery, device OAuth, encrypted reasoning replay, Grok-native tools, bounded image editing, and explicit subscription usage, together with extensive transport and entitlement hardening. See [CHANGELOG.md](CHANGELOG.md) for the complete release notes. If you installed the published npm package, update with the command above. If you are testing a local checkout instead, reinstall the checkout:
 
 ```bash
 pi remove npm:pi-xai-oauth && pi install .

--- a/compatibility/pi-versions.json
+++ b/compatibility/pi-versions.json
@@ -3,11 +3,11 @@
     "@earendil-works/pi-ai",
     "@earendil-works/pi-coding-agent"
   ],
-  "peerRange": ">=0.80.1 <0.81.0",
+  "peerRange": ">=0.80.1 <0.82.0",
   "minimum": "0.80.1",
-  "latest": "0.80.10",
+  "latest": "0.81.0",
   "unsupported": {
     "older": "0.79.10",
-    "upper": "0.81.0"
+    "upper": "0.82.0"
   }
 }

--- a/docs/testing/assertion-parity.md
+++ b/docs/testing/assertion-parity.md
@@ -157,7 +157,7 @@ replacement tests pass alongside the legacy verifier.
 | `verify-compatibility.js:161-213` | one tarball, packed identity/peers/required/forbidden paths | retain `pack` mode; add Vitest config/tests/fixtures/loader smoke to required list | [x] |
 | `verify-compatibility.js:215-269` | unsupported strict failure and forced warning diagnostics | retain `unsupported` mode | [x] |
 | `verify-compatibility.js:271-291` | matrix output and command dispatch | retain plain-Node CLI | [x] |
-| `run-compatibility-matrix.js:34-114` | alias/exact parsing, checked endpoint restriction, one tarball, exact installed Pi pair, packed `npm test` and typecheck | retain clean packed matrix at 0.80.1/0.80.10 | [x] |
+| `run-compatibility-matrix.js:34-114` | alias/exact parsing, checked endpoint restriction, one tarball, exact installed Pi pair, packed `npm test` and typecheck | retain clean packed matrix at 0.80.1/0.81.0 | [x] |
 
 ## Isolation checklist
 

--- a/extensions/xai-oauth.ts
+++ b/extensions/xai-oauth.ts
@@ -148,7 +148,7 @@ export default async function (pi: ExtensionAPI) {
       deferredRetryAfter = Date.now() + 5_000;
       return;
     }
-    const auth = await resolveRegistryRequestAuth(ctx.modelRegistry, lookupModel);
+    const auth = await resolveRegistryRequestAuth(ctx.modelRegistry, lookupModel, ctx?.modelRuntime);
     const authorization = auth?.ok && typeof auth.headers?.Authorization === "string"
       ? auth.headers.Authorization
       : "";

--- a/extensions/xai-oauth.ts
+++ b/extensions/xai-oauth.ts
@@ -1,7 +1,7 @@
 import type { OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { selectXaiModelCatalog, type XaiCatalogSelection } from "./xai/catalog";
-import { getGrokAuthCredentials, getStartupXaiCatalogAuth } from "./xai/auth";
+import { getGrokAuthCredentials, getStartupXaiCatalogAuth, resolveRegistryRequestAuth } from "./xai/auth";
 import { DEFAULT_XAI_MODEL, XAI_PROVIDER_ID } from "./xai/constants";
 import { CURATED_FALLBACK_MODELS, expandXaiCatalogWithAliases, setXaiRuntimeModels, type XaiCatalogModel } from "./xai/models";
 import { createXaiOAuth } from "./xai/oauth";
@@ -144,11 +144,11 @@ export default async function (pi: ExtensionAPI) {
     const lookupModel =
       ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, DEFAULT_XAI_MODEL) ||
       currentModels.map((model) => ctx?.modelRegistry?.find?.(XAI_PROVIDER_ID, model.id)).find(Boolean);
-    if (!lookupModel || typeof ctx?.modelRegistry?.getApiKeyAndHeaders !== "function") {
+    if (!lookupModel || !ctx?.modelRegistry) {
       deferredRetryAfter = Date.now() + 5_000;
       return;
     }
-    const auth = await ctx.modelRegistry.getApiKeyAndHeaders(lookupModel);
+    const auth = await resolveRegistryRequestAuth(ctx.modelRegistry, lookupModel);
     const authorization = auth?.ok && typeof auth.headers?.Authorization === "string"
       ? auth.headers.Authorization
       : "";

--- a/extensions/xai/auth.ts
+++ b/extensions/xai/auth.ts
@@ -201,32 +201,69 @@ function credentialFromResolvedAuth(auth: any): XaiCredential | null {
 }
 
 /**
- * Resolve request auth through the extension-facing ModelRegistry facade.
+ * Normalize a ModelRuntime.getAuth / getProviderAuth resolution into the stable
+ * extension request-auth shape used by credential helpers.
+ */
+function requestAuthFromResolution(
+  resolution: any,
+  providerId = XAI_PROVIDER_ID,
+): { ok: true; apiKey?: string; headers?: Record<string, string> } | { ok: false; error: string } {
+  if (!resolution?.auth) {
+    return { ok: false, error: `No API key found for "${providerId}"` };
+  }
+  return {
+    ok: true,
+    apiKey: typeof resolution.auth.apiKey === "string" ? resolution.auth.apiKey : undefined,
+    headers: resolution.auth.headers,
+  };
+}
+
+function resolveAuthRuntime(registry: any, modelRuntime?: any): any | undefined {
+  if (modelRuntime && typeof modelRuntime.getAuth === "function") return modelRuntime;
+  if (registry && typeof registry.getAuth === "function") return registry;
+  if (registry?.modelRuntime && typeof registry.modelRuntime.getAuth === "function") {
+    return registry.modelRuntime;
+  }
+  if (registry?.runtime && typeof registry.runtime.getAuth === "function") {
+    return registry.runtime;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve request auth preferring ModelRuntime.getAuth when the host exposes it.
  *
- * On Pi 0.80.8+, ModelRegistry.getApiKeyAndHeaders projects ModelRuntime.getAuth
- * into the stable `{ ok, apiKey, headers }` shape that extension event contexts
- * expose. Prefer that path when a model handle is available; fall back to the
- * provider-scoped getProviderAuth projection when only a provider id can be used.
- * Extensions never receive ModelRuntime directly on ctx.
+ * Extension event contexts historically only supply `ctx.modelRegistry`. On
+ * Pi 0.80.8+, that registry projects `ModelRuntime.getAuth` through
+ * `getApiKeyAndHeaders` / `getProviderAuth`. Prefer an explicit runtime
+ * `getAuth` surface when present (including future `ctx.modelRuntime`), then
+ * the registry projections so the 0.80.1 packed boundary keeps working.
  */
 export async function resolveRegistryRequestAuth(
   registry: any,
   model?: any,
+  modelRuntime?: any,
 ): Promise<{ ok: true; apiKey?: string; headers?: Record<string, string> } | { ok: false; error: string } | null> {
+  const runtime = resolveAuthRuntime(registry, modelRuntime);
+  if (runtime) {
+    try {
+      return requestAuthFromResolution(
+        await runtime.getAuth(model ?? XAI_PROVIDER_ID),
+        typeof model?.provider === "string" ? model.provider : XAI_PROVIDER_ID,
+      );
+    } catch (error) {
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
   if (model && typeof registry?.getApiKeyAndHeaders === "function") {
     return await registry.getApiKeyAndHeaders(model);
   }
   if (typeof registry?.getProviderAuth === "function") {
     try {
-      const resolution = await registry.getProviderAuth(XAI_PROVIDER_ID);
-      if (!resolution?.auth) {
-        return { ok: false, error: `No API key found for "${XAI_PROVIDER_ID}"` };
-      }
-      return {
-        ok: true,
-        apiKey: typeof resolution.auth.apiKey === "string" ? resolution.auth.apiKey : undefined,
-        headers: resolution.auth.headers,
-      };
+      return requestAuthFromResolution(await registry.getProviderAuth(XAI_PROVIDER_ID));
     } catch (error) {
       return {
         ok: false,
@@ -237,21 +274,23 @@ export async function resolveRegistryRequestAuth(
   return null;
 }
 
-function registrySupportsRequestAuth(registry: any): boolean {
-  return typeof registry?.getApiKeyAndHeaders === "function"
+function registrySupportsRequestAuth(registry: any, modelRuntime?: any): boolean {
+  return !!resolveAuthRuntime(registry, modelRuntime)
+    || typeof registry?.getApiKeyAndHeaders === "function"
     || typeof registry?.getProviderAuth === "function";
 }
 
 /** Resolve a tagged xAI credential through pi's managed model registry. */
 export async function resolvePiManagedXaiCredential(ctx: any): Promise<XaiCredential | null> {
   const registry = ctx?.modelRegistry;
-  if (typeof registry?.find !== "function" || !registrySupportsRequestAuth(registry)) {
+  const modelRuntime = ctx?.modelRuntime;
+  if (typeof registry?.find !== "function" || !registrySupportsRequestAuth(registry, modelRuntime)) {
     return null;
   }
   for (const modelId of xaiRegistryCandidateIds(ctx)) {
     const registryModel = registry.find(XAI_PROVIDER_ID, modelId);
     if (!registryModel) continue;
-    const auth = await resolveRegistryRequestAuth(registry, registryModel);
+    const auth = await resolveRegistryRequestAuth(registry, registryModel, modelRuntime);
     const credential = credentialFromResolvedAuth(auth);
     if (credential) return credential;
   }
@@ -264,9 +303,10 @@ export async function resolvePiManagedXaiCredential(ctx: any): Promise<XaiCreden
  */
 export async function resolvePiManagedXaiOAuthCredential(ctx: any): Promise<XaiCredential | null> {
   const registry = ctx?.modelRegistry;
+  const modelRuntime = ctx?.modelRuntime;
   if (
     typeof registry?.find !== "function"
-    || !registrySupportsRequestAuth(registry)
+    || !registrySupportsRequestAuth(registry, modelRuntime)
     || typeof registry?.isUsingOAuth !== "function"
   ) {
     return null;
@@ -279,7 +319,7 @@ export async function resolvePiManagedXaiOAuthCredential(ctx: any): Promise<XaiC
     const registryModel = registry.find(XAI_PROVIDER_ID, modelId);
     if (!registryModel || !registryModelUsesOAuth(registry, registryModel)) continue;
     const credential = credentialFromResolvedAuth(
-      await resolveRegistryRequestAuth(registry, registryModel),
+      await resolveRegistryRequestAuth(registry, registryModel, modelRuntime),
     );
     const legacyAccessAfter = legacyStoredOAuthAccess(registry);
     if (

--- a/extensions/xai/auth.ts
+++ b/extensions/xai/auth.ts
@@ -200,15 +200,58 @@ function credentialFromResolvedAuth(auth: any): XaiCredential | null {
     : null;
 }
 
+/**
+ * Resolve request auth through the extension-facing ModelRegistry facade.
+ *
+ * On Pi 0.80.8+, ModelRegistry.getApiKeyAndHeaders projects ModelRuntime.getAuth
+ * into the stable `{ ok, apiKey, headers }` shape that extension event contexts
+ * expose. Prefer that path when a model handle is available; fall back to the
+ * provider-scoped getProviderAuth projection when only a provider id can be used.
+ * Extensions never receive ModelRuntime directly on ctx.
+ */
+export async function resolveRegistryRequestAuth(
+  registry: any,
+  model?: any,
+): Promise<{ ok: true; apiKey?: string; headers?: Record<string, string> } | { ok: false; error: string } | null> {
+  if (model && typeof registry?.getApiKeyAndHeaders === "function") {
+    return await registry.getApiKeyAndHeaders(model);
+  }
+  if (typeof registry?.getProviderAuth === "function") {
+    try {
+      const resolution = await registry.getProviderAuth(XAI_PROVIDER_ID);
+      if (!resolution?.auth) {
+        return { ok: false, error: `No API key found for "${XAI_PROVIDER_ID}"` };
+      }
+      return {
+        ok: true,
+        apiKey: typeof resolution.auth.apiKey === "string" ? resolution.auth.apiKey : undefined,
+        headers: resolution.auth.headers,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+  return null;
+}
+
+function registrySupportsRequestAuth(registry: any): boolean {
+  return typeof registry?.getApiKeyAndHeaders === "function"
+    || typeof registry?.getProviderAuth === "function";
+}
+
 /** Resolve a tagged xAI credential through pi's managed model registry. */
 export async function resolvePiManagedXaiCredential(ctx: any): Promise<XaiCredential | null> {
-  if (typeof ctx?.modelRegistry?.find !== "function" || typeof ctx?.modelRegistry?.getApiKeyAndHeaders !== "function") {
+  const registry = ctx?.modelRegistry;
+  if (typeof registry?.find !== "function" || !registrySupportsRequestAuth(registry)) {
     return null;
   }
   for (const modelId of xaiRegistryCandidateIds(ctx)) {
-    const registryModel = ctx.modelRegistry.find(XAI_PROVIDER_ID, modelId);
+    const registryModel = registry.find(XAI_PROVIDER_ID, modelId);
     if (!registryModel) continue;
-    const auth = await ctx.modelRegistry.getApiKeyAndHeaders(registryModel);
+    const auth = await resolveRegistryRequestAuth(registry, registryModel);
     const credential = credentialFromResolvedAuth(auth);
     if (credential) return credential;
   }
@@ -223,7 +266,7 @@ export async function resolvePiManagedXaiOAuthCredential(ctx: any): Promise<XaiC
   const registry = ctx?.modelRegistry;
   if (
     typeof registry?.find !== "function"
-    || typeof registry?.getApiKeyAndHeaders !== "function"
+    || !registrySupportsRequestAuth(registry)
     || typeof registry?.isUsingOAuth !== "function"
   ) {
     return null;
@@ -236,7 +279,7 @@ export async function resolvePiManagedXaiOAuthCredential(ctx: any): Promise<XaiC
     const registryModel = registry.find(XAI_PROVIDER_ID, modelId);
     if (!registryModel || !registryModelUsesOAuth(registry, registryModel)) continue;
     const credential = credentialFromResolvedAuth(
-      await registry.getApiKeyAndHeaders(registryModel),
+      await resolveRegistryRequestAuth(registry, registryModel),
     );
     const legacyAccessAfter = legacyStoredOAuthAccess(registry);
     if (
@@ -255,7 +298,7 @@ export async function resolvePiManagedXaiOAuthCredential(ctx: any): Promise<XaiC
 /**
  * Return whether Pi currently identifies an xAI registry model as stored OAuth.
  *
- * This uses the public registry facade available across Pi 0.80.1–0.80.10.
+ * This uses the public registry facade available across Pi 0.80.1–0.81.0.
  */
 export function hasPiManagedXaiOAuth(ctx: any): boolean {
   const registry = ctx?.modelRegistry;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "pi-xai-oauth": "bin/setup.js"
       },
       "devDependencies": {
-        "@earendil-works/pi-ai": "0.80.10",
-        "@earendil-works/pi-coding-agent": "0.80.10",
+        "@earendil-works/pi-ai": "0.81.0",
+        "@earendil-works/pi-coding-agent": "0.81.0",
         "@types/node": "^26.0.0",
         "@vitest/coverage-v8": "4.1.10",
         "jiti": "^2.7.0",
@@ -21,8 +21,8 @@
         "vitest": "4.1.10"
       },
       "peerDependencies": {
-        "@earendil-works/pi-ai": ">=0.80.1 <0.81.0",
-        "@earendil-works/pi-coding-agent": ">=0.80.1 <0.81.0"
+        "@earendil-works/pi-ai": ">=0.80.1 <0.82.0",
+        "@earendil-works/pi-coding-agent": ">=0.80.1 <0.82.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -548,13 +548,13 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.10.tgz",
-      "integrity": "sha512-nwnOR3SuLYGRFfyQm8ri4Nj5VGVAvAM9GuqQd3u7BUQj0d6hmD2F8w7OHAAjThE3CuySIdM+v8E22QJG6/RfCg==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.81.0.tgz",
+      "integrity": "sha512-Fe6JYbW0CGVvmD4dwuFreynwZxlTElIMFRqYDl4llRiwfYZjjtAqbV1hY8MrdGqP15+FySBv5RGodOsHqlhvZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.10",
+        "@earendil-works/pi-ai": "^0.81.0",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -564,9 +564,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
-      "integrity": "sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.81.0.tgz",
+      "integrity": "sha512-n3lDV1Px/2BOp86rUJkoHcXuQ6uf7711VEtSjE5gTwrnPeMAEjzV3LnbQ3wTF9bUxl253Igi3U35U1CMF5POng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -590,15 +590,15 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.10.tgz",
-      "integrity": "sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.81.0.tgz",
+      "integrity": "sha512-2p0Dnx+3fkPLga8M82eg14ZYNLcFLhqxxKyVVfqUSIio9Xx4p7UjvJtopx/6PTeJKmdJl1/xOm/c02AFcJ+l/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.10",
-        "@earendil-works/pi-ai": "^0.80.10",
-        "@earendil-works/pi-tui": "^0.80.10",
+        "@earendil-works/pi-agent-core": "^0.81.0",
+        "@earendil-works/pi-ai": "^0.81.0",
+        "@earendil-works/pi-tui": "^0.81.0",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -1108,9 +1108,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
-      "integrity": "sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.81.0.tgz",
+      "integrity": "sha512-vdrrV//CldG3Dt20vj+iCRcHOlPwxlOBJwwLg1KE/92IO+TlEwbf4uwKXgFZHGVh9lEJXtYsKzIRb/nHw5YuAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
     "image": "https://raw.githubusercontent.com/BlockedPath/pi-xai-oauth/main/preview.jpeg"
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": ">=0.80.1 <0.81.0",
-    "@earendil-works/pi-coding-agent": ">=0.80.1 <0.81.0"
+    "@earendil-works/pi-ai": ">=0.80.1 <0.82.0",
+    "@earendil-works/pi-coding-agent": ">=0.80.1 <0.82.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "0.80.10",
-    "@earendil-works/pi-coding-agent": "0.80.10",
+    "@earendil-works/pi-ai": "0.81.0",
+    "@earendil-works/pi-coding-agent": "0.81.0",
     "@types/node": "^26.0.0",
     "@vitest/coverage-v8": "4.1.10",
     "jiti": "^2.7.0",

--- a/tests/provider/registry-reregistration.test.ts
+++ b/tests/provider/registry-reregistration.test.ts
@@ -60,12 +60,40 @@ const refreshedProviderConfig = {
   ],
 };
 
+const baselineModelConfig = {
+  id: "baseline-model",
+  name: "Baseline model",
+  reasoning: false,
+  input: ["text"] as ("text" | "image")[],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 1_000,
+  maxTokens: 100,
+};
+
 function codingAgentApi(): any {
   return PiCodingAgent as any;
 }
 
 function hasModelRuntime(): boolean {
   return typeof codingAgentApi().ModelRuntime === "function";
+}
+
+/**
+ * Mirror Pi 0.81.0 remoteModels(): discard a persisted store entry when the
+ * local catalog is newer than the store's lastModified watermark.
+ */
+function modelsFromStoreIfNewerThanLocal(
+  stored: { models?: any[]; lastModified?: number } | undefined,
+  localLastModified: number,
+): any[] | undefined {
+  if (!stored?.models?.length) return undefined;
+  if (
+    stored.lastModified === undefined
+    || stored.lastModified <= localLastModified
+  ) {
+    return undefined;
+  }
+  return stored.models;
 }
 
 beforeEach(async () => {
@@ -121,7 +149,7 @@ describe("ModelRegistry re-registration precedence", () => {
     expect(ids).toEqual(["grok-4.5", "new-entitled"]);
   });
 
-  it("does not let a stale models-store.json catalog override extension registration", async () => {
+  it("discards a stale models-store.json overlay when the local catalog is newer", async () => {
     if (!hasModelRuntime()) {
       expect(true).toBe(true);
       return;
@@ -133,6 +161,8 @@ describe("ModelRegistry re-registration precedence", () => {
     const modelsPath = join(agentDir, "models.json");
     const modelsStorePath = join(agentDir, "models-store.json");
     await writeFile(modelsPath, JSON.stringify({ providers: {} }));
+
+    // Store watermark is older than the local catalog mtime used below.
     await writeFile(
       modelsStorePath,
       JSON.stringify({
@@ -151,33 +181,107 @@ describe("ModelRegistry re-registration precedence", () => {
               maxTokens: 100,
             },
           ],
-          checkedAt: Date.now(),
-          lastModified: Date.now() - 1_000,
+          checkedAt: Date.now() - 10_000,
+          lastModified: 1,
         },
       }),
     );
 
+    let storedCredential: any = {
+      type: "oauth",
+      access: "store-oauth-access",
+      refresh: "refresh",
+      expires: Date.now() + 60_000,
+    };
+    const credentialStore = {
+      async read(providerId: string) {
+        return providerId === "xai-auth" ? storedCredential : undefined;
+      },
+      async list() {
+        return storedCredential
+          ? [{ providerId: "xai-auth", type: storedCredential.type }]
+          : [];
+      },
+      async modify(_providerId: string, update: (current: any) => Promise<any>) {
+        const next = await update(storedCredential);
+        if (next !== undefined) storedCredential = next;
+        return storedCredential;
+      },
+      async delete() {
+        storedCredential = undefined;
+      },
+    };
+
     const runtime = await codingAgent.ModelRuntime.create({
+      credentials: credentialStore,
       modelsPath,
       modelsStorePath,
-      allowModelNetwork: false,
+      allowModelNetwork: true,
     });
     const registry = new codingAgent.ModelRegistry(runtime);
 
-    registry.registerProvider("xai-auth", refreshedProviderConfig);
-    await runtime.refresh({ allowNetwork: false });
+    // Local catalog is newer than store lastModified:1, so remoteModels-style
+    // policy must discard the persisted overlay and keep the local baseline.
+    const localCatalogModifiedAt = Date.now();
+    let refreshCalls = 0;
+    let sawStaleStore = false;
 
-    expect(registry.find("xai-auth", "stale-from-store")).toBeUndefined();
-    expect(registry.find("xai-auth", "grok-4.5")).toMatchObject({
-      id: "grok-4.5",
+    registry.registerProvider("xai-auth", {
+      name: "xAI store precedence",
       baseUrl: "https://cli-chat-proxy.grok.com/v1",
+      api: "openai-responses",
+      authHeader: true,
+      oauth: {
+        name: "xAI store precedence",
+        async login() {
+          throw new Error("not used");
+        },
+        async refreshToken(credentials: any) {
+          return credentials;
+        },
+        getApiKey(credentials: any) {
+          return credentials.access;
+        },
+      },
+      models: [baselineModelConfig],
+      async refreshModels(context: {
+        store: { read: () => Promise<any> };
+        allowNetwork?: boolean;
+      }) {
+        refreshCalls += 1;
+        const stored = await context.store.read();
+        if (stored?.models?.some((model: { id: string }) => model.id === "stale-from-store")) {
+          sawStaleStore = true;
+        }
+        const fromStore = modelsFromStoreIfNewerThanLocal(stored, localCatalogModifiedAt);
+        if (fromStore) {
+          return fromStore.map((model) => ({
+            id: model.id,
+            name: model.name ?? model.id,
+            reasoning: !!model.reasoning,
+            input: model.input ?? ["text"],
+            cost: model.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: model.contextWindow ?? 1_000,
+            maxTokens: model.maxTokens ?? 100,
+          }));
+        }
+        return [baselineModelConfig];
+      },
+    });
+
+    await runtime.refresh({ allowNetwork: true, force: true });
+
+    expect(refreshCalls).toBeGreaterThan(0);
+    expect(sawStaleStore).toBe(true);
+    expect(registry.find("xai-auth", "stale-from-store")).toBeUndefined();
+    expect(registry.find("xai-auth", "baseline-model")).toMatchObject({
+      id: "baseline-model",
     });
     expect(
       runtime
         .getModels("xai-auth")
-        .map((model: { id: string }) => model.id)
-        .sort(),
-    ).toEqual(["grok-4.5", "new-entitled"]);
+        .map((model: { id: string }) => model.id),
+    ).toEqual(["baseline-model"]);
   });
 
   it("prefers ModelRuntime.getAuth over the legacy getApiKeyAndHeaders projection", async () => {

--- a/tests/provider/registry-reregistration.test.ts
+++ b/tests/provider/registry-reregistration.test.ts
@@ -1,0 +1,206 @@
+import * as PiCodingAgent from "@earendil-works/pi-coding-agent";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	resolvePiManagedXaiCredential,
+	resolveRegistryRequestAuth,
+} from "../../extensions/xai/auth";
+import {
+	CURATED_FALLBACK_MODELS,
+	setXaiRuntimeModels,
+} from "../../extensions/xai/models";
+import { TEST_MODEL } from "../fixtures/models";
+import { createTempDir } from "../fixtures/temp";
+
+let temp: Awaited<ReturnType<typeof createTempDir>>;
+
+const staleProviderConfig = {
+	name: "xAI stale catalog",
+	baseUrl: "https://example.invalid/stale/v1",
+	api: "openai-responses",
+	authHeader: true,
+	models: [
+		{
+			id: "stale-bundled-model",
+			name: "Stale bundled model",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 8_000,
+			maxTokens: 100,
+		},
+	],
+};
+
+const refreshedProviderConfig = {
+	name: "xAI refreshed catalog",
+	baseUrl: "https://cli-chat-proxy.grok.com/v1",
+	api: "openai-responses",
+	authHeader: true,
+	models: [
+		{
+			id: "grok-4.5",
+			name: "Grok 4.5",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 0 },
+			contextWindow: 500_000,
+			maxTokens: 64_000,
+		},
+		{
+			id: "new-entitled",
+			name: "New entitled",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 100_000,
+			maxTokens: 8_000,
+		},
+	],
+};
+
+beforeEach(async () => {
+	temp = await createTempDir("pi-xai-registry-");
+	vi.stubEnv("HOME", temp.path);
+});
+
+afterEach(async () => {
+	setXaiRuntimeModels(CURATED_FALLBACK_MODELS);
+	vi.unstubAllEnvs();
+	await temp.cleanup();
+});
+
+describe("ModelRegistry re-registration precedence", () => {
+	it("replaces a stale registered catalog when models are re-registered", async () => {
+		const codingAgent = PiCodingAgent as any;
+		if (typeof codingAgent.ModelRuntime !== "function") {
+			// Minimum matrix (0.80.1) still uses the older registry surface.
+			expect(true).toBe(true);
+			return;
+		}
+
+		const runtime = await codingAgent.ModelRuntime.create({
+			modelsPath: null,
+			allowModelNetwork: false,
+		});
+		const registry = new codingAgent.ModelRegistry(runtime);
+
+		registry.registerProvider("xai-auth", staleProviderConfig);
+		await runtime.refresh({ allowNetwork: false });
+		expect(registry.find("xai-auth", "stale-bundled-model")).toBeDefined();
+		expect(registry.find("xai-auth", "grok-4.5")).toBeUndefined();
+
+		// Extension catalog refresh unregisters then re-registers with the new
+		// exact entitlement set so stale models cannot outlive a successful refresh.
+		registry.unregisterProvider("xai-auth");
+		registry.registerProvider("xai-auth", refreshedProviderConfig);
+		await runtime.refresh({ allowNetwork: false });
+
+		expect(registry.find("xai-auth", "stale-bundled-model")).toBeUndefined();
+		expect(registry.find("xai-auth", "grok-4.5")).toMatchObject({
+			id: "grok-4.5",
+			baseUrl: "https://cli-chat-proxy.grok.com/v1",
+			contextWindow: 500_000,
+		});
+		expect(registry.find("xai-auth", "new-entitled")).toBeDefined();
+
+		const ids = registry
+			.getAll()
+			.filter((model: { provider: string }) => model.provider === "xai-auth")
+			.map((model: { id: string }) => model.id)
+			.sort();
+		expect(ids).toEqual(["grok-4.5", "new-entitled"]);
+	});
+
+	it("projects ModelRuntime.getAuth through the registry facade for request auth", async () => {
+		const codingAgent = PiCodingAgent as any;
+		if (typeof codingAgent.ModelRuntime !== "function") {
+			expect(true).toBe(true);
+			return;
+		}
+
+		let stored: any = {
+			type: "oauth",
+			access: "registry-oauth-access",
+			refresh: "refresh",
+			expires: Date.now() + 60_000,
+		};
+		const credentialStore = {
+			async read(providerId: string) {
+				return providerId === "xai-auth" ? stored : undefined;
+			},
+			async list() {
+				return stored ? [{ providerId: "xai-auth", type: stored.type }] : [];
+			},
+			async modify(
+				_providerId: string,
+				update: (current: any) => Promise<any>,
+			) {
+				const next = await update(stored);
+				if (next !== undefined) stored = next;
+				return stored;
+			},
+			async delete() {
+				stored = undefined;
+			},
+		};
+
+		const runtime = await codingAgent.ModelRuntime.create({
+			credentials: credentialStore,
+			modelsPath: null,
+			allowModelNetwork: false,
+		});
+		const registry = new codingAgent.ModelRegistry(runtime);
+		registry.registerProvider("xai-auth", {
+			...refreshedProviderConfig,
+			oauth: {
+				name: "xAI registry auth",
+				async login() {
+					throw new Error("not used");
+				},
+				async refreshToken(credentials: any) {
+					return credentials;
+				},
+				getApiKey(credentials: any) {
+					return credentials.access;
+				},
+			},
+		});
+		await runtime.refresh({ allowNetwork: false });
+
+		const model = registry.find("xai-auth", "grok-4.5");
+		expect(model).toBeDefined();
+
+		const auth = await resolveRegistryRequestAuth(registry, model);
+		expect(auth).toMatchObject({
+			ok: true,
+			apiKey: "registry-oauth-access",
+		});
+
+		await expect(
+			resolvePiManagedXaiCredential({
+				model: { ...TEST_MODEL, id: "grok-4.5" },
+				modelRegistry: registry,
+			}),
+		).resolves.toEqual({
+			kind: "oauth-session",
+			token: "registry-oauth-access",
+		});
+	});
+
+	it("falls back to provider-scoped getProviderAuth when model auth is unavailable", async () => {
+		const auth = await resolveRegistryRequestAuth({
+			getProviderAuth: async () => ({
+				auth: {
+					apiKey: "provider-scoped-token",
+					headers: { Authorization: "Bearer provider-scoped-token" },
+				},
+				source: "stored OAuth",
+			}),
+		});
+		expect(auth).toEqual({
+			ok: true,
+			apiKey: "provider-scoped-token",
+			headers: { Authorization: "Bearer provider-scoped-token" },
+		});
+	});
+});

--- a/tests/provider/registry-reregistration.test.ts
+++ b/tests/provider/registry-reregistration.test.ts
@@ -1,12 +1,14 @@
 import * as PiCodingAgent from "@earendil-works/pi-coding-agent";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-	resolvePiManagedXaiCredential,
-	resolveRegistryRequestAuth,
+  resolvePiManagedXaiCredential,
+  resolveRegistryRequestAuth,
 } from "../../extensions/xai/auth";
 import {
-	CURATED_FALLBACK_MODELS,
-	setXaiRuntimeModels,
+  CURATED_FALLBACK_MODELS,
+  setXaiRuntimeModels,
 } from "../../extensions/xai/models";
 import { TEST_MODEL } from "../fixtures/models";
 import { createTempDir } from "../fixtures/temp";
@@ -14,193 +16,263 @@ import { createTempDir } from "../fixtures/temp";
 let temp: Awaited<ReturnType<typeof createTempDir>>;
 
 const staleProviderConfig = {
-	name: "xAI stale catalog",
-	baseUrl: "https://example.invalid/stale/v1",
-	api: "openai-responses",
-	authHeader: true,
-	models: [
-		{
-			id: "stale-bundled-model",
-			name: "Stale bundled model",
-			reasoning: false,
-			input: ["text"],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 8_000,
-			maxTokens: 100,
-		},
-	],
+  name: "xAI stale catalog",
+  baseUrl: "https://example.invalid/stale/v1",
+  api: "openai-responses",
+  authHeader: true,
+  models: [
+    {
+      id: "stale-bundled-model",
+      name: "Stale bundled model",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 8_000,
+      maxTokens: 100,
+    },
+  ],
 };
 
 const refreshedProviderConfig = {
-	name: "xAI refreshed catalog",
-	baseUrl: "https://cli-chat-proxy.grok.com/v1",
-	api: "openai-responses",
-	authHeader: true,
-	models: [
-		{
-			id: "grok-4.5",
-			name: "Grok 4.5",
-			reasoning: true,
-			input: ["text", "image"],
-			cost: { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 0 },
-			contextWindow: 500_000,
-			maxTokens: 64_000,
-		},
-		{
-			id: "new-entitled",
-			name: "New entitled",
-			reasoning: false,
-			input: ["text"],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 100_000,
-			maxTokens: 8_000,
-		},
-	],
+  name: "xAI refreshed catalog",
+  baseUrl: "https://cli-chat-proxy.grok.com/v1",
+  api: "openai-responses",
+  authHeader: true,
+  models: [
+    {
+      id: "grok-4.5",
+      name: "Grok 4.5",
+      reasoning: true,
+      input: ["text", "image"],
+      cost: { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 0 },
+      contextWindow: 500_000,
+      maxTokens: 64_000,
+    },
+    {
+      id: "new-entitled",
+      name: "New entitled",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 100_000,
+      maxTokens: 8_000,
+    },
+  ],
 };
 
+function codingAgentApi(): any {
+  return PiCodingAgent as any;
+}
+
+function hasModelRuntime(): boolean {
+  return typeof codingAgentApi().ModelRuntime === "function";
+}
+
 beforeEach(async () => {
-	temp = await createTempDir("pi-xai-registry-");
-	vi.stubEnv("HOME", temp.path);
+  temp = await createTempDir("pi-xai-registry-");
+  vi.stubEnv("HOME", temp.path);
 });
 
 afterEach(async () => {
-	setXaiRuntimeModels(CURATED_FALLBACK_MODELS);
-	vi.unstubAllEnvs();
-	await temp.cleanup();
+  setXaiRuntimeModels(CURATED_FALLBACK_MODELS);
+  vi.unstubAllEnvs();
+  await temp.cleanup();
 });
 
 describe("ModelRegistry re-registration precedence", () => {
-	it("replaces a stale registered catalog when models are re-registered", async () => {
-		const codingAgent = PiCodingAgent as any;
-		if (typeof codingAgent.ModelRuntime !== "function") {
-			// Minimum matrix (0.80.1) still uses the older registry surface.
-			expect(true).toBe(true);
-			return;
-		}
+  it("replaces a stale registered catalog when models are re-registered", async () => {
+    if (!hasModelRuntime()) {
+      // Minimum matrix (0.80.1) still uses the older registry surface.
+      expect(true).toBe(true);
+      return;
+    }
 
-		const runtime = await codingAgent.ModelRuntime.create({
-			modelsPath: null,
-			allowModelNetwork: false,
-		});
-		const registry = new codingAgent.ModelRegistry(runtime);
+    const codingAgent = codingAgentApi();
+    const runtime = await codingAgent.ModelRuntime.create({
+      modelsPath: null,
+      allowModelNetwork: false,
+    });
+    const registry = new codingAgent.ModelRegistry(runtime);
 
-		registry.registerProvider("xai-auth", staleProviderConfig);
-		await runtime.refresh({ allowNetwork: false });
-		expect(registry.find("xai-auth", "stale-bundled-model")).toBeDefined();
-		expect(registry.find("xai-auth", "grok-4.5")).toBeUndefined();
+    registry.registerProvider("xai-auth", staleProviderConfig);
+    await runtime.refresh({ allowNetwork: false });
+    expect(registry.find("xai-auth", "stale-bundled-model")).toBeDefined();
+    expect(registry.find("xai-auth", "grok-4.5")).toBeUndefined();
 
-		// Extension catalog refresh unregisters then re-registers with the new
-		// exact entitlement set so stale models cannot outlive a successful refresh.
-		registry.unregisterProvider("xai-auth");
-		registry.registerProvider("xai-auth", refreshedProviderConfig);
-		await runtime.refresh({ allowNetwork: false });
+    // Extension catalog refresh unregisters then re-registers with the new
+    // exact entitlement set so stale models cannot outlive a successful refresh.
+    registry.unregisterProvider("xai-auth");
+    registry.registerProvider("xai-auth", refreshedProviderConfig);
+    await runtime.refresh({ allowNetwork: false });
 
-		expect(registry.find("xai-auth", "stale-bundled-model")).toBeUndefined();
-		expect(registry.find("xai-auth", "grok-4.5")).toMatchObject({
-			id: "grok-4.5",
-			baseUrl: "https://cli-chat-proxy.grok.com/v1",
-			contextWindow: 500_000,
-		});
-		expect(registry.find("xai-auth", "new-entitled")).toBeDefined();
+    expect(registry.find("xai-auth", "stale-bundled-model")).toBeUndefined();
+    expect(registry.find("xai-auth", "grok-4.5")).toMatchObject({
+      id: "grok-4.5",
+      baseUrl: "https://cli-chat-proxy.grok.com/v1",
+      contextWindow: 500_000,
+    });
+    expect(registry.find("xai-auth", "new-entitled")).toBeDefined();
 
-		const ids = registry
-			.getAll()
-			.filter((model: { provider: string }) => model.provider === "xai-auth")
-			.map((model: { id: string }) => model.id)
-			.sort();
-		expect(ids).toEqual(["grok-4.5", "new-entitled"]);
-	});
+    const ids = registry
+      .getAll()
+      .filter((model: { provider: string }) => model.provider === "xai-auth")
+      .map((model: { id: string }) => model.id)
+      .sort();
+    expect(ids).toEqual(["grok-4.5", "new-entitled"]);
+  });
 
-	it("projects ModelRuntime.getAuth through the registry facade for request auth", async () => {
-		const codingAgent = PiCodingAgent as any;
-		if (typeof codingAgent.ModelRuntime !== "function") {
-			expect(true).toBe(true);
-			return;
-		}
+  it("does not let a stale models-store.json catalog override extension registration", async () => {
+    if (!hasModelRuntime()) {
+      expect(true).toBe(true);
+      return;
+    }
 
-		let stored: any = {
-			type: "oauth",
-			access: "registry-oauth-access",
-			refresh: "refresh",
-			expires: Date.now() + 60_000,
-		};
-		const credentialStore = {
-			async read(providerId: string) {
-				return providerId === "xai-auth" ? stored : undefined;
-			},
-			async list() {
-				return stored ? [{ providerId: "xai-auth", type: stored.type }] : [];
-			},
-			async modify(
-				_providerId: string,
-				update: (current: any) => Promise<any>,
-			) {
-				const next = await update(stored);
-				if (next !== undefined) stored = next;
-				return stored;
-			},
-			async delete() {
-				stored = undefined;
-			},
-		};
+    const codingAgent = codingAgentApi();
+    const agentDir = join(temp.path, ".pi", "agent");
+    await mkdir(agentDir, { recursive: true });
+    const modelsPath = join(agentDir, "models.json");
+    const modelsStorePath = join(agentDir, "models-store.json");
+    await writeFile(modelsPath, JSON.stringify({ providers: {} }));
+    await writeFile(
+      modelsStorePath,
+      JSON.stringify({
+        "xai-auth": {
+          models: [
+            {
+              id: "stale-from-store",
+              name: "Stale from store",
+              provider: "xai-auth",
+              api: "openai-responses",
+              baseUrl: "https://example.invalid/stale-store",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 1_000,
+              maxTokens: 100,
+            },
+          ],
+          checkedAt: Date.now(),
+          lastModified: Date.now() - 1_000,
+        },
+      }),
+    );
 
-		const runtime = await codingAgent.ModelRuntime.create({
-			credentials: credentialStore,
-			modelsPath: null,
-			allowModelNetwork: false,
-		});
-		const registry = new codingAgent.ModelRegistry(runtime);
-		registry.registerProvider("xai-auth", {
-			...refreshedProviderConfig,
-			oauth: {
-				name: "xAI registry auth",
-				async login() {
-					throw new Error("not used");
-				},
-				async refreshToken(credentials: any) {
-					return credentials;
-				},
-				getApiKey(credentials: any) {
-					return credentials.access;
-				},
-			},
-		});
-		await runtime.refresh({ allowNetwork: false });
+    const runtime = await codingAgent.ModelRuntime.create({
+      modelsPath,
+      modelsStorePath,
+      allowModelNetwork: false,
+    });
+    const registry = new codingAgent.ModelRegistry(runtime);
 
-		const model = registry.find("xai-auth", "grok-4.5");
-		expect(model).toBeDefined();
+    registry.registerProvider("xai-auth", refreshedProviderConfig);
+    await runtime.refresh({ allowNetwork: false });
 
-		const auth = await resolveRegistryRequestAuth(registry, model);
-		expect(auth).toMatchObject({
-			ok: true,
-			apiKey: "registry-oauth-access",
-		});
+    expect(registry.find("xai-auth", "stale-from-store")).toBeUndefined();
+    expect(registry.find("xai-auth", "grok-4.5")).toMatchObject({
+      id: "grok-4.5",
+      baseUrl: "https://cli-chat-proxy.grok.com/v1",
+    });
+    expect(
+      runtime
+        .getModels("xai-auth")
+        .map((model: { id: string }) => model.id)
+        .sort(),
+    ).toEqual(["grok-4.5", "new-entitled"]);
+  });
 
-		await expect(
-			resolvePiManagedXaiCredential({
-				model: { ...TEST_MODEL, id: "grok-4.5" },
-				modelRegistry: registry,
-			}),
-		).resolves.toEqual({
-			kind: "oauth-session",
-			token: "registry-oauth-access",
-		});
-	});
+  it("prefers ModelRuntime.getAuth over the legacy getApiKeyAndHeaders projection", async () => {
+    if (!hasModelRuntime()) {
+      expect(true).toBe(true);
+      return;
+    }
 
-	it("falls back to provider-scoped getProviderAuth when model auth is unavailable", async () => {
-		const auth = await resolveRegistryRequestAuth({
-			getProviderAuth: async () => ({
-				auth: {
-					apiKey: "provider-scoped-token",
-					headers: { Authorization: "Bearer provider-scoped-token" },
-				},
-				source: "stored OAuth",
-			}),
-		});
-		expect(auth).toEqual({
-			ok: true,
-			apiKey: "provider-scoped-token",
-			headers: { Authorization: "Bearer provider-scoped-token" },
-		});
-	});
+    const codingAgent = codingAgentApi();
+    let stored: any = {
+      type: "oauth",
+      access: "registry-oauth-access",
+      refresh: "refresh",
+      expires: Date.now() + 60_000,
+    };
+    const credentialStore = {
+      async read(providerId: string) {
+        return providerId === "xai-auth" ? stored : undefined;
+      },
+      async list() {
+        return stored ? [{ providerId: "xai-auth", type: stored.type }] : [];
+      },
+      async modify(_providerId: string, update: (current: any) => Promise<any>) {
+        const next = await update(stored);
+        if (next !== undefined) stored = next;
+        return stored;
+      },
+      async delete() {
+        stored = undefined;
+      },
+    };
+
+    const runtime = await codingAgent.ModelRuntime.create({
+      credentials: credentialStore,
+      modelsPath: null,
+      allowModelNetwork: false,
+    });
+    const registry = new codingAgent.ModelRegistry(runtime);
+    registry.registerProvider("xai-auth", {
+      ...refreshedProviderConfig,
+      oauth: {
+        name: "xAI registry auth",
+        async login() {
+          throw new Error("not used");
+        },
+        async refreshToken(credentials: any) {
+          return credentials;
+        },
+        getApiKey(credentials: any) {
+          return credentials.access;
+        },
+      },
+    });
+    await runtime.refresh({ allowNetwork: false });
+
+    const model = registry.find("xai-auth", "grok-4.5");
+    expect(model).toBeDefined();
+
+    const getApiKeyAndHeaders = vi.spyOn(registry, "getApiKeyAndHeaders");
+    const getAuth = vi.spyOn(runtime, "getAuth");
+
+    const auth = await resolveRegistryRequestAuth(registry, model, runtime);
+    expect(auth).toMatchObject({
+      ok: true,
+      apiKey: "registry-oauth-access",
+    });
+    expect(getAuth).toHaveBeenCalled();
+    expect(getApiKeyAndHeaders).not.toHaveBeenCalled();
+
+    await expect(
+      resolvePiManagedXaiCredential({
+        model: { ...TEST_MODEL, id: "grok-4.5" },
+        modelRegistry: registry,
+        modelRuntime: runtime,
+      }),
+    ).resolves.toEqual({
+      kind: "oauth-session",
+      token: "registry-oauth-access",
+    });
+  });
+
+  it("falls back to provider-scoped getProviderAuth when model auth is unavailable", async () => {
+    const auth = await resolveRegistryRequestAuth({
+      getProviderAuth: async () => ({
+        auth: {
+          apiKey: "provider-scoped-token",
+          headers: { Authorization: "Bearer provider-scoped-token" },
+        },
+        source: "stored OAuth",
+      }),
+    });
+    expect(auth).toEqual({
+      ok: true,
+      apiKey: "provider-scoped-token",
+      headers: { Authorization: "Bearer provider-scoped-token" },
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- adopt Pi **0.81.0** as the latest exact tested boundary while keeping minimum **0.80.1**
- widen peers to `>=0.80.1 <0.82.0` and pin exact Pi dev dependencies / lockfile to 0.81.0
- migrate extension request-auth to prefer `ModelRuntime.getAuth` when the host exposes it, then ModelRegistry `getApiKeyAndHeaders` / `getProviderAuth` projections for older supported boundaries
- add ModelRuntime re-registration coverage and a store-backed models-store precedence regression
- document deferral of Pi's `refreshModels(context)` hook (login-generation tracking, force-refresh, and package-owned cache policy remain package-owned)

## Review fixes

1. **Auth migration** — `resolveRegistryRequestAuth` prefers `ModelRuntime.getAuth` (via explicit `ctx.modelRuntime`, `registry.runtime`, or a registry that exposes `getAuth`), then falls back to legacy registry projections for the 0.80.1 packed boundary.
2. **models-store precedence** — store-backed `refreshModels` regression seeds a stale `models-store.json` overlay (`stale-from-store`, `lastModified: 1`), asserts the refresh path **reads** that stale entry, then discards it when the local catalog mtime is newer (mirrors Pi 0.81.0 `remoteModels()` policy). Only the local baseline remains.

## Release review

- **0.80.8**: `ModelRuntime` / `getAuth` replaced SDK `getApiKeyAndHeaders`; extension-facing `ModelRegistry` remains available as a projection
- **0.80.9–0.80.10**: built-in xAI catalog churn; no extension-facing break
- **0.81.0**: full provider extensions, `refreshModels`, catalog-store precedence fix; candidate matrix green without production breaks

## Validation

- `npm test` / focused registry suite green after the store-backed precedence rewrite
- `npm run typecheck`
- clean packed `0.81.0 --candidate` before the boundary widen
- `npm run compatibility:check`: policy, live registry, pack, unsupported peers 0.79.10 and 0.82.0
- CI matrix: exact packed 0.80.1 and 0.81.0

Closes #134
