### PR TITLE
fix(tools): ack menu bridge open before picker close

### DIFF
--- a/.scaffold/constraints.md
+++ b/.scaffold/constraints.md
@@ -1,21 +1,19 @@
-# Constraints & Safety Rules — Issue #118
+# Constraints & Safety Rules — Issue #128
 
-## Scaffold-only scope
+## Scope
 
-- Touch only `.scaffold/*` for this issue.
-- Do not change production code, tests, modality docs, changelog, package version, or OAuth behavior.
-- Do not invent unmerged work or restate closed issues as open.
+- Fix menu-bridge `open` ack timing only (`extensions/xai/tools/commands.ts` + focused tests + CHANGELOG/scaffold).
+- Do not implement #129 (honest `done.ok` for all toast-only failures), #130 (full bridge coverage), or #131 (cross-package contract docs) in this PR.
 
-## Progress content rules
+## Must
 
-- Keep security-relevant vision-routing decisions: converter-only image advertisement, truthful text-only metadata elsewhere, grant capture/invalidation, consumed historical-image pruning (including post-hook recursive scrubbing), current-unconsumed image routing, and no history/tools/ciphertext on the vision target.
-- Keep final validation evidence (test counts, typecheck, exact Pi boundaries, independent review outcome).
-- Remove transient execution narration and duplicate converter/metadata/historical-image/validation bullets.
-- Never leave completed work under `In Progress`.
-- Keep branch and delivery state aligned with post-merge `origin/main`.
+- Call `done({ ok: true })` when interactive open is accepted for launch, before awaiting picker close.
+- Pre-validate active xAI model and UI before ack; reply `ok: false` when open cannot launch.
+- Never re-call `done` after a successful launch ack (post-launch failures stay in-UI).
+- Never log secrets, tokens, or raw bridge payloads.
 
-## Non-goals
+## Must not
 
-- Do not re-open or re-implement vision-routing, pruning, or modality-doc work.
-- Do not treat `.scaffold/` as an authoritative security control.
-- Do not rewrite git history of earlier PRs.
+- Change slash-command `/xai-tools` interactive behavior for humans typing the command.
+- Widen scope into vision routing, OAuth, catalog, or unrelated tools.
+- Skip error handling on OAuth refresh (N/A here; do not regress elsewhere).

--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -1,28 +1,22 @@
-# Shared Agent Context — Issue #118
+# Shared Agent Context — Issue #128
 
