### PR TITLE
test(tools): expand menu bridge coverage

### DIFF
--- a/.scaffold/constraints.md
+++ b/.scaffold/constraints.md
@@ -1,20 +1,20 @@
-# Constraints & Safety Rules — Issue #129
+# Constraints & Safety Rules — Issue #130
 
 ## Scope
 
-- Fix truthful `done` results for the existing xAI tools menu bridge.
-- Limit production changes to `extensions/xai/tools/commands.ts`; add focused tests and release/state notes.
+- Expand unit coverage for the existing `pi-clickable-menu:xai-tools` bridge.
+- Limit changes to command tests, the bridge registration implementation when correctness requires it, and persistent state notes.
 
 ## Must
 
-- Preserve all existing slash-command UI notifications.
-- Forward actual shared-handler outcomes for `status`, `enable`, and `disable`.
-- Preserve issue #128's early `open` launch acknowledgement and exactly-once reply behavior.
-- Keep non-xAI disable semantics: remove only the requested authorization and preserve others.
+- Preserve issue #128's early `open` acknowledgement before picker closure.
+- Preserve issue #129's honest `done` results for status, enable, disable, and failures.
+- Isolate throwing host callbacks and avoid duplicate handling after same-API registration.
+- Keep slash-command behavior and UI notifications unchanged.
 - Never log raw bridge payloads, credentials, or authenticated state.
 
 ## Must not
 
-- Re-await picker close before acknowledging `open`.
-- Expand into issue #130's full bridge matrix or issue #131's cross-package documentation.
-- Change OAuth, catalog, transport, or unrelated tool behavior.
+- Work on GitHub #131 documentation or #132 built-in-tool changes.
+- Change OAuth, catalog, transport, routing, or unrelated tool behavior.
+- Add broad fixture behavior when the existing event bus already models the contract.

--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -1,20 +1,20 @@
-# Shared Agent Context — Issue #129
+# Shared Agent Context — Issue #130
 
