### PR TITLE
Fix honest xAI tools menu bridge results

### DIFF
--- a/.scaffold/constraints.md
+++ b/.scaffold/constraints.md
@@ -1,19 +1,20 @@
-# Constraints & Safety Rules — Issue #128
+# Constraints & Safety Rules — Issue #129
 
 ## Scope
 
-- Fix menu-bridge `open` ack timing only (`extensions/xai/tools/commands.ts` + focused tests + CHANGELOG/scaffold).
-- Do not implement #129 (honest `done.ok` for all toast-only failures), #130 (full bridge coverage), or #131 (cross-package contract docs) in this PR.
+- Fix truthful `done` results for the existing xAI tools menu bridge.
+- Limit production changes to `extensions/xai/tools/commands.ts`; add focused tests and release/state notes.
 
 ## Must
 
-- Call `done({ ok: true })` when interactive open is accepted for launch, before awaiting picker close.
-- Pre-validate active xAI model and UI before ack; reply `ok: false` when open cannot launch.
-- Never re-call `done` after a successful launch ack (post-launch failures stay in-UI).
-- Never log secrets, tokens, or raw bridge payloads.
+- Preserve all existing slash-command UI notifications.
+- Forward actual shared-handler outcomes for `status`, `enable`, and `disable`.
+- Preserve issue #128's early `open` launch acknowledgement and exactly-once reply behavior.
+- Keep non-xAI disable semantics: remove only the requested authorization and preserve others.
+- Never log raw bridge payloads, credentials, or authenticated state.
 
 ## Must not
 
-- Change slash-command `/xai-tools` interactive behavior for humans typing the command.
-- Widen scope into vision routing, OAuth, catalog, or unrelated tools.
-- Skip error handling on OAuth refresh (N/A here; do not regress elsewhere).
+- Re-await picker close before acknowledging `open`.
+- Expand into issue #130's full bridge matrix or issue #131's cross-package documentation.
+- Change OAuth, catalog, transport, or unrelated tool behavior.

--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -1,22 +1,20 @@
-# Shared Agent Context — Issue #128
+# Shared Agent Context — Issue #129
 