-**Issue:** <https://github.com/BlockedPath/pi-xai-oauth/issues/118>
-**Branch:** `chore/118-scaffold-progress`
-**Base:** `origin/main` at `24df74a`
+**Issue:** <https://github.com/BlockedPath/pi-xai-oauth/issues/128>
+**Linear:** [BLO-11](https://linear.app/blockedpath/issue/BLO-11/gh-128-menu-bridge-open-waits-for-picker-close-before-done-4s-false)
+**Series:** [BLO-10](https://linear.app/blockedpath/issue/BLO-10/pi-xai-oauth-menu-bridge-hardening-series-github-128-131) / GitHub #128–#131
+**Branch:** `fix/128-menu-bridge-picker-timeout`
 
-## Why this exists
+## Problem
 
-After the vision-routing series (PR #109, then #114–#117 and #119), `.scaffold/progress.md` still carried intermediate execution narration: repeated converter/metadata/historical-image/validation bullets, completed validation parked under `In Progress`, and a branch name that was no longer current after merge. Later issue branches overwrote the file with their own progress, so the durable series summary was never left in a post-merge form.
+`registerXaiToolsCommand` listens on `pi-clickable-menu:xai-tools`. For `action: "open"` it awaited `handleXaiToolsArgs` / `showXaiToolPicker` and only then called `done({ ok: true })`. `pi-clickable-menu` treats a missing `done` within ~4 seconds as bridge failure, so users who keep the picker open get a false “No xAI tools bridge response” error.
 
-## Scope
+## Fix
 
-Scaffold-only consolidation. Production code, tests, and modality documentation are already merged; this issue does not change behavior or policy claims.
+Validate launch (active xAI model + `hasUI`), `reply({ ok: true })`, then await `showXaiToolPicker` without holding `done`. Post-launch picker errors notify only.
 
-## Series already on main
+## Follow-ups (out of scope)
 
-| Work | State |
+| Issue | Topic |
 | --- | --- |
-| PR #109 — Pi converter image advertisement + grant binding + historical pruning | Merged |
-| PR #120 / #114 — post-hook recursive pruning | Merged |
-| PR #122 / #115 — trim duplicated vision assertions | Merged |
-| PR #123 / #116 — typed `model.input` | Merged |
-| PR #126 / #117 — mixed historical text preserved | Merged |
-| #119 modality-doc split (`24df74a`) | On main; issue closed |
-
-## Deliverable
-
-A factual `.scaffold/progress.md` for the series, with matching plan/context/constraints for #118, ready to commit and PR.
+| #129 | Forward real success/failure through `done` for status/enable/disable |
+| #130 | Expand bridge unit coverage |
+| #131 | Document/share bridge contract |

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,24 +1,22 @@
-# Implementation Plan — Issue #118: Consolidate vision-routing scaffold progress
+# Implementation Plan — Issue #128: Menu bridge open ack before picker close
 
-**Branch:** `chore/118-scaffold-progress`
-**Base:** `origin/main` at `24df74a`
+**Branch:** `fix/128-menu-bridge-picker-timeout`
+**Base:** `origin/main`
 
 ## Goal
 
-Replace the repeated vision-routing progress narration with a short post-merge record that keeps security decisions and final validation evidence, and points branch/delivery state at current main.
+Stop the `pi-clickable-menu:xai-tools` bridge from awaiting interactive picker close before `done({ ok: true })`, which false-triggers the menu host’s ~4s timeout.
 
 ## Phases
 
-1. [x] Confirm issue scope, blockers, and that the vision-routing series is already on `origin/main`.
-2. [x] Fast-forward `chore/118-scaffold-progress` onto current main.
-3. [x] Rewrite `.scaffold/progress.md` into consolidated completed/delivery entries with no completed work under `In Progress`.
-4. [x] Retarget plan, context, and constraints to issue #118 scaffold-only scope.
-5. [x] Open a PR that closes #118 (and note #119 already landed on main).
+1. [x] Confirm issue scope (#128 only; #129–#131 follow in series order).
+2. [x] Ack `open` on launch after pre-validation (active xAI model + UI), then await picker without holding `done`.
+3. [x] Add regression: `done` resolves while a held picker is still open; reject open with no model.
+4. [x] CHANGELOG + focused Vitest for `tests/tools/commands.test.ts`.
 
 ## Validation Contract
 
-- No completed work remains under `In Progress`.
-- Branch and delivery state match post-merge `origin/main`.
-- Converter, metadata, historical-image, and validation details are not repeated across many bullets.
-- Security-relevant decisions and final validation results remain recorded.
-- Only `.scaffold/*` changes; no production behavior or docs policy changes.
+- `action: "open"` calls `done` when the picker is accepted for launch, not after close.
+- Missing xAI model / missing UI still reply failure before any interactive wait.
+- Post-launch picker errors notify in-UI only (do not re-call `done`).
+- Focused tools command tests pass.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,45 +1,19 @@
-# Execution Progress — Vision-routing hardening series
+# Execution Progress — Issue #128
 
-**Branch:** `chore/118-scaffold-progress`
-**Base:** `origin/main` at `24df74a`
-**Series window:** 2026-07-19 → 2026-07-20
+**Branch:** `fix/128-menu-bridge-picker-timeout`
 
 ## Completed
 
-### Core fix (PR #109)
-
-- [x] Advertise `image` only on Pi's delegated Responses conversion-model copy so vision routing sees real conversation images; catalog metadata, package rewrites, and payload hooks keep truthful text-only source capability.
-- [x] Bind each routed stream to the grant captured at stream start so reset/re-enable cannot authorize an old request.
-- [x] Replace consumed historical user images and computer screenshots with bounded placeholders while preserving current unconsumed user/tool images and the `computer_screenshot` object shape.
-- [x] Keep encrypted reasoning isolated: the vision target request sends no conversation history, tools, or ciphertext.
-- [x] Document the conversion advertisement and lifecycle rules in `docs/model-input-modalities.md` and `CHANGELOG.md`.
-- [x] Merged: <https://github.com/BlockedPath/pi-xai-oauth/pull/109>
-
-### Post-hook recursive pruning (PR #120 / #114)
-
-- [x] Share `omitConsumedXaiResponsesVisionImages` before and after caller payload hooks.
-- [x] Recursively strip every image shape recognized by route planning from consumed history.
-- [x] Merged: <https://github.com/BlockedPath/pi-xai-oauth/pull/120>
-
-### Follow-up cleanup
-
-- [x] #115 / PR #122: trim duplicated Pi-converted vision regression assertions.
-- [x] #116 / PR #123: use typed `model.input` in vision conversion routing.
-- [x] #117 / PR #126: assert mixed historical content retains ordinary user text with the bounded placeholder.
-- [x] #119: split vision-routing modality docs into conversion, authorization-lifecycle, and request-behavior paragraphs (on main as `24df74a`; issue closed).
-
-## Final validation (series)
-
-- [x] Full `npm test` passed on the series tip (43 files / 486 tests + loader).
-- [x] Typecheck, compatibility policy/pack checks, and exact Pi 0.80.1 / 0.80.10 boundaries passed.
-- [x] Independent/fresh-context reviews of the security fixes reported no remaining blockers.
+- [x] Read issue #128 and series notes (#129–#131 deferred).
+- [x] Bridge `open`: ack on launch after model/UI validation; await picker without holding `done`.
+- [x] Regressions: ack-before-picker-close; reject open with no xAI model.
+- [x] CHANGELOG Unreleased fixed entry.
+- [x] Focused `tests/tools/commands.test.ts` (17) + `npm run typecheck` passed.
 
 ## In Progress
 
 - None.
 
-## Delivery
+## Next
 
-- [x] Vision-routing hardening and follow-ups are merged on `origin/main` (`24df74a`).
-- [x] Scaffold progress consolidated under issue #118; branch and delivery state match post-merge main.
-- [x] Opened PR: <https://github.com/BlockedPath/pi-xai-oauth/pull/127>
+- Commit + PR closing #128 when requested (series follow-ups #129–#131 remain separate).

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -8,12 +8,12 @@
 - [x] Bridge `open`: ack on launch after model/UI validation; await picker without holding `done`.
 - [x] Regressions: ack-before-picker-close; reject open with no xAI model.
 - [x] CHANGELOG Unreleased fixed entry.
-- [x] Focused `tests/tools/commands.test.ts` (17) + `npm run typecheck` passed.
+- [x] Full `npm test` (44 files / 495 tests + loader) and `npm run typecheck` passed.
 
 ## In Progress
 
 - None.
 
-## Next
+## Delivery
 
-- Commit + PR closing #128 when requested (series follow-ups #129–#131 remain separate).
+- Commit + PR closing #128 (series follow-ups #129–#131 remain separate).

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,14 +1,14 @@
 # Execution Progress — Issue #128
 
 **Branch:** `fix/128-menu-bridge-picker-timeout`
+**PR:** https://github.com/BlockedPath/pi-xai-oauth/pull/137
 
 ## Completed
 
-- [x] Read issue #128 and series notes (#129–#131 deferred).
 - [x] Bridge `open`: ack on launch after model/UI validation; await picker without holding `done`.
 - [x] Regressions: ack-before-picker-close; reject open with no xAI model.
-- [x] CHANGELOG Unreleased fixed entry.
-- [x] Full `npm test` (44 files / 495 tests + loader) and `npm run typecheck` passed.
+- [x] Adopted Pi **0.81.1** as `policy.latest` after clean packed `--candidate` (unblocks CI registry gate vs 0.81.0).
+- [x] `npm run compatibility:check`, `npm test` (495), `npm run typecheck` passed on tip.
 
 ## In Progress
 
@@ -16,4 +16,4 @@
 
 ## Delivery
 
-- Commit + PR closing #128 (series follow-ups #129–#131 remain separate).
+- PR #137 closes #128; includes 0.81.1 boundary pin required for policy CI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 
 ### Fixed
 
+- Fixed the `pi-clickable-menu:xai-tools` bridge so `action: "open"` acknowledges `done` when the interactive picker is accepted for launch, instead of waiting until the picker closes (avoids the menu host's ~4s false timeout).
 - Consolidated duplicate `xai_web_search` and Grok-native `web_search` registrations into one collision-safe, opt-in `web_search` picker entry. The old `xai_web_search` command spelling remains an input-only compatibility alias, and the public name is still never registered globally.
 - Contained the direct Grok-native `read_file`, `search_replace`, and `list_dir` adapters to resolved workspace paths, safely limited missing-leaf creation to contained physical parents, and capped package-owned full text reads at 5,000,000 bytes. `run_terminal_command` remains an unrestricted delegation to pi `bash`, so this is direct-adapter defense-in-depth rather than a filesystem sandbox.
 - Restricted legacy local PNG/JPEG inputs across custom tools, Responses payload normalization, and vision routing to byte-bounded, byte-validated regular files inside the active workspace, with sanitized failures for traversal, outward symlinks, special files, MIME spoofing, oversized sources, and pixel bombs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 
 - Recorded the package-scope decision to keep provider-neutral goal/plan workflows, autonomous continuation, runtime plan management, and write-restriction policy out of `pi-xai-oauth`; see [ADR 0001](docs/decisions/0001-goal-plan-package-scope.md).
 - Reviewed Pi 0.80.8 through 0.81.0 and adopted 0.81.0 as the latest exact tested boundary after clean packed candidate validation, while preserving the 0.80.1 minimum.
-- Widened aligned Pi peers to `>=0.80.1 <0.82.0` and pinned development metadata exactly to 0.81.0.
+- Reviewed Pi 0.81.1 and adopted it as the latest exact tested boundary after clean packed candidate validation, while preserving the 0.80.1 minimum and `>=0.80.1 <0.82.0` peer range.
+- Widened aligned Pi peers to `>=0.80.1 <0.82.0` and pinned development metadata exactly to 0.81.1.
 - Migrated extension request-auth resolution to prefer `ModelRuntime.getAuth` when the host exposes it, then the ModelRegistry `getApiKeyAndHeaders` / `getProviderAuth` projections for older supported boundaries.
 - Deferred adopting Pi's `refreshModels(context)` provider hook: account-bound `/models-v2` discovery still needs login-generation tracking, force-refresh after credential switch, and package-owned token-free cache TTL/stale policy that the generic hook does not replace.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This package adds xAI's **account-specific OAuth model catalog** to pi, with **G
 
 > **Latest release:** `pi-xai-oauth` **1.3.6** adds authenticated account-specific model discovery, browser and device OAuth, encrypted reasoning replay, Grok-native local tools, bounded image editing, and explicit subscription usage while hardening xAI routing, payloads, headers, redirects, and entitlement enforcement. Existing npm installs should run `pi update npm:pi-xai-oauth`; local checkout installs should keep only one copy with `pi remove npm:pi-xai-oauth && pi install .`.
 >
-> **Compatibility:** 1.3.6 supports aligned `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` versions `>=0.80.1 <0.82.0`. The exact tested boundaries are 0.80.1 and 0.81.0.
+> **Compatibility:** 1.3.6 supports aligned `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` versions `>=0.80.1 <0.82.0`. The exact tested boundaries are 0.80.1 and 0.81.1.
 
 See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and fix history.
 
@@ -180,7 +180,7 @@ Both Pi runtime peers use the same bounded range:
 @earendil-works/pi-coding-agent:  >=0.80.1 <0.82.0
 ```
 
-The lower boundary is **0.80.1**, the first published Pi 0.80 release. It provides the `@earendil-works/pi-ai/compat` transport used by this extension and the matching Pi 0.80 extension-loader contract. The packed package's complete test and typecheck suites run against exact 0.80.1 in CI. The other matrix boundary is exact **0.81.0**, the latest release inside the allowed line when this policy was reviewed. Pi 0.80.8 introduced the unified `ModelRuntime` credential API and replaced the exported `AuthStorage` surface with `readStoredCredential()` for one-off reads; this package supports both the 0.80.1 legacy surface and the 0.81.0 ModelRegistry projection of `ModelRuntime.getAuth` through a bounded compatibility path.
+The lower boundary is **0.80.1**, the first published Pi 0.80 release. It provides the `@earendil-works/pi-ai/compat` transport used by this extension and the matching Pi 0.80 extension-loader contract. The packed package's complete test and typecheck suites run against exact 0.80.1 in CI. The other matrix boundary is exact **0.81.1**, the latest release inside the allowed line when this policy was reviewed. Pi 0.80.8 introduced the unified `ModelRuntime` credential API and replaced the exported `AuthStorage` surface with `readStoredCredential()` for one-off reads; this package supports both the 0.80.1 legacy surface and the 0.81.x ModelRegistry projection of `ModelRuntime.getAuth` through a bounded compatibility path.
 
 The exclusive `<0.82.0` upper bound is deliberate. Pi is pre-1.0, so a new minor line may contain breaking API or loader changes; this project does not claim support until that line passes the packed compatibility suite. npm therefore reports a peer-resolution warning or error during installation for older releases such as 0.79.10 and for the untested 0.82 line, rather than allowing a later runtime loader failure.
 
@@ -751,7 +751,7 @@ pi update npm:pi-xai-oauth
 
 This pulls the latest version from npm and updates your installed extension.
 
-Version 1.3.6 requires aligned Pi runtime packages in `>=0.80.1 <0.82.0`, with exact packed-package validation at 0.80.1 and 0.81.0. It adds authenticated model discovery, device OAuth, encrypted reasoning replay, Grok-native tools, bounded image editing, and explicit subscription usage, together with extensive transport and entitlement hardening. See [CHANGELOG.md](CHANGELOG.md) for the complete release notes. If you installed the published npm package, update with the command above. If you are testing a local checkout instead, reinstall the checkout:
+Version 1.3.6 requires aligned Pi runtime packages in `>=0.80.1 <0.82.0`, with exact packed-package validation at 0.80.1 and 0.81.1. It adds authenticated model discovery, device OAuth, encrypted reasoning replay, Grok-native tools, bounded image editing, and explicit subscription usage, together with extensive transport and entitlement hardening. See [CHANGELOG.md](CHANGELOG.md) for the complete release notes. If you installed the published npm package, update with the command above. If you are testing a local checkout instead, reinstall the checkout:
 
 ```bash
 pi remove npm:pi-xai-oauth && pi install .

--- a/compatibility/pi-versions.json
+++ b/compatibility/pi-versions.json
@@ -5,7 +5,7 @@
   ],
   "peerRange": ">=0.80.1 <0.82.0",
   "minimum": "0.80.1",
-  "latest": "0.81.0",
+  "latest": "0.81.1",
   "unsupported": {
     "older": "0.79.10",
     "upper": "0.82.0"

--- a/docs/testing/assertion-parity.md
+++ b/docs/testing/assertion-parity.md
@@ -157,7 +157,7 @@ replacement tests pass alongside the legacy verifier.
 | `verify-compatibility.js:161-213` | one tarball, packed identity/peers/required/forbidden paths | retain `pack` mode; add Vitest config/tests/fixtures/loader smoke to required list | [x] |
 | `verify-compatibility.js:215-269` | unsupported strict failure and forced warning diagnostics | retain `unsupported` mode | [x] |
 | `verify-compatibility.js:271-291` | matrix output and command dispatch | retain plain-Node CLI | [x] |
-| `run-compatibility-matrix.js:34-114` | alias/exact parsing, checked endpoint restriction, one tarball, exact installed Pi pair, packed `npm test` and typecheck | retain clean packed matrix at 0.80.1/0.81.0 | [x] |
+| `run-compatibility-matrix.js:34-114` | alias/exact parsing, checked endpoint restriction, one tarball, exact installed Pi pair, packed `npm test` and typecheck | retain clean packed matrix at 0.80.1/0.81.1 | [x] |
 
 ## Isolation checklist
 

--- a/extensions/xai/tools/commands.ts
+++ b/extensions/xai/tools/commands.ts
@@ -368,8 +368,36 @@ export function registerXaiToolsCommand(
 		const action = (data.action ?? "open").toLowerCase();
 		try {
 			if (action === "open") {
-				await handleXaiToolsArgs(pi, visionRouting, "", ctx);
+				// Menu hosts (pi-clickable-menu) treat a missing done within ~4s as
+				// bridge failure. Acknowledge once the interactive picker is accepted
+				// for launch — do not wait for the user to close it.
+				const model = activeXaiModel(ctx);
+				if (!model) {
+					const error = "Select an xAI/Grok model before opening /xai-tools.";
+					ctx.ui.notify(error, "error");
+					reply({ ok: false, error });
+					return;
+				}
+				if (!ctx.hasUI) {
+					ctx.ui.notify(
+						`${XAI_TOOLS_USAGE} Interactive selection requires TUI or RPC mode.`,
+						"error",
+					);
+					reply({ ok: false, error: "Interactive selection requires TUI or RPC mode." });
+					return;
+				}
 				reply({ ok: true });
+				try {
+					await showXaiToolPicker(pi, ctx, model);
+				} catch (err) {
+					// done already acknowledged launch; surface post-launch failures in-UI only.
+					const message = err instanceof Error ? err.message : String(err);
+					try {
+						ctx.ui.notify(message, "error");
+					} catch {
+						// ignore notify failures after ack
+					}
+				}
 				return;
 			}
 			if (action === "status") {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "pi-xai-oauth": "bin/setup.js"
       },
       "devDependencies": {
-        "@earendil-works/pi-ai": "0.81.0",
-        "@earendil-works/pi-coding-agent": "0.81.0",
+        "@earendil-works/pi-ai": "0.81.1",
+        "@earendil-works/pi-coding-agent": "0.81.1",
         "@types/node": "^26.0.0",
         "@vitest/coverage-v8": "4.1.10",
         "jiti": "^2.7.0",
@@ -548,13 +548,13 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.81.0.tgz",
-      "integrity": "sha512-Fe6JYbW0CGVvmD4dwuFreynwZxlTElIMFRqYDl4llRiwfYZjjtAqbV1hY8MrdGqP15+FySBv5RGodOsHqlhvZQ==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.81.1.tgz",
+      "integrity": "sha512-yqbh68CyhqxMov/jUogFJfMqlu2Gd37GAki+tr59YCmAPHfomiCA5ESzusXtpGzABeiZFC/OrRdQ4GwCCOMIHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.81.0",
+        "@earendil-works/pi-ai": "^0.81.1",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -564,9 +564,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.81.0.tgz",
-      "integrity": "sha512-n3lDV1Px/2BOp86rUJkoHcXuQ6uf7711VEtSjE5gTwrnPeMAEjzV3LnbQ3wTF9bUxl253Igi3U35U1CMF5POng==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.81.1.tgz",
+      "integrity": "sha512-hzHE7Z8l5mgJk+ke67Lge0rwS2+wbKJrFKl9o5M1R1rh33+cCT7D1AHz1OAtX5wFs90E1/BTGhyJRTUHaMxGvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -590,15 +590,15 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.81.0.tgz",
-      "integrity": "sha512-2p0Dnx+3fkPLga8M82eg14ZYNLcFLhqxxKyVVfqUSIio9Xx4p7UjvJtopx/6PTeJKmdJl1/xOm/c02AFcJ+l/g==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.81.1.tgz",
+      "integrity": "sha512-r6ovAsZOgAqbC/aU6s+/dPnv/sGZBuWyZNvi3pXjpbuX5wvp3XvGkQI7/VLvX2o9XpmpFaPUxKNym1WfkN/P8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.81.0",
-        "@earendil-works/pi-ai": "^0.81.0",
-        "@earendil-works/pi-tui": "^0.81.0",
+        "@earendil-works/pi-agent-core": "^0.81.1",
+        "@earendil-works/pi-ai": "^0.81.1",
+        "@earendil-works/pi-tui": "^0.81.1",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -1108,9 +1108,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.81.0.tgz",
-      "integrity": "sha512-vdrrV//CldG3Dt20vj+iCRcHOlPwxlOBJwwLg1KE/92IO+TlEwbf4uwKXgFZHGVh9lEJXtYsKzIRb/nHw5YuAA==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.81.1.tgz",
+      "integrity": "sha512-OMEe+Zt8oQYi/rCq3upxsTlIScWL0FPhXwQus34TbQb3EmTx88S7Uzx32JxvQiEeWOw8eDCdJf2PBUBE9r6wIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "@earendil-works/pi-coding-agent": ">=0.80.1 <0.82.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "0.81.0",
-    "@earendil-works/pi-coding-agent": "0.81.0",
+    "@earendil-works/pi-ai": "0.81.1",
+    "@earendil-works/pi-coding-agent": "0.81.1",
     "@types/node": "^26.0.0",
     "@vitest/coverage-v8": "4.1.10",
     "jiti": "^2.7.0",

--- a/tests/tools/commands.test.ts
+++ b/tests/tools/commands.test.ts
@@ -332,6 +332,53 @@ describe("/xai-tools command", () => {
     expect(notices.at(-1).message).toMatch(/may use xAI credits/);
   });
 
+  it("acknowledges menu bridge open before the interactive picker closes", async () => {
+    const { h, notices } = setup();
+    let releasePicker!: () => void;
+    const pickerHeldOpen = new Promise<void>((resolve) => {
+      releasePicker = resolve;
+    });
+    let pickerClosed = false;
+
+    const result = await new Promise<{ ok: boolean; error?: string }>((resolve) => {
+      h.api.events.emit(XAI_TOOLS_MENU_CHANNEL, {
+        action: "open",
+        ctx: commandContext(TEST_MODEL, notices, {
+          ui: {
+            notify(message: string, type?: string) {
+              notices.push({ message, type });
+            },
+            select: async () => undefined,
+            custom: async () => {
+              await pickerHeldOpen;
+              pickerClosed = true;
+            },
+          },
+        }),
+        done: resolve,
+      });
+    });
+
+    // done must win before the held picker finishes (menu host ~4s timeout).
+    expect(result).toEqual({ ok: true });
+    expect(pickerClosed).toBe(false);
+    releasePicker();
+  });
+
+  it("rejects menu bridge open when no xAI model is active", async () => {
+    const { h, notices } = setup();
+    const result = await new Promise<{ ok: boolean; error?: string }>((resolve) => {
+      h.api.events.emit(XAI_TOOLS_MENU_CHANNEL, {
+        action: "open",
+        ctx: commandContext(undefined, notices),
+        done: resolve,
+      });
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/Select an xAI\/Grok model/i);
+    expect(notices.at(-1).message).toMatch(/Select an xAI\/Grok model/i);
+  });
+
   it("replies with an error when the bridge lacks a UI context", async () => {
     const { h } = setup();
     const result = await new Promise<{ ok: boolean; error?: string }>((resolve) => {


### PR DESCRIPTION
## Summary
- Fixes #128: `pi-clickable-menu:xai-tools` `action: "open"` now calls `done({ ok: true })` when the interactive picker is accepted for launch, instead of waiting until the user closes it (avoids the menu host’s ~4s false timeout).
- Pre-validates an active xAI model and UI before ack; post-launch picker errors stay in-UI only.
- Adopts Pi **0.81.1** as `policy.latest` (exact peer/devDeps + docs) after clean packed candidate validation, unblocking the CI registry gate that failed on `0.81.1 !== 0.81.0`. Peer range remains `>=0.80.1 <0.82.0` with minimum **0.80.1**.
- #129–#131 remain follow-ups in the menu-bridge series.

## Test plan
- [x] `npm run test:unit -- tests/tools/commands.test.ts`
- [x] `npm test` (44 files / 495 tests + loader)
- [x] `npm run typecheck`
- [x] `node scripts/run-compatibility-matrix.js 0.81.1 --candidate`
- [x] `npm run compatibility:check`
- [x] `npm run compatibility:boundaries` (0.80.1 + 0.81.1)
- [x] Manually: from pi-clickable-menu, open xAI tools and keep the picker open >4s — no “No xAI tools bridge response” error