### PR TITLE
docs(tools): define xAI menu bridge contract

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -19,3 +19,4 @@ auth.json
 *.local
 pi-session-*.html
 cat.svg
+.agent-task.md

--- a/.scaffold/constraints.md
+++ b/.scaffold/constraints.md
@@ -1,20 +1,23 @@
-# Constraints & Safety Rules — Issue #130
+# Constraints & Safety Rules — Issue #131
 
 ## Scope
 
-- Expand unit coverage for the existing `pi-clickable-menu:xai-tools` bridge.
-- Limit changes to command tests, the bridge registration implementation when correctness requires it, and persistent state notes.
+- Document the listener-owned `pi-clickable-menu:xai-tools` protocol as v1.
+- Apply only the small malformed-payload hardening requested by #131.
+- Add focused tests, README linkage, release notes, and state updates.
 
 ## Must
 
-- Preserve issue #128's early `open` acknowledgement before picker closure.
-- Preserve issue #129's honest `done` results for status, enable, disable, and failures.
-- Isolate throwing host callbacks and avoid duplicate handling after same-API registration.
-- Keep slash-command behavior and UI notifications unchanged.
-- Never log raw bridge payloads, credentials, or authenticated state.
+- Keep `XAI_TOOLS_MENU_CHANNEL` as the single production source of truth.
+- Preserve issue #128's early `open` launch acknowledgement.
+- Preserve issue #129's honest `status`, `enable`, and `disable` outcomes.
+- Validate raw action, tool, context/UI, and callback fields before command dispatch.
+- Call a supplied callable `done` exactly once for every accepted or rejected request.
+- Keep errors bounded to safe human-readable messages; never reflect raw payloads or context.
 
 ## Must not
 
-- Work on GitHub #131 documentation or #132 built-in-tool changes.
-- Change OAuth, catalog, transport, routing, or unrelated tool behavior.
-- Add broad fixture behavior when the existing event bus already models the contract.
+- Add a separate shared-type package or require a new wire-version field.
+- Re-await picker close before acknowledging `open`.
+- Expand bridge behavior/coverage into issue #130 or built-in tool work in #132.
+- Change OAuth, catalog, transport, or unrelated tool behavior.

--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -1,20 +1,29 @@
-# Shared Agent Context — Issue #130
+# Shared Agent Context — Issue #131
 