-**Issue:** <https://github.com/BlockedPath/pi-xai-oauth/issues/128>
-**Linear:** [BLO-11](https://linear.app/blockedpath/issue/BLO-11/gh-128-menu-bridge-open-waits-for-picker-close-before-done-4s-false)
-**Series:** [BLO-10](https://linear.app/blockedpath/issue/BLO-10/pi-xai-oauth-menu-bridge-hardening-series-github-128-131) / GitHub #128–#131
-**Branch:** `fix/128-menu-bridge-picker-timeout`
+**Issue:** <https://github.com/BlockedPath/pi-xai-oauth/issues/129>
+**Linear:** [BLO-12](https://linear.app/blockedpath/issue/BLO-12/gh-129-menu-bridge-replies-oktrue-even-when-handlexaitoolsargs)
+**Series:** BLO-10 / GitHub #128–#131
+**Branch:** `fix/129-menu-bridge-honest-ok`
 
 ## Problem
 
-`registerXaiToolsCommand` listens on `pi-clickable-menu:xai-tools`. For `action: "open"` it awaited `handleXaiToolsArgs` / `showXaiToolPicker` and only then called `done({ ok: true })`. `pi-clickable-menu` treats a missing `done` within ~4 seconds as bridge failure, so users who keep the picker open get a false “No xAI tools bridge response” error.
+`handleXaiToolsArgs` reported ordinary rejections only through `ctx.ui.notify` and returned `void`. The menu bridge therefore replied `{ ok: true }` after invalid tools, non-xAI enables, registry failures, or unavailable vision routing.
 
 ## Fix
 
-Validate launch (active xAI model + `hasUI`), `reply({ ok: true })`, then await `showXaiToolPicker` without holding `done`. Post-launch picker errors notify only.
+Return a small shared command result and pass it unchanged to bridge `done` for `status`, `enable`, and `disable`. Keep slash-command notifications and issue #128's prevalidated, early `open` acknowledgement unchanged.
 
-## Follow-ups (out of scope)
+## Focus
 
-| Issue | Topic |
-| --- | --- |
-| #129 | Forward real success/failure through `done` for status/enable/disable |
-| #130 | Expand bridge unit coverage |
-| #131 | Document/share bridge contract |
+- Production: `extensions/xai/tools/commands.ts`
+- Regressions: `tests/tools/commands.test.ts`
+- Release note: `CHANGELOG.md`

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,22 +1,22 @@
-# Implementation Plan — Issue #128: Menu bridge open ack before picker close
+# Implementation Plan — Issue #129: Honest menu bridge results
 
-**Branch:** `fix/128-menu-bridge-picker-timeout`
+**Branch:** `fix/129-menu-bridge-honest-ok`
 **Base:** `origin/main`
 
 ## Goal
 
-Stop the `pi-clickable-menu:xai-tools` bridge from awaiting interactive picker close before `done({ ok: true })`, which false-triggers the menu host’s ~4s timeout.
+Make `pi-clickable-menu:xai-tools` return the actual shared command result for `status`, `enable`, and `disable`, while preserving issue #128's early `open` launch acknowledgement.
 
 ## Phases
 
-1. [x] Confirm issue scope (#128 only; #129–#131 follow in series order).
-2. [x] Ack `open` on launch after pre-validation (active xAI model + UI), then await picker without holding `done`.
-3. [x] Add regression: `done` resolves while a held picker is still open; reject open with no model.
-4. [x] CHANGELOG + focused Vitest for `tests/tools/commands.test.ts`.
+1. [x] Map every shared-handler success and failure branch.
+2. [x] Return a structured `{ ok, error? }` result while preserving slash-command notifications.
+3. [x] Forward handler results through bridge `done` and add focused rejection regressions.
+4. [x] Run full tests, typecheck, diagnostics, exact Pi boundaries, and independent review.
 
 ## Validation Contract
 
-- `action: "open"` calls `done` when the picker is accepted for launch, not after close.
-- Missing xAI model / missing UI still reply failure before any interactive wait.
-- Post-launch picker errors notify in-UI only (do not re-call `done`).
-- Focused tools command tests pass.
+- Invalid tools, non-xAI enables, registry failures, and unavailable vision routing reply `ok: false`.
+- Successful status/enable/disable requests reply `ok: true`.
+- `open` still acknowledges accepted launch before picker close; post-launch picker failures remain UI-only.
+- Disabling outside an xAI model preserves unrelated tool authorizations.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,14 +1,18 @@
-# Execution Progress — Issue #128
+# Execution Progress — Issue #129
 
-**Branch:** `fix/128-menu-bridge-picker-timeout`
-**PR:** https://github.com/BlockedPath/pi-xai-oauth/pull/137
+**Branch:** `fix/129-menu-bridge-honest-ok`
+**Issue:** https://github.com/BlockedPath/pi-xai-oauth/issues/129
+**Linear:** BLO-12
 
 ## Completed
 
-- [x] Bridge `open`: ack on launch after model/UI validation; await picker without holding `done`.
-- [x] Regressions: ack-before-picker-close; reject open with no xAI model.
-- [x] Adopted Pi **0.81.1** as `policy.latest` after clean packed `--candidate` (unblocks CI registry gate vs 0.81.0).
-- [x] `npm run compatibility:check`, `npm test` (495), `npm run typecheck` passed on tip.
+- [x] Read GitHub/Linear issue context and confirmed #128 is merged.
+- [x] Mapped handler, model-scope, vision-routing, bridge, and fixture behavior.
+- [x] Added structured shared-handler outcomes and honest bridge forwarding.
+- [x] Added regressions for invalid tools, non-xAI enable, unavailable vision routing, empty tool, and disable registry failures.
+- [x] Focused command tests pass (22); full suite passes (44 files, 500 tests); loader and TypeScript checks pass.
+- [x] Compatibility policy/pack checks and exact Pi 0.80.1 / 0.81.1 packed boundaries pass (0.81.1 passed on retry after one unrelated credential-test timeout).
+- [x] Fresh independent review found no production fixes; broader success-path bridge coverage remains in issue #130.
 
 ## In Progress
 
@@ -16,4 +20,4 @@
 
 ## Delivery
 
-- PR #137 closes #128; includes 0.81.1 boundary pin required for policy CI.
+Implementation and validation are complete; the branch is ready for commit/PR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 
 ### Fixed
 
+- Fixed the `pi-clickable-menu:xai-tools` bridge so `status`, `enable`, and `disable` return the shared command handler's actual success or failure instead of acknowledging toast-only failures as successful.
 - Fixed the `pi-clickable-menu:xai-tools` bridge so `action: "open"` acknowledges `done` when the interactive picker is accepted for launch, instead of waiting until the picker closes (avoids the menu host's ~4s false timeout).
 - Consolidated duplicate `xai_web_search` and Grok-native `web_search` registrations into one collision-safe, opt-in `web_search` picker entry. The old `xai_web_search` command spelling remains an input-only compatibility alias, and the public name is still never registered globally.
 - Contained the direct Grok-native `read_file`, `search_replace`, and `list_dir` adapters to resolved workspace paths, safely limited missing-leaf creation to contained physical parents, and capped package-owned full text reads at 5,000,000 bytes. `run_terminal_command` remains an unrestricted delegation to pi `bash`, so this is direct-adapter defense-in-depth rather than a filesystem sandbox.

--- a/extensions/xai/tools/commands.ts
+++ b/extensions/xai/tools/commands.ts
@@ -49,6 +49,8 @@ const XAI_TOOLS_USAGE =
 /** Event channel used by pi-clickable-menu (and other extensions) to drive /xai-tools. */
 export const XAI_TOOLS_MENU_CHANNEL = "pi-clickable-menu:xai-tools";
 
+type XaiToolsCommandResult = { ok: true } | { ok: false; error: string };
+
 function commandToolName(value: string | undefined): XaiNetworkToolName | undefined {
   if (!value) return undefined;
   const normalized = value.toLowerCase();
@@ -114,6 +116,36 @@ function notifyUpdate(
       : `Disabled ${displayName}.`,
     active ? "warning" : "info",
   );
+}
+
+function handleVisionRoutingUpdate(
+  visionRouting: XaiVisionRoutingController | undefined,
+  action: "enable" | "disable",
+  model: Model<Api> | undefined,
+  ctx: ExtensionCommandContext,
+): XaiToolsCommandResult {
+  if (!visionRouting) {
+    const error = "xAI vision routing is unavailable.";
+    ctx.ui.notify(error, "error");
+    return { ok: false, error };
+  }
+
+  const result = action === "enable" ? visionRouting.enable(model) : visionRouting.disable();
+  if (result.state === "enabled") {
+    ctx.ui.notify(
+      `Enabled vision routing for this xAI session: images are sent to ${result.targetModelId} in a separate authenticated request that may consume additional usage or credits; its generated description becomes sensitive session content. No cross-request image or description cache is created.`,
+      "warning",
+    );
+    return { ok: true };
+  }
+  if (action === "disable") {
+    ctx.ui.notify("Disabled vision routing.", "info");
+    return { ok: true };
+  }
+
+  const error = result.reason ?? "xAI vision routing is unavailable.";
+  ctx.ui.notify(error, "error");
+  return { ok: false, error };
 }
 
 async function showXaiToolSelectLoop(
@@ -237,16 +269,18 @@ async function showXaiToolPicker(
   pi: ExtensionAPI,
   ctx: ExtensionCommandContext,
   model: Model<Api>,
-) {
+): Promise<XaiToolsCommandResult> {
   if (!ctx.hasUI) {
-    ctx.ui.notify(`${XAI_TOOLS_USAGE} Interactive selection requires TUI or RPC mode.`, "error");
-    return;
+    const error = `${XAI_TOOLS_USAGE} Interactive selection requires TUI or RPC mode.`;
+    ctx.ui.notify(error, "error");
+    return { ok: false, error };
   }
   if (ctx.mode === "tui") {
     await showXaiToolTuiPicker(pi, ctx, model);
-    return;
+    return { ok: true };
   }
   await showXaiToolSelectLoop(pi, ctx, model);
+  return { ok: true };
 }
 
 /** Shared /xai-tools argument handler (slash command + menu bridge). */
@@ -255,17 +289,17 @@ async function handleXaiToolsArgs(
 	visionRouting: XaiVisionRoutingController | undefined,
 	args: string,
 	ctx: ExtensionCommandContext,
-): Promise<void> {
+): Promise<XaiToolsCommandResult> {
 	const [action, rawToolName, ...extra] = args.trim().split(/\s+/).filter(Boolean);
 	const model = activeXaiModel(ctx);
 
 	if (!action) {
 		if (!model) {
-			ctx.ui.notify("Select an xAI/Grok model before opening /xai-tools.", "error");
-			return;
+			const error = "Select an xAI/Grok model before opening /xai-tools.";
+			ctx.ui.notify(error, "error");
+			return { ok: false, error };
 		}
-		await showXaiToolPicker(pi, ctx, model);
-		return;
+		return showXaiToolPicker(pi, ctx, model);
 	}
 
 	if (action.toLowerCase() === "status" && !rawToolName) {
@@ -273,7 +307,7 @@ async function handleXaiToolsArgs(
 			`xAI API tools${model ? ` for ${model.id}` : " (no active xAI model)"}: ${activeToolStatus(pi, visionRouting, model)}`,
 			"info",
 		);
-		return;
+		return { ok: true };
 	}
 
 	const normalizedAction = action.toLowerCase();
@@ -283,23 +317,7 @@ async function handleXaiToolsArgs(
 		(normalizedAction === "enable" || normalizedAction === "disable") &&
 		extra.length === 0
 	) {
-		if (!visionRouting) {
-			ctx.ui.notify("xAI vision routing is unavailable.", "error");
-			return;
-		}
-		const result =
-			normalizedAction === "enable" ? visionRouting.enable(model) : visionRouting.disable();
-		if (result.state === "enabled") {
-			ctx.ui.notify(
-				`Enabled vision routing for this xAI session: images are sent to ${result.targetModelId} in a separate authenticated request that may consume additional usage or credits; its generated description becomes sensitive session content. No cross-request image or description cache is created.`,
-				"warning",
-			);
-		} else if (normalizedAction === "disable") {
-			ctx.ui.notify("Disabled vision routing.", "info");
-		} else {
-			ctx.ui.notify(result.reason ?? "xAI vision routing is unavailable.", "error");
-		}
-		return;
+		return handleVisionRoutingUpdate(visionRouting, normalizedAction, model, ctx);
 	}
 
 	const toolName = commandToolName(rawToolName);
@@ -309,7 +327,7 @@ async function handleXaiToolsArgs(
 		extra.length > 0
 	) {
 		ctx.ui.notify(XAI_TOOLS_USAGE, "error");
-		return;
+		return { ok: false, error: XAI_TOOLS_USAGE };
 	}
 
 	const result = setXaiNetworkToolActive(
@@ -318,7 +336,13 @@ async function handleXaiToolsArgs(
 		toolName,
 		normalizedAction === "enable",
 	);
-	notifyUpdate(ctx, toolName, result.active, result.error);
+	if (result.ok) {
+		notifyUpdate(ctx, toolName, result.active);
+		return { ok: true };
+	}
+	const error = result.error ?? "The xAI tool request failed.";
+	notifyUpdate(ctx, toolName, result.active, error);
+	return { ok: false, error };
 }
 
 type XaiToolsMenuRequest = {
@@ -401,8 +425,8 @@ export function registerXaiToolsCommand(
 				return;
 			}
 			if (action === "status") {
-				await handleXaiToolsArgs(pi, visionRouting, "status", ctx);
-				reply({ ok: true });
+				const result = await handleXaiToolsArgs(pi, visionRouting, "status", ctx);
+				reply(result);
 				return;
 			}
 			if (action === "enable" || action === "disable") {
@@ -411,8 +435,8 @@ export function registerXaiToolsCommand(
 					reply({ ok: false, error: "xAI tools bridge enable/disable requires tool." });
 					return;
 				}
-				await handleXaiToolsArgs(pi, visionRouting, `${action} ${tool}`, ctx);
-				reply({ ok: true });
+				const result = await handleXaiToolsArgs(pi, visionRouting, `${action} ${tool}`, ctx);
+				reply(result);
 				return;
 			}
 			reply({ ok: false, error: `Unknown xAI tools bridge action: ${action}` });

--- a/tests/tools/commands.test.ts
+++ b/tests/tools/commands.test.ts
@@ -35,6 +35,15 @@ function setup() {
   return { h, notices, run };
 }
 
+function emitMenuRequest(
+  h: ReturnType<typeof createExtensionHarness>,
+  request: Record<string, unknown>,
+): Promise<{ ok: boolean; error?: string }> {
+  return new Promise((resolve) => {
+    h.api.events.emit(XAI_TOOLS_MENU_CHANNEL, { ...request, done: resolve });
+  });
+}
+
 describe("/xai-tools command", () => {
   it("enables vision routing as transport policy without registering an active tool", async () => {
     const h = createExtensionHarness();
@@ -330,6 +339,65 @@ describe("/xai-tools command", () => {
     expect(result).toEqual({ ok: true });
     expect(isXaiNetworkToolActive(h.api, "xai_generate_image")).toBe(true);
     expect(notices.at(-1).message).toMatch(/may use xAI credits/);
+  });
+
+  it.each([
+    ["an unknown tool", "not_a_tool", TEST_MODEL, /Usage:/],
+    [
+      "a non-xAI model",
+      "xai_generate_image",
+      { provider: "anthropic", id: "claude" },
+      /Select an xAI\/Grok model/,
+    ],
+    ["unavailable vision routing", "vision-routing", TEST_MODEL, /vision routing is unavailable/i],
+  ])("reports menu bridge failure for %s", async (_case, tool, model, errorPattern) => {
+    const { h, notices } = setup();
+    const result = await emitMenuRequest(h, {
+      action: "enable",
+      tool,
+      ctx: commandContext(model, notices),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(errorPattern);
+    expect(notices.at(-1).message).toMatch(errorPattern);
+  });
+
+  it("reports menu bridge registry failures when disabling a tool", async () => {
+    const { h, notices, run } = setup();
+    await run("enable xai_generate_image");
+
+    for (const failure of [
+      { registry: { get: true }, error: /could not be read/ },
+      { registry: { set: true }, error: /could not be updated/ },
+    ]) {
+      h.failRegistry(failure.registry);
+      const result = await emitMenuRequest(h, {
+        action: "disable",
+        tool: "xai_generate_image",
+        ctx: commandContext(TEST_MODEL, notices),
+      });
+      h.failRegistry();
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(failure.error);
+      expect(notices.at(-1).message).toMatch(failure.error);
+      expect(isXaiNetworkToolActive(h.api, "xai_generate_image")).toBe(true);
+    }
+  });
+
+  it("rejects a menu bridge enable or disable without a tool", async () => {
+    const { h, notices } = setup();
+    const result = await emitMenuRequest(h, {
+      action: "disable",
+      tool: " ",
+      ctx: commandContext(TEST_MODEL, notices),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "xAI tools bridge enable/disable requires tool.",
+    });
   });
 
   it("acknowledges menu bridge open before the interactive picker closes", async () => {


### PR DESCRIPTION
## Summary
- return structured success/failure results from the shared `/xai-tools` handler
- forward real outcomes through the clickable-menu bridge for `status`, `enable`, and `disable`
- preserve the early `open` launch acknowledgement introduced for #128
- cover invalid tools, non-xAI enables, unavailable vision routing, missing tools, and registry failures

## Validation
- `npm test` (44 files, 500 tests)
- `npm run typecheck`
- `npm run compatibility:check`
- `npm run compatibility:boundaries` (Pi 0.80.1 and 0.81.1)
- independent reviewer pass

Closes #129