-**Issue:** <https://github.com/BlockedPath/pi-xai-oauth/issues/129>
-**Linear:** [BLO-12](https://linear.app/blockedpath/issue/BLO-12/gh-129-menu-bridge-replies-oktrue-even-when-handlexaitoolsargs)
+**Issue:** <https://github.com/BlockedPath/pi-xai-oauth/issues/130>
+**Linear:** [BLO-13](https://linear.app/blockedpath/issue/BLO-13/gh-130-expand-bridge-unit-coverage-openstatusdisableinvalid-tooldouble)
 **Series:** BLO-10 / GitHub #128–#131
-**Branch:** `fix/129-menu-bridge-honest-ok`
+**Branch:** `test/130-bridge-unit-coverage`
 
 ## Problem
 
-`handleXaiToolsArgs` reported ordinary rejections only through `ctx.ui.notify` and returned `void`. The menu bridge therefore replied `{ ok: true }` after invalid tools, non-xAI enables, registry failures, or unavailable vision routing.
+The bridge contract fixes are merged, but success/default/error and callback-lifecycle branches remain incompletely covered. Repeated `registerXaiToolsCommand` calls also retain the old event listener and can double-handle one request.
 
-## Fix
+## Approach
 
-Return a small shared command result and pass it unchanged to bridge `done` for `status`, `enable`, and `disable`. Keep slash-command notifications and issue #128's prevalidated, early `open` acknowledgement unchanged.
+Add focused bridge tests for omitted/explicit open, status, disable, empty and invalid tools, unknown action, callback throw isolation, and repeated registration. Preserve issue #128's early open acknowledgement and issue #129's honest result forwarding; replace any prior same-API bridge listener during re-registration.
 
 ## Focus
 
-- Production: `extensions/xai/tools/commands.ts`
+- Production: `extensions/xai/tools/commands.ts` only if required for repeated-registration correctness
 - Regressions: `tests/tools/commands.test.ts`
-- Release note: `CHANGELOG.md`
+- Fixture: `tests/fixtures/extension-api.ts` only if existing multi-listener support proves insufficient

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -13,7 +13,7 @@ Expand the `pi-clickable-menu:xai-tools` bridge regression matrix after issues #
 2. [x] Define focused cases for default/explicit open, status, disable, empty and invalid tools, unknown actions, throwing callbacks, and repeated registration.
 3. [x] Add the regression matrix and the smallest production fix required for single-listener re-registration.
 4. [x] Run focused tests, typecheck, full gates, exact Pi boundaries, diagnostics, and independent review.
-5. [ ] Commit and open a PR that closes GitHub #130.
+5. [x] Commit and open a PR that closes GitHub #130.
 
 ## Validation Contract
 

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,22 +1,25 @@
-# Implementation Plan — Issue #129: Honest menu bridge results
+# Implementation Plan — Issue #130: Bridge unit coverage
 
-**Branch:** `fix/129-menu-bridge-honest-ok`
+**Branch:** `test/130-bridge-unit-coverage`
 **Base:** `origin/main`
 
 ## Goal
 
-Make `pi-clickable-menu:xai-tools` return the actual shared command result for `status`, `enable`, and `disable`, while preserving issue #128's early `open` launch acknowledgement.
+Expand the `pi-clickable-menu:xai-tools` bridge regression matrix after issues #128 and #129, preserving early truthful acknowledgements and preventing repeated registration from double-handling requests.
 
 ## Phases
 
-1. [x] Map every shared-handler success and failure branch.
-2. [x] Return a structured `{ ok, error? }` result while preserving slash-command notifications.
-3. [x] Forward handler results through bridge `done` and add focused rejection regressions.
-4. [x] Run full tests, typecheck, diagnostics, exact Pi boundaries, and independent review.
+1. [x] Inspect the merged bridge contract, current tests, fixture event bus, and GitHub issue.
+2. [x] Define focused cases for default/explicit open, status, disable, empty and invalid tools, unknown actions, throwing callbacks, and repeated registration.
+3. [x] Add the regression matrix and the smallest production fix required for single-listener re-registration.
+4. [x] Run focused tests, typecheck, full gates, exact Pi boundaries, diagnostics, and independent review.
+5. [ ] Commit and open a PR that closes GitHub #130.
 
 ## Validation Contract
 
-- Invalid tools, non-xAI enables, registry failures, and unavailable vision routing reply `ok: false`.
-- Successful status/enable/disable requests reply `ok: true`.
-- `open` still acknowledges accepted launch before picker close; post-launch picker failures remain UI-only.
+- Omitted and explicit `open` reply `{ ok: true }` before the picker closes.
+- `status`, enable, and disable report their honest results and expected UI notifications.
+- Empty/invalid tools and unknown actions reply `{ ok: false }`.
+- A throwing `done` callback cannot escape or prevent accepted picker launch.
+- Re-registering on the same ExtensionAPI replaces the prior bridge listener instead of double-handling.
 - Disabling outside an xAI model preserves unrelated tool authorizations.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,23 +1,27 @@
-# Execution Progress — Issue #129
+# Execution Progress — Issue #130
 
-**Branch:** `fix/129-menu-bridge-honest-ok`
-**Issue:** https://github.com/BlockedPath/pi-xai-oauth/issues/129
-**Linear:** BLO-12
+**Branch:** `test/130-bridge-unit-coverage`
+**Issue:** https://github.com/BlockedPath/pi-xai-oauth/issues/130
+**Linear:** BLO-13
 
 ## Completed
 
-- [x] Read GitHub/Linear issue context and confirmed #128 is merged.
-- [x] Mapped handler, model-scope, vision-routing, bridge, and fixture behavior.
-- [x] Added structured shared-handler outcomes and honest bridge forwarding.
-- [x] Added regressions for invalid tools, non-xAI enable, unavailable vision routing, empty tool, and disable registry failures.
-- [x] Focused command tests pass (22); full suite passes (44 files, 500 tests); loader and TypeScript checks pass.
-- [x] Compatibility policy/pack checks and exact Pi 0.80.1 / 0.81.1 packed boundaries pass (0.81.1 passed on retry after one unrelated credential-test timeout).
-- [x] Fresh independent review found no production fixes; broader success-path bridge coverage remains in issue #130.
+- [x] Confirmed the branch starts at current `origin/main` with #128 and #129 merged.
+- [x] Read the bridge implementation, command tests, extension fixture, and issue requirements.
+- [x] Ran parallel scout/reviewer recon and mapped every requested case.
+- [x] Installed locked dependencies and confirmed the existing 22 focused tests pass.
+- [x] Captured the focused baseline: 84% statements, 76.47% branches, and 87.02% lines for `commands.ts`.
+- [x] Added all requested bridge cases: default/explicit open, status, disable, empty/invalid tools, unknown action, throwing `done`, and repeated registration.
+- [x] Replaced prior same-API bridge subscriptions during registration to prevent duplicate handling.
+- [x] Focused suite passes (30 tests); focused `commands.ts` coverage rose to 86.34% statements, 78.7% branches, and 89.47% lines.
+- [x] Full suite passes (44 files, 508 tests), loader smoke passes, and TypeScript reports no errors.
+- [x] Compatibility policy/pack checks and exact Pi 0.80.1 / 0.81.1 packed boundaries pass.
+- [x] Diagnostics have no blocking errors; two fresh independent reviewers found no fixes worth doing.
 
 ## In Progress
 
-- None.
+- [ ] Commit the green changes and open a PR closing GitHub #130.
 
-## Delivery
+## Next
 
-Implementation and validation are complete; the branch is ready for commit/PR.
+Commit the validated changes, push this branch, and open the closing PR.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -20,8 +20,10 @@
 
 ## In Progress
 
-- [ ] Commit the green changes and open a PR closing GitHub #130.
+- None.
 
-## Next
+## Delivery
 
-Commit the validated changes, push this branch, and open the closing PR.
+- Commit: `643cfc7` (`test(tools): expand menu bridge coverage`)
+- Pull request: https://github.com/BlockedPath/pi-xai-oauth/pull/139
+- PR body closes GitHub #130.

--- a/extensions/xai/tools/commands.ts
+++ b/extensions/xai/tools/commands.ts
@@ -49,6 +49,8 @@ const XAI_TOOLS_USAGE =
 /** Event channel used by pi-clickable-menu (and other extensions) to drive /xai-tools. */
 export const XAI_TOOLS_MENU_CHANNEL = "pi-clickable-menu:xai-tools";
 
+const xaiToolsMenuUnsubscribeByApi = new WeakMap<ExtensionAPI, () => void>();
+
 type XaiToolsCommandResult = { ok: true } | { ok: false; error: string };
 
 function commandToolName(value: string | undefined): XaiNetworkToolName | undefined {
@@ -371,9 +373,11 @@ export function registerXaiToolsCommand(
 		pi.events && typeof pi.events.on === "function"
 			? pi.events.on.bind(pi.events)
 			: null;
+	xaiToolsMenuUnsubscribeByApi.get(pi)?.();
+	xaiToolsMenuUnsubscribeByApi.delete(pi);
 	if (!on) return;
 
-	on(XAI_TOOLS_MENU_CHANNEL, async (raw) => {
+	const unsubscribe = on(XAI_TOOLS_MENU_CHANNEL, async (raw) => {
 		const data = (raw ?? {}) as XaiToolsMenuRequest;
 		const reply = (result: { ok: boolean; error?: string }) => {
 			try {
@@ -445,4 +449,7 @@ export function registerXaiToolsCommand(
 			reply({ ok: false, error: message });
 		}
 	});
+	if (typeof unsubscribe === "function") {
+		xaiToolsMenuUnsubscribeByApi.set(pi, unsubscribe);
+	}
 }

--- a/tests/tools/commands.test.ts
+++ b/tests/tools/commands.test.ts
@@ -327,18 +327,48 @@ describe("/xai-tools command", () => {
     expect(typeof h.api.events.on).toBe("function");
     expect(typeof h.api.events.emit).toBe("function");
 
-    const result = await new Promise<{ ok: boolean; error?: string }>((resolve) => {
-      h.api.events.emit(XAI_TOOLS_MENU_CHANNEL, {
-        action: "enable",
-        tool: "xai_generate_image",
-        ctx: commandContext(TEST_MODEL, notices),
-        done: resolve,
-      });
+    const result = await emitMenuRequest(h, {
+      action: "enable",
+      tool: "xai_generate_image",
+      ctx: commandContext(TEST_MODEL, notices),
     });
 
     expect(result).toEqual({ ok: true });
     expect(isXaiNetworkToolActive(h.api, "xai_generate_image")).toBe(true);
     expect(notices.at(-1).message).toMatch(/may use xAI credits/);
+  });
+
+  it("reports status through the menu bridge notification path", async () => {
+    const { h, notices } = setup();
+
+    const result = await emitMenuRequest(h, {
+      action: "status",
+      ctx: commandContext(TEST_MODEL, notices),
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(notices).toEqual([
+      {
+        message: expect.stringMatching(/^xAI API tools for grok-4\.5:/),
+        type: "info",
+      },
+    ]);
+  });
+
+  it("disables an enabled tool through the menu bridge", async () => {
+    const { h, notices, run } = setup();
+    await run("enable xai_generate_image");
+    notices.length = 0;
+
+    const result = await emitMenuRequest(h, {
+      action: "disable",
+      tool: "xai_generate_image",
+      ctx: commandContext(TEST_MODEL, notices),
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(isXaiNetworkToolActive(h.api, "xai_generate_image")).toBe(false);
+    expect(notices).toEqual([{ message: "Disabled xai_generate_image.", type: "info" }]);
   });
 
   it.each([
@@ -386,11 +416,15 @@ describe("/xai-tools command", () => {
     }
   });
 
-  it("rejects a menu bridge enable or disable without a tool", async () => {
+  it.each([
+    ["enable with an omitted tool", "enable", undefined],
+    ["disable with an empty tool", "disable", ""],
+    ["enable with a whitespace-only tool", "enable", " "],
+  ])("rejects a menu bridge %s", async (_case, action, tool) => {
     const { h, notices } = setup();
     const result = await emitMenuRequest(h, {
-      action: "disable",
-      tool: " ",
+      action,
+      tool,
       ctx: commandContext(TEST_MODEL, notices),
     });
 
@@ -398,19 +432,28 @@ describe("/xai-tools command", () => {
       ok: false,
       error: "xAI tools bridge enable/disable requires tool.",
     });
+    expect(notices).toEqual([]);
   });
 
-  it("acknowledges menu bridge open before the interactive picker closes", async () => {
+  it.each([
+    ["omitted action", undefined],
+    ["explicit open", "open"],
+  ])("acknowledges menu bridge %s before the interactive picker closes", async (_case, action) => {
     const { h, notices } = setup();
     let releasePicker!: () => void;
     const pickerHeldOpen = new Promise<void>((resolve) => {
       releasePicker = resolve;
     });
+    let finishPicker!: () => void;
+    const pickerFinished = new Promise<void>((resolve) => {
+      finishPicker = resolve;
+    });
     let pickerClosed = false;
+    const replies: Array<{ ok: boolean; error?: string }> = [];
 
-    const result = await new Promise<{ ok: boolean; error?: string }>((resolve) => {
+    const reply = new Promise<{ ok: boolean; error?: string }>((resolve) => {
       h.api.events.emit(XAI_TOOLS_MENU_CHANNEL, {
-        action: "open",
+        ...(action === undefined ? {} : { action }),
         ctx: commandContext(TEST_MODEL, notices, {
           ui: {
             notify(message: string, type?: string) {
@@ -420,17 +463,72 @@ describe("/xai-tools command", () => {
             custom: async () => {
               await pickerHeldOpen;
               pickerClosed = true;
+              finishPicker();
             },
           },
         }),
-        done: resolve,
+        done(result: { ok: boolean; error?: string }) {
+          replies.push(result);
+          resolve(result);
+        },
       });
     });
 
-    // done must win before the held picker finishes (menu host ~4s timeout).
-    expect(result).toEqual({ ok: true });
+    // done must win before the held picker finishes (menu host timeout is ~4s).
+    await expect(reply).resolves.toEqual({ ok: true });
     expect(pickerClosed).toBe(false);
     releasePicker();
+    await pickerFinished;
+    await Promise.resolve();
+    expect(replies).toEqual([{ ok: true }]);
+  });
+
+  it("isolates a throwing done callback and still launches the accepted picker", async () => {
+    const { h, notices } = setup();
+    let doneCalls = 0;
+    let markPickerLaunched!: () => void;
+    const pickerLaunched = new Promise<void>((resolve) => {
+      markPickerLaunched = resolve;
+    });
+
+    expect(() => {
+      h.api.events.emit(XAI_TOOLS_MENU_CHANNEL, {
+        action: "open",
+        ctx: commandContext(TEST_MODEL, notices, {
+          ui: {
+            notify(message: string, type?: string) {
+              notices.push({ message, type });
+            },
+            select: async () => undefined,
+            custom: async () => {
+              markPickerLaunched();
+            },
+          },
+        }),
+        done() {
+          doneCalls++;
+          throw new Error("menu host closed");
+        },
+      });
+    }).not.toThrow();
+
+    await pickerLaunched;
+    expect(doneCalls).toBe(1);
+    expect(notices).toEqual([]);
+  });
+
+  it("rejects an unknown menu bridge action", async () => {
+    const { h, notices } = setup();
+    const result = await emitMenuRequest(h, {
+      action: "toggle",
+      ctx: commandContext(TEST_MODEL, notices),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Unknown xAI tools bridge action: toggle",
+    });
+    expect(notices).toEqual([]);
   });
 
   it("rejects menu bridge open when no xAI model is active", async () => {
@@ -457,6 +555,27 @@ describe("/xai-tools command", () => {
     });
     expect(result.ok).toBe(false);
     expect(result.error).toMatch(/command UI context/i);
+  });
+
+  it("replaces the prior menu bridge listener when registered twice", async () => {
+    const { h, notices } = setup();
+    registerXaiToolsCommand(h.api);
+    const replies: Array<{ ok: boolean; error?: string }> = [];
+
+    await new Promise<void>((resolve) => {
+      h.api.events.emit(XAI_TOOLS_MENU_CHANNEL, {
+        action: "status",
+        ctx: commandContext(TEST_MODEL, notices),
+        done(result: { ok: boolean; error?: string }) {
+          replies.push(result);
+        },
+      });
+      setImmediate(resolve);
+    });
+
+    expect(replies).toEqual([{ ok: true }]);
+    expect(notices).toHaveLength(1);
+    expect(notices[0]).toMatchObject({ type: "info" });
   });
 
   it("skips bridge registration when pi.events.on is missing", () => {


### PR DESCRIPTION
## Summary
- cover omitted and explicit `open` acknowledgements before picker closure
- cover bridge status, successful disable, empty and invalid tools, unknown actions, and throwing `done` callbacks
- replace prior same-API bridge subscriptions so repeated registration cannot double-handle one request

## Validation
- `npm run test:unit -- tests/tools/commands.test.ts` (30 tests)
- focused V8 coverage for `commands.ts`: 86.34% statements, 78.7% branches, 89.47% lines
- `npm run typecheck`
- `npm test` (44 files, 508 tests)
- `npm run compatibility:check`
- `npm run compatibility:boundaries` (Pi 0.80.1 and 0.81.1)
- independent parallel reviewer pass

Closes #130