-**Issue:** <https://github.com/BlockedPath/pi-xai-oauth/issues/130>
-**Linear:** [BLO-13](https://linear.app/blockedpath/issue/BLO-13/gh-130-expand-bridge-unit-coverage-openstatusdisableinvalid-tooldouble)
-**Series:** BLO-10 / GitHub #128–#131
-**Branch:** `test/130-bridge-unit-coverage`
+**Issue:** <https://github.com/BlockedPath/pi-xai-oauth/issues/131>
+**Branch:** `docs/131-bridge-contract`
+**Base:** current `origin/main` with #128 and #129 merged
 
 ## Problem
 
-The bridge contract fixes are merged, but success/default/error and callback-lifecycle branches remain incompletely covered. Repeated `registerXaiToolsCommand` calls also retain the old event listener and can double-handle one request.
+The cross-package `pi-clickable-menu:xai-tools` event contract is informal. The listener casts raw payloads directly, then calls `.toLowerCase()` on `action` outside its protected dispatch block. A non-string action can throw before a supplied `done` callback is invoked.
 
-## Approach
+## Existing behavior to preserve
 
-Add focused bridge tests for omitted/explicit open, status, disable, empty and invalid tools, unknown action, callback throw isolation, and repeated registration. Preserve issue #128's early open acknowledgement and issue #129's honest result forwarding; replace any prior same-API bridge listener during re-registration.
+- `XAI_TOOLS_MENU_CHANNEL` in `extensions/xai/tools/commands.ts` is exported and is the listener-owned channel source of truth.
+- `open` reports `{ ok: true }` when the picker is accepted for launch, not when it closes.
+- `status`, `enable`, and `disable` forward the shared command handler's actual success or failure.
 
-## Focus
+## Approved approach
 
-- Production: `extensions/xai/tools/commands.ts` only if required for repeated-registration correctness
-- Regressions: `tests/tools/commands.test.ts`
-- Fixture: `tests/fixtures/extension-api.ts` only if existing multi-listener support proves insufficient
+Add `docs/bridge-xai-tools.md` as protocol v1, link it from README, and state that v1 is a document/behavior revision rather than a wire `version` field. Validate raw object fields and required UI methods before dispatch. If a callable `done` is supplied, reply exactly once with a discriminated success/error result. Missing or non-callable `done` cannot be answered and must fail safely without dispatch.
+
+## Implemented
+
+- Production: `extensions/xai/tools/commands.ts` now validates the raw payload before dispatch and uses a once-only reply closure.
+- Regressions: `tests/tools/commands.test.ts` covers non-string action/tool fields, unusable UI context, missing callable `done`, and the stable channel literal.
+- Documentation: `docs/bridge-xai-tools.md`, `README.md`, and `CHANGELOG.md` define and link protocol v1.
+
+## Validation state
+
+`npm test`, `npm run typecheck`, and both exact packed compatibility boundaries pass. The full local suite reports 44 files and 508 tests. The package dry-run excludes `.agent-task.md`, final pi-lens session diagnostics have no blockers, and the final independent review is clean.

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,25 +1,25 @@
-# Implementation Plan — Issue #130: Bridge unit coverage
+# Implementation Plan — Issue #131: xAI tools bridge contract
 
-**Branch:** `test/130-bridge-unit-coverage`
+**Branch:** `docs/131-bridge-contract`
 **Base:** `origin/main`
 
 ## Goal
 
-Expand the `pi-clickable-menu:xai-tools` bridge regression matrix after issues #128 and #129, preserving early truthful acknowledgements and preventing repeated registration from double-handling requests.
+Publish the listener-owned v1 contract for `pi-clickable-menu:xai-tools` and close the malformed-payload gap without expanding into issues #130 or #132.
 
 ## Phases
 
-1. [x] Inspect the merged bridge contract, current tests, fixture event bus, and GitHub issue.
-2. [x] Define focused cases for default/explicit open, status, disable, empty and invalid tools, unknown actions, throwing callbacks, and repeated registration.
-3. [x] Add the regression matrix and the smallest production fix required for single-listener re-registration.
-4. [x] Run focused tests, typecheck, full gates, exact Pi boundaries, diagnostics, and independent review.
-5. [x] Commit and open a PR that closes GitHub #130.
+1. [x] Inspect issue #131, the listener, peer emitter, focused tests, and existing #128/#129 behavior.
+2. [x] Add a versioned bridge document and link it from the `/xai-tools` README section.
+3. [x] Validate raw request fields before dispatch and reply exactly once to malformed requests that provide a callable `done`.
+4. [x] Add focused malformed-payload regressions and update release notes/state.
+5. [x] Run focused tests, typecheck, full gates, exact compatibility boundaries, and independent review.
+6. [ ] Commit, push, and open a PR that closes #131.
 
 ## Validation Contract
 
-- Omitted and explicit `open` reply `{ ok: true }` before the picker closes.
-- `status`, enable, and disable report their honest results and expected UI notifications.
-- Empty/invalid tools and unknown actions reply `{ ok: false }`.
-- A throwing `done` callback cannot escape or prevent accepted picker launch.
-- Re-registering on the same ExtensionAPI replaces the prior bridge listener instead of double-handling.
-- Disabling outside an xAI model preserves unrelated tool authorizations.
+- `XAI_TOOLS_MENU_CHANNEL` remains the listener-owned source of truth.
+- Protocol v1 documents `action`, `tool`, `ctx`, and `done` without adding a wire-version field.
+- Non-string actions/tools and unusable contexts are rejected before dispatch; a callable `done` receives one `{ ok: false, error }` result.
+- `status`, `enable`, and `disable` return the shared handler's honest result.
+- `open` acknowledges accepted picker launch before picker close, with post-launch failures remaining UI-only.

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -14,7 +14,7 @@ Publish the listener-owned v1 contract for `pi-clickable-menu:xai-tools` and clo
 3. [x] Validate raw request fields before dispatch and reply exactly once to malformed requests that provide a callable `done`.
 4. [x] Add focused malformed-payload regressions and update release notes/state.
 5. [x] Run focused tests, typecheck, full gates, exact compatibility boundaries, and independent review.
-6. [ ] Commit, push, and open a PR that closes #131.
+6. [x] Commit, push, and open a PR that closes #131.
 
 ## Validation Contract
 

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,29 +1,30 @@
-# Execution Progress — Issue #130
+# Execution Progress — Issue #131
 
-**Branch:** `test/130-bridge-unit-coverage`
-**Issue:** https://github.com/BlockedPath/pi-xai-oauth/issues/130
-**Linear:** BLO-13
+**Branch:** `docs/131-bridge-contract`
+**Issue:** https://github.com/BlockedPath/pi-xai-oauth/issues/131
 
 ## Completed
 
-- [x] Confirmed the branch starts at current `origin/main` with #128 and #129 merged.
-- [x] Read the bridge implementation, command tests, extension fixture, and issue requirements.
-- [x] Ran parallel scout/reviewer recon and mapped every requested case.
-- [x] Installed locked dependencies and confirmed the existing 22 focused tests pass.
-- [x] Captured the focused baseline: 84% statements, 76.47% branches, and 87.02% lines for `commands.ts`.
-- [x] Added all requested bridge cases: default/explicit open, status, disable, empty/invalid tools, unknown action, throwing `done`, and repeated registration.
-- [x] Replaced prior same-API bridge subscriptions during registration to prevent duplicate handling.
-- [x] Focused suite passes (30 tests); focused `commands.ts` coverage rose to 86.34% statements, 78.7% branches, and 89.47% lines.
-- [x] Full suite passes (44 files, 508 tests), loader smoke passes, and TypeScript reports no errors.
-- [x] Compatibility policy/pack checks and exact Pi 0.80.1 / 0.81.1 packed boundaries pass.
-- [x] Diagnostics have no blocking errors; two fresh independent reviewers found no fixes worth doing.
+- [x] Read the task, issue, project guidance, entrypoint, setup, README, and prior scaffold state.
+- [x] Confirmed the branch is based on current `origin/main` with #128/#129 merged.
+- [x] Inspected the listener, peer emitter, focused tests, changelog, and documentation patterns.
+- [x] Ran parallel scout/reviewer analysis; both identified the non-string `action` path that can skip `done`.
+- [x] Chose a document-versioned v1 contract with no new wire field and the existing exported channel constant as source of truth.
+- [x] Added `docs/bridge-xai-tools.md`, README linkage, and Unreleased changelog notes.
+- [x] Added pre-dispatch validation for action, tool, command UI context, picker surface, and callable `done`.
+- [x] Added exactly-once replies and fail-safe no-dispatch behavior when no callable reply exists.
+- [x] Added malformed action/tool/UI/callback regressions and a channel-stability assertion.
+- [x] Focused command tests pass (30); TypeScript typecheck passes.
+- [x] Full policy/unit/loader gate passes (44 files, 508 tests).
+- [x] Exact packed Pi 0.80.1 and 0.81.1 compatibility boundaries pass.
+- [x] Package dry-run includes the protocol doc and excludes `.agent-task.md`.
+- [x] Final independent review reports no remaining blockers or fixes worth doing now.
+- [x] Final pi-lens session diagnostics report no blocking issues.
 
 ## In Progress
 
-- None.
+- [ ] Commit, push, and open the PR.
 
-## Delivery
+## Next
 
-- Commit: `643cfc7` (`test(tools): expand menu bridge coverage`)
-- Pull request: https://github.com/BlockedPath/pi-xai-oauth/pull/139
-- PR body closes GitHub #130.
+Commit the reviewed green diff and open a PR that closes #131.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -20,11 +20,9 @@
 - [x] Package dry-run includes the protocol doc and excludes `.agent-task.md`.
 - [x] Final independent review reports no remaining blockers or fixes worth doing now.
 - [x] Final pi-lens session diagnostics report no blocking issues.
+- [x] Committed and pushed the implementation on `docs/131-bridge-contract`.
+- [x] Opened PR #140 with `Closes #131`.
 
-## In Progress
+## Delivery
 
-- [ ] Commit, push, and open the PR.
-
-## Next
-
-Commit the reviewed green diff and open a PR that closes #131.
+PR: https://github.com/BlockedPath/pi-xai-oauth/pull/140

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 ### Added
 
 - Added disabled-by-default, session-scoped vision routing for exact authenticated text-only entitlements, with deterministic exact-catalog target selection, a bounded image-only description request, final image-free enforcement, lifecycle invalidation, and `/xai-tools` cost/privacy controls.
+- Added the listener-owned, versioned `pi-clickable-menu:xai-tools` bridge contract, covering its canonical channel, request shape, action timing, and honest result semantics.
 - Added disabled-by-default `xai_image_to_video` with pinned create/status polling, DNS-pinned unauthenticated MP4 download, bounded streamed private storage, and honest remote-job cancellation semantics.
 - Added ModelRuntime re-registration coverage, a store-backed models-store precedence regression (discard stale overlays when the local catalog is newer), and request-auth tests that prefer `ModelRuntime.getAuth` over the legacy `getApiKeyAndHeaders` projection.
 
@@ -23,6 +24,7 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 
 ### Fixed
 
+- Fixed the `pi-clickable-menu:xai-tools` bridge so malformed action, tool, and command-context fields are rejected before dispatch and every request with a callable `done` receives exactly one result.
 - Fixed the `pi-clickable-menu:xai-tools` bridge so `status`, `enable`, and `disable` return the shared command handler's actual success or failure instead of acknowledging toast-only failures as successful.
 - Fixed the `pi-clickable-menu:xai-tools` bridge so `action: "open"` acknowledges `done` when the interactive picker is accepted for launch, instead of waiting until the picker closes (avoids the menu host's ~4s false timeout).
 - Consolidated duplicate `xai_web_search` and Grok-native `web_search` registrations into one collision-safe, opt-in `web_search` picker entry. The old `xai_web_search` command spelling remains an input-only compatibility alias, and the public name is still never registered globally.

--- a/README.md
+++ b/README.md
@@ -462,6 +462,8 @@ The picker shows each tool's category and cost-risk context, warns that calls ma
 
 `vision-routing` is transport policy rather than a callable model tool, so it never enters Pi's active-tool registry. It appears only when exact authenticated capability evidence supports a text-only source and a separate text-and-image target. `web_search` appears once in the picker for any active xAI model (still opt-in); the older `xai_web_search` spelling remains accepted only as a backward-compatible `/xai-tools enable` or `disable` argument. `/xai-tools` is owned by this package; it does not depend on pi's optional example `/tools` extension.
 
+Extension authors that drive `/xai-tools` through `pi.events` must follow the listener-owned [xAI tools menu bridge protocol v1](docs/bridge-xai-tools.md), including its early `open` launch acknowledgement and honest success/error results.
+
 > **Tip:** See the ⚠️ warning above about local vs published package conflicts.
 
 ### `xai_generate_text`

--- a/docs/bridge-xai-tools.md
+++ b/docs/bridge-xai-tools.md
@@ -1,0 +1,118 @@
+# xAI tools menu bridge protocol v1
+
+This document defines version 1 of the in-process event bridge between
+`pi-clickable-menu` (or another Pi extension) and the `/xai-tools` command
+owned by `pi-xai-oauth`. `pi-xai-oauth` is the listener and owns this
+contract.
+
+Protocol v1 is a documentation and behavior version. There is no `version`
+field in the v1 request. A future incompatible protocol must be documented
+explicitly and use a distinguishable channel or version mechanism rather than
+silently changing this contract.
+
+## Channel and ownership
+
+The event channel is:
+
+```text
+pi-clickable-menu:xai-tools
+```
+
+The canonical source is the exported `XAI_TOOLS_MENU_CHANNEL` constant in
+[`extensions/xai/tools/commands.ts`][commands]. Listener code and this
+repository's tests must use that export. A peer package that cannot import this
+package without creating an unwanted dependency may repeat the documented
+literal, but must treat this listener-owned document and constant as
+authoritative. This contract does not require a separate shared package.
+
+The bridge is local, in-memory extension communication through `pi.events`.
+The request contains a live Pi command context and is not a JSON or
+cross-process protocol.
+
+## Request
+
+Emit one object on the channel:
+
+```ts
+type XaiToolsMenuRequestV1 = {
+  action?: "open" | "status" | "enable" | "disable";
+  tool?: string;
+  ctx: ExtensionCommandContext;
+  done: (result: XaiToolsMenuResultV1) => void;
+};
+```
+
+- `action` is an optional string. Omission defaults to `open` for
+  compatibility. Values are trimmed and matched case-insensitively; emitters
+  should send the lowercase values shown above.
+- `tool` is required as a non-empty string for `enable` and `disable`. It is
+  not used by `open` or `status`, and emitters should omit it for those
+  actions.
+- `ctx` is the required live `ExtensionCommandContext` from the menu host. It
+  must expose `ui.notify`; `open` also requires an interactive TUI or RPC
+  picker surface.
+- `done` is a required callback. The listener calls it once for every accepted
+  or rejected request that supplies a callable callback.
+
+The listener validates raw fields before command dispatch. Malformed actions,
+tools, or contexts return an error through a callable `done` and do not change
+tool state. A request with a missing or non-callable `done` cannot be
+acknowledged, so the listener ignores it without dispatching or throwing
+through the shared event bus.
+
+Example:
+
+```ts
+pi.events.emit("pi-clickable-menu:xai-tools", {
+  action: "enable",
+  tool: "web_search",
+  ctx,
+  done: (result) => {
+    if (!result.ok) ctx.ui.notify(result.error, "error");
+  },
+});
+```
+
+## Actions
+
+- `open` validates that an xAI model and interactive UI are available,
+  acknowledges launch, and then opens the package-owned picker.
+- `status` displays the current session-scoped xAI tool state through the
+  supplied command context.
+- `enable` enables one supported `/xai-tools` target for the current session.
+- `disable` disables one supported `/xai-tools` target for the current session.
+
+Tool names and eligibility are owned by `/xai-tools`; bridge consumers must not
+maintain an independent entitlement or activation model. Unknown actions or
+unsupported tool names are rejected.
+
+## Result
+
+```ts
+type XaiToolsMenuResultV1 =
+  | { ok: true }
+  | { ok: false; error: string };
+```
+
+`error` is a safe, human-readable explanation. Consumers may display it, but
+should branch on `ok` rather than matching exact error text.
+
+The result is an operation result, not merely confirmation that a toast was
+shown:
+
+- `status`, `enable`, and `disable` return the shared `/xai-tools` handler's
+  actual success or failure. Registry, model-eligibility, routing-policy, and
+  argument failures therefore return `{ ok: false, error }`.
+- `open` has an intentional timing exception. `{ ok: true }` means the picker
+  was accepted for launch. The listener calls `done` before awaiting picker
+  closure so a menu host does not report a false timeout while the user is
+  interacting.
+- A successful `open` result does not mean the user changed a tool or closed
+  the picker. Failures after launch acknowledgement are reported in the Pi UI
+  only; the listener does not call `done` a second time.
+
+The emitter may enforce its own bounded timeout for a missing listener or
+response. That timeout does not change the listener's acknowledgement
+semantics.
+
+[commands]: ../extensions/xai/tools/commands.ts

--- a/extensions/xai/tools/commands.ts
+++ b/extensions/xai/tools/commands.ts
@@ -53,6 +53,8 @@ const xaiToolsMenuUnsubscribeByApi = new WeakMap<ExtensionAPI, () => void>();
 
 type XaiToolsCommandResult = { ok: true } | { ok: false; error: string };
 
+type XaiToolsMenuDone = (result: XaiToolsCommandResult) => void;
+
 function commandToolName(value: string | undefined): XaiNetworkToolName | undefined {
   if (!value) return undefined;
   const normalized = value.toLowerCase();
@@ -347,14 +349,6 @@ async function handleXaiToolsArgs(
 	return { ok: false, error };
 }
 
-type XaiToolsMenuRequest = {
-	action?: "open" | "status" | "enable" | "disable";
-	tool?: string;
-	/** ExtensionCommandContext from the menu host (required for open / UI notify). */
-	ctx?: ExtensionCommandContext;
-	done?: (result: { ok: boolean; error?: string }) => void;
-}
-
 /** Register the package-owned command for explicitly managing network-backed xAI tools. */
 export function registerXaiToolsCommand(
 	pi: ExtensionAPI,
@@ -378,23 +372,64 @@ export function registerXaiToolsCommand(
 	if (!on) return;
 
 	const unsubscribe = on(XAI_TOOLS_MENU_CHANNEL, async (raw) => {
-		const data = (raw ?? {}) as XaiToolsMenuRequest;
-		const reply = (result: { ok: boolean; error?: string }) => {
-			try {
-				data.done?.(result);
-			} catch {
-				// ignore listener reply failures
+		let source: Record<string, unknown> | undefined;
+		let done: XaiToolsMenuDone | undefined;
+		try {
+			if (raw !== null && (typeof raw === "object" || typeof raw === "function")) {
+				source = raw as Record<string, unknown>;
+				const candidate = source.done;
+				if (typeof candidate === "function") done = candidate as XaiToolsMenuDone;
 			}
-		};
-
-		const ctx = data.ctx;
-		if (!ctx || typeof ctx !== "object" || !ctx.ui) {
-			reply({ ok: false, error: "xAI tools bridge requires a command UI context." });
+		} catch {
+			// A throwing done accessor cannot provide a callable reply path.
 			return;
 		}
 
-		const action = (data.action ?? "open").toLowerCase();
+		// A response is impossible without a callable callback. Never dispatch an
+		// unacknowledgeable request or throw back through the shared event bus.
+		if (!done) return;
+
+		let replied = false;
+		const reply = (result: XaiToolsCommandResult) => {
+			if (replied) return;
+			replied = true;
+			try {
+				done(result);
+			} catch {
+				// Ignore host callback failures after the listener has completed its reply.
+			}
+		};
+
 		try {
+			if (!source || Array.isArray(raw) || typeof raw !== "object") {
+				reply({ ok: false, error: "xAI tools bridge request must be an object." });
+				return;
+			}
+
+			const rawAction = source.action;
+			if (rawAction !== undefined && typeof rawAction !== "string") {
+				reply({ ok: false, error: "xAI tools bridge action must be a string." });
+				return;
+			}
+			const action = (rawAction ?? "open").trim().toLowerCase();
+
+			const rawTool = source.tool;
+			if (rawTool !== undefined && typeof rawTool !== "string") {
+				reply({ ok: false, error: "xAI tools bridge tool must be a string." });
+				return;
+			}
+
+			const rawCtx = source.ctx;
+			if (!rawCtx || typeof rawCtx !== "object") {
+				reply({ ok: false, error: "xAI tools bridge requires a command UI context." });
+				return;
+			}
+			const ctx = rawCtx as ExtensionCommandContext;
+			if (!ctx.ui || typeof ctx.ui.notify !== "function") {
+				reply({ ok: false, error: "xAI tools bridge requires a command UI context." });
+				return;
+			}
+
 			if (action === "open") {
 				// Menu hosts (pi-clickable-menu) treat a missing done within ~4s as
 				// bridge failure. Acknowledge once the interactive picker is accepted
@@ -414,16 +449,20 @@ export function registerXaiToolsCommand(
 					reply({ ok: false, error: "Interactive selection requires TUI or RPC mode." });
 					return;
 				}
+				const picker = ctx.mode === "tui" ? ctx.ui.custom : ctx.ui.select;
+				if (typeof picker !== "function") {
+					reply({ ok: false, error: "xAI tools bridge requires an interactive picker UI." });
+					return;
+				}
 				reply({ ok: true });
 				try {
 					await showXaiToolPicker(pi, ctx, model);
-				} catch (err) {
-					// done already acknowledged launch; surface post-launch failures in-UI only.
-					const message = err instanceof Error ? err.message : String(err);
+				} catch {
+					// done already acknowledged launch; surface a bounded UI-only error.
 					try {
-						ctx.ui.notify(message, "error");
+						ctx.ui.notify("xAI tools picker failed.", "error");
 					} catch {
-						// ignore notify failures after ack
+						// Ignore notify failures after acknowledgement.
 					}
 				}
 				return;
@@ -434,7 +473,7 @@ export function registerXaiToolsCommand(
 				return;
 			}
 			if (action === "enable" || action === "disable") {
-				const tool = typeof data.tool === "string" ? data.tool.trim() : "";
+				const tool = rawTool?.trim() ?? "";
 				if (!tool) {
 					reply({ ok: false, error: "xAI tools bridge enable/disable requires tool." });
 					return;
@@ -443,10 +482,9 @@ export function registerXaiToolsCommand(
 				reply(result);
 				return;
 			}
-			reply({ ok: false, error: `Unknown xAI tools bridge action: ${action}` });
-		} catch (err) {
-			const message = err instanceof Error ? err.message : String(err);
-			reply({ ok: false, error: message });
+			reply({ ok: false, error: "Unknown xAI tools bridge action." });
+		} catch {
+			reply({ ok: false, error: "xAI tools bridge request failed." });
 		}
 	});
 	if (typeof unsubscribe === "function") {

--- a/tests/tools/commands.test.ts
+++ b/tests/tools/commands.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME,
   XAI_GROK_NATIVE_WEB_SEARCH_NAME,
@@ -527,7 +527,6 @@ describe("/xai-tools command", () => {
     expect(notices.some(({ message }) => message.includes("private-picker-detail"))).toBe(false);
   });
 
-);
 
   it("reports status through the menu bridge notification path", async () => {
     const { h, notices } = setup();
@@ -717,7 +716,7 @@ describe("/xai-tools command", () => {
 
     expect(result).toEqual({
       ok: false,
-      error: "Unknown xAI tools bridge action: toggle",
+      error: "Unknown xAI tools bridge action.",
     });
     expect(notices).toEqual([]);
   });

--- a/tests/tools/commands.test.ts
+++ b/tests/tools/commands.test.ts
@@ -338,6 +338,197 @@ describe("/xai-tools command", () => {
     expect(notices.at(-1).message).toMatch(/may use xAI credits/);
   });
 
+  it("keeps the listener-owned bridge channel stable", () => {
+    expect(XAI_TOOLS_MENU_CHANNEL).toBe("pi-clickable-menu:xai-tools");
+  });
+
+  it.each([
+    ["action", { action: 42 }, /action must be a string/i],
+    ["tool", { action: "enable", tool: { name: "xai_generate_image" } }, /tool must be a string/i],
+  ])("rejects a non-string bridge %s before dispatch", (_field, request, errorPattern) => {
+    const { h, notices } = setup();
+    const done = vi.fn();
+
+    expect(() => {
+      h.api.events.emit(XAI_TOOLS_MENU_CHANNEL, {
+        ...request,
+        ctx: commandContext(TEST_MODEL, notices),
+        done,
+      });
+    }).not.toThrow();
+
+    expect(done).toHaveBeenCalledOnce();
+    expect(done).toHaveBeenCalledWith({ ok: false, error: expect.stringMatching(errorPattern) });
+    expect(isXaiNetworkToolActive(h.api, "xai_generate_image")).toBe(false);
+  });
+
+  it("does not reflect an unknown bridge action in its error", () => {
+    const { h } = setup();
+    const done = vi.fn();
+
+    h.api.events.emit(XAI_TOOLS_MENU_CHANNEL, {
+      action: "private-action-value",
+      ctx: commandContext(TEST_MODEL),
+      done,
+    });
+
+    expect(done).toHaveBeenCalledOnce();
+    expect(done).toHaveBeenCalledWith({
+      ok: false,
+      error: "Unknown xAI tools bridge action.",
+    });
+    expect(done.mock.calls[0]?.[0]?.error).not.toContain("private-action-value");
+  });
+
+  it("does not reflect thrown bridge payload details in its error", () => {
+    const { h } = setup();
+    const done = vi.fn();
+    const request: Record<string, unknown> = {
+      ctx: commandContext(TEST_MODEL),
+      done,
+    };
+    Object.defineProperty(request, "action", {
+      get() {
+        throw new Error("private-payload-detail");
+      },
+    });
+
+    h.api.events.emit(XAI_TOOLS_MENU_CHANNEL, request);
+
+    expect(done).toHaveBeenCalledOnce();
+    expect(done).toHaveBeenCalledWith({
+      ok: false,
+      error: "xAI tools bridge request failed.",
+    });
+    expect(done.mock.calls[0]?.[0]?.error).not.toContain("private-payload-detail");
+  });
+
+  it("rejects an unusable bridge UI context before changing tool state", () => {
+    const { h } = setup();
+    const done = vi.fn();
+
+    h.api.events.emit(XAI_TOOLS_MENU_CHANNEL, {
+      action: "enable",
+      tool: "xai_generate_image",
+      ctx: { ...commandContext(TEST_MODEL), ui: {} },
+      done,
+    });
+
+    expect(done).toHaveBeenCalledOnce();
+    expect(done).toHaveBeenCalledWith({
+      ok: false,
+      error: expect.stringMatching(/command UI context/i),
+    });
+    expect(isXaiNetworkToolActive(h.api, "xai_generate_image")).toBe(false);
+  });
+
+  it("does not dispatch a bridge request without a callable done", () => {
+    const { h } = setup();
+
+    expect(() => {
+      h.api.events.emit(XAI_TOOLS_MENU_CHANNEL, {
+        action: "enable",
+        tool: "xai_generate_image",
+        ctx: commandContext(TEST_MODEL),
+        done: "not-a-callback",
+      });
+    }).not.toThrow();
+
+    expect(isXaiNetworkToolActive(h.api, "xai_generate_image")).toBe(false);
+  });
+
+  it.each([
+    ["an unknown tool", "not_a_tool", TEST_MODEL, /Usage:/],
+    [
+      "a non-xAI model",
+      "xai_generate_image",
+      { provider: "anthropic", id: "claude" },
+      /Select an xAI\/Grok model/,
+    ],
+    ["unavailable vision routing", "vision-routing", TEST_MODEL, /vision routing is unavailable/i],
+  ])("reports menu bridge failure for %s", async (_case, tool, model, errorPattern) => {
+    const { h, notices } = setup();
+    const result = await emitMenuRequest(h, {
+      action: "enable",
+      tool,
+      ctx: commandContext(model, notices),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(errorPattern);
+    expect(notices.at(-1).message).toMatch(errorPattern);
+  });
+
+  it("reports menu bridge registry failures when disabling a tool", async () => {
+    const { h, notices, run } = setup();
+    await run("enable xai_generate_image");
+
+    for (const failure of [
+      { registry: { get: true }, error: /could not be read/ },
+      { registry: { set: true }, error: /could not be updated/ },
+    ]) {
+      h.failRegistry(failure.registry);
+      const result = await emitMenuRequest(h, {
+        action: "disable",
+        tool: "xai_generate_image",
+        ctx: commandContext(TEST_MODEL, notices),
+      });
+      h.failRegistry();
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(failure.error);
+      expect(notices.at(-1).message).toMatch(failure.error);
+      expect(isXaiNetworkToolActive(h.api, "xai_generate_image")).toBe(true);
+    }
+  });
+
+  it("rejects a menu bridge enable or disable without a tool", async () => {
+    const { h, notices } = setup();
+    const result = await emitMenuRequest(h, {
+      action: "disable",
+      tool: " ",
+      ctx: commandContext(TEST_MODEL, notices),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "xAI tools bridge enable/disable requires tool.",
+    });
+  });
+
+  it("does not reflect post-launch picker failures or reply twice", async () => {
+    const { h, notices } = setup();
+    const done = vi.fn();
+
+    h.api.events.emit(XAI_TOOLS_MENU_CHANNEL, {
+      action: "open",
+      ctx: commandContext(TEST_MODEL, notices, {
+        ui: {
+          notify(message: string, type?: string) {
+            notices.push({ message, type });
+          },
+          select: async () => undefined,
+          custom: async () => {
+            throw new Error("private-picker-detail");
+          },
+        },
+      }),
+      done,
+    });
+
+    await vi.waitFor(() => {
+      expect(notices.at(-1)).toEqual({
+        message: "xAI tools picker failed.",
+        type: "error",
+      });
+    });
+    expect(done).toHaveBeenCalledOnce();
+    expect(done).toHaveBeenCalledWith({ ok: true });
+    expect(notices.some(({ message }) => message.includes("private-picker-detail"))).toBe(false);
+  });
+
+);
+
   it("reports status through the menu bridge notification path", async () => {
     const { h, notices } = setup();
 


### PR DESCRIPTION
## Summary
- document the listener-owned `pi-clickable-menu:xai-tools` protocol v1, including the canonical channel, request/result shapes, and `open` launch acknowledgement timing
- validate raw bridge fields before dispatch, reply exactly once when a callable `done` is present, and keep malformed/picker errors bounded and non-reflective
- add focused bridge regressions and exclude worktree task metadata from packed releases

## Validation
- `npm test` (44 files, 508 tests)
- `npm run typecheck`
- `npm run compatibility:boundaries` (Pi 0.80.1 and 0.81.1)
- `npm pack --dry-run --json` (`docs/bridge-xai-tools.md` included; `.agent-task.md` excluded)
- final independent reviewer pass: clean

Closes #131
