### PR TITLE
feat(tools): accept built-in xai SuperGrok login for network tools

### DIFF
--- a/.scaffold/constraints.md
+++ b/.scaffold/constraints.md
@@ -1,23 +1,22 @@
-# Constraints & Safety Rules — Issue #131
+# Constraints & Safety Rules — Issue #132
 
 ## Scope
 
-- Document the listener-owned `pi-clickable-menu:xai-tools` protocol as v1.
-- Apply only the small malformed-payload hardening requested by #131.
-- Add focused tests, README linkage, release notes, and state updates.
+- Broaden only network-tool eligibility and managed credential/usage lookup to Pi's built-in `xai` provider.
+- Keep `XAI_PROVIDER_ID` as the package-owned `xai-auth` provider identity.
 
 ## Must
 
-- Keep `XAI_TOOLS_MENU_CHANNEL` as the single production source of truth.
-- Preserve issue #128's early `open` launch acknowledgement.
-- Preserve issue #129's honest `status`, `enable`, and `disable` outcomes.
-- Validate raw action, tool, context/UI, and callback fields before command dispatch.
-- Call a supplied callable `done` exactly once for every accepted or rejected request.
-- Keep errors bounded to safe human-readable messages; never reflect raw payloads or context.
+- Prefer the active compatible provider when searching `xai-auth` and `xai` credentials.
+- Route built-in SuperGrok OAuth as `oauth-session` and built-in API keys as `api-key`.
+- Keep usage OAuth-only, bounded, identity-first, and inactive for an active built-in API key.
+- Clear network-tool opt-ins when switching to a non-compatible provider.
+- Preserve exact supported Pi boundaries and existing Grok CLI credential reuse.
 
 ## Must not
 
-- Add a separate shared-type package or require a new wire-version field.
-- Re-await picker close before acknowledging `open`.
-- Expand bridge behavior/coverage into issue #130 or built-in tool work in #132.
-- Change OAuth, catalog, transport, or unrelated tool behavior.
+- Register, replace, unregister, refresh, or stream the built-in `xai` provider.
+- Broaden package catalog, entitlement, vision-routing, or local Grok-adapter checks beyond `xai-auth`.
+- Send built-in API keys through the CLI session proxy or usage endpoints.
+- Work on issues #130 or #131.
+- Log, persist, or expose credentials, identity, authenticated headers, or raw authenticated bodies.

--- a/.scaffold/context.md
+++ b/.scaffold/context.md
@@ -1,29 +1,23 @@
-# Shared Agent Context — Issue #131
+# Shared Agent Context — Issue #132
 
-**Issue:** <https://github.com/BlockedPath/pi-xai-oauth/issues/131>
-**Branch:** `docs/131-bridge-contract`
-**Base:** current `origin/main` with #128 and #129 merged
+**Issue:** <https://github.com/BlockedPath/pi-xai-oauth/issues/132>
+**Linear:** [BLO-15](https://linear.app/blockedpath/issue/BLO-15/gh-132-support-pis-built-in-xai-supergrok-x-premium-login-for-network)
+**Branch:** `feat/132-builtin-xai-tools`
 
 ## Problem
 
-The cross-package `pi-clickable-menu:xai-tools` event contract is informal. The listener casts raw payloads directly, then calls `.toLowerCase()` on `action` outside its protected dispatch block. A non-string action can throw before a supplied `done` callback is invoked.
+Network-tool scope and Pi-managed credential/usage lookup are hard-coded to this package's `xai-auth` provider. Pi's built-in `xai` provider now supports SuperGrok/X Premium OAuth and API keys, but installed package tools reject its active models and cannot classify its credential provenance.
 
-## Existing behavior to preserve
+## Approved Boundary
 
-- `XAI_TOOLS_MENU_CHANNEL` in `extensions/xai/tools/commands.ts` is exported and is the listener-owned channel source of truth.
-- `open` reports `{ ok: true }` when the picker is accepted for launch, not when it closes.
-- `status`, `enable`, and `disable` forward the shared command handler's actual success or failure.
+- `XAI_PROVIDER_ID = "xai-auth"` remains package ownership for registration, catalog, stream, vision routing, and automatic local Grok adapters.
+- A separate `xai` ID plus a narrow compatibility predicate applies only to network tools and usage model gating.
+- Managed credential search covers both providers active-first.
+- Built-in OAuth uses CLI-session routes; built-in API keys use public API routes.
+- Usage accepts Pi-managed OAuth only and must not fall through from an active built-in API key to another account/provider.
 
-## Approved approach
+## Focus
 
-Add `docs/bridge-xai-tools.md` as protocol v1, link it from README, and state that v1 is a document/behavior revision rather than a wire `version` field. Validate raw object fields and required UI methods before dispatch. If a callable `done` is supplied, reply exactly once with a discriminated success/error result. Missing or non-callable `done` cannot be answered and must fail safely without dispatch.
-
-## Implemented
-
-- Production: `extensions/xai/tools/commands.ts` now validates the raw payload before dispatch and uses a once-only reply closure.
-- Regressions: `tests/tools/commands.test.ts` covers non-string action/tool fields, unusable UI context, missing callable `done`, and the stable channel literal.
-- Documentation: `docs/bridge-xai-tools.md`, `README.md`, and `CHANGELOG.md` define and link protocol v1.
-
-## Validation state
-
-`npm test`, `npm run typecheck`, and both exact packed compatibility boundaries pass. The full local suite reports 44 files and 508 tests. The package dry-run excludes `.agent-task.md`, final pi-lens session diagnostics have no blockers, and the final independent review is clean.
+- Production: `extensions/xai/constants.ts`, `extensions/xai/tools/model-scope.ts`, `extensions/xai/auth.ts`, `extensions/xai/usage.ts`.
+- Regressions: tools command/lifecycle/native isolation, credentials, and usage status.
+- Docs/release: `README.md`, `CHANGELOG.md`.

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,25 +1,28 @@
-# Implementation Plan — Issue #131: xAI tools bridge contract
+# Implementation Plan — Issue #132: Built-in xAI network tools
 
-**Branch:** `docs/131-bridge-contract`
-**Base:** `origin/main`
+**Branch:** `feat/132-builtin-xai-tools`
+**Issue:** https://github.com/BlockedPath/pi-xai-oauth/issues/132
+**Linear:** BLO-15
 
 ## Goal
 
-Publish the listener-owned v1 contract for `pi-clickable-menu:xai-tools` and close the malformed-payload gap without expanding into issues #130 or #132.
+Support Pi's built-in `xai` SuperGrok/X Premium credentials for opt-in network tools and subscription usage without taking over Pi's built-in chat, catalog, stream, vision routing, or package-owned local Grok adapters.
 
 ## Phases
 
-1. [x] Inspect issue #131, the listener, peer emitter, focused tests, and existing #128/#129 behavior.
-2. [x] Add a versioned bridge document and link it from the `/xai-tools` README section.
-3. [x] Validate raw request fields before dispatch and reply exactly once to malformed requests that provide a callable `done`.
-4. [x] Add focused malformed-payload regressions and update release notes/state.
-5. [x] Run focused tests, typecheck, full gates, exact compatibility boundaries, and independent review.
-6. [x] Commit, push, and open a PR that closes #131.
+1. [x] Read the task, GitHub/Linear context, required entrypoints, auth/tool/usage modules, tests, and Pi 0.81.1 provider/runtime behavior.
+2. [x] Add the narrow `xai-auth`/`xai` network-tool provider boundary.
+3. [x] Resolve both providers active-first with OAuth/API-key provenance and strict usage rejection.
+4. [x] Add network lifecycle, command, credential, usage, and non-takeover regressions.
+5. [x] Update README/changelog and persistent state.
+6. [ ] Run diagnostics, focused/full tests, typecheck, exact Pi boundaries, and independent review.
+7. [ ] Commit, push, open a PR closing #132, and update BLO-15.
 
 ## Validation Contract
 
-- `XAI_TOOLS_MENU_CHANNEL` remains the listener-owned source of truth.
-- Protocol v1 documents `action`, `tool`, `ctx`, and `done` without adding a wire-version field.
-- Non-string actions/tools and unusable contexts are rejected before dispatch; a callable `done` receives one `{ ok: false, error }` result.
-- `status`, `enable`, and `disable` return the shared handler's honest result.
-- `open` acknowledges accepted picker launch before picker close, with post-launch failures remaining UI-only.
+- Active `xai/grok-*` models can opt into and execute network-backed tools.
+- Built-in OAuth resolves as `oauth-session`; built-in API keys resolve as `api-key`.
+- Usage accepts Pi-managed OAuth only and rejects an active built-in API-key credential.
+- Switching to a non-xAI provider clears network opt-ins.
+- `xai-auth` remains the only package-registered/catalog/stream provider.
+- Automatic local Grok adapters and vision routing remain `xai-auth`-only.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,28 +1,30 @@
-# Execution Progress — Issue #131
+# Execution Progress — Issue #132
 
-**Branch:** `docs/131-bridge-contract`
-**Issue:** https://github.com/BlockedPath/pi-xai-oauth/issues/131
+**Branch:** `feat/132-builtin-xai-tools`
+**Issue:** https://github.com/BlockedPath/pi-xai-oauth/issues/132
+**Linear:** BLO-15
 
 ## Completed
 
-- [x] Read the task, issue, project guidance, entrypoint, setup, README, and prior scaffold state.
-- [x] Confirmed the branch is based on current `origin/main` with #128/#129 merged.
-- [x] Inspected the listener, peer emitter, focused tests, changelog, and documentation patterns.
-- [x] Ran parallel scout/reviewer analysis; both identified the non-string `action` path that can skip `done`.
-- [x] Chose a document-versioned v1 contract with no new wire field and the existing exported channel constant as source of truth.
-- [x] Added `docs/bridge-xai-tools.md`, README linkage, and Unreleased changelog notes.
-- [x] Added pre-dispatch validation for action, tool, command UI context, picker surface, and callable `done`.
-- [x] Added exactly-once replies and fail-safe no-dispatch behavior when no callable reply exists.
-- [x] Added malformed action/tool/UI/callback regressions and a channel-stability assertion.
-- [x] Focused command tests pass (30); TypeScript typecheck passes.
-- [x] Full policy/unit/loader gate passes (44 files, 508 tests).
-- [x] Exact packed Pi 0.80.1 and 0.81.1 compatibility boundaries pass.
-- [x] Package dry-run includes the protocol doc and excludes `.agent-task.md`.
-- [x] Final independent review reports no remaining blockers or fixes worth doing now.
-- [x] Final pi-lens session diagnostics report no blocking issues.
-- [x] Committed and pushed the implementation on `docs/131-bridge-contract`.
-- [x] Opened PR #140 with `Closes #131`.
+- [x] Confirmed the active feature branch and clean baseline except the caller-owned `.agent-task.md`.
+- [x] Read GitHub #132 and Linear BLO-15; Linear is already In Progress.
+- [x] Read required entrypoint/setup files and mapped network-tool, auth, usage, route, native-adapter, and test behavior.
+- [x] Inspected Pi 0.81.1's built-in `xai` provider, OAuth flow, ModelRuntime provenance, and ModelRegistry compatibility facade.
+- [x] Ran parallel scout/planner review and synthesized the active-first provider/provenance plan.
+- [x] Baseline focused tests pass (4 files, 50 tests) and TypeScript passes.
 
-## Delivery
+- [x] Added narrow tool-compatible provider constants and broadened only network-tool scope.
+- [x] Added active-first two-provider credential lookup with built-in OAuth/API-key provenance.
+- [x] Extended OAuth-only usage status to built-in SuperGrok OAuth while rejecting active API keys.
+- [x] Added command, lifecycle, route, credential, usage, and local-adapter isolation regressions.
+- [x] Updated README and Unreleased changelog documentation.
+- [x] Full suite passes (44 files, 506 tests), loader and TypeScript checks pass.
+- [x] Compatibility policy/pack checks and exact Pi 0.80.1 / 0.81.1 packed boundaries pass.
 
-PR: https://github.com/BlockedPath/pi-xai-oauth/pull/140
+## In Progress
+
+- [ ] Run independent review and final diagnostics; resolve any findings.
+
+## Next
+
+Complete independent review, then commit, push, open a PR closing #132, and update BLO-15.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 - Added the listener-owned, versioned `pi-clickable-menu:xai-tools` bridge contract, covering its canonical channel, request shape, action timing, and honest result semantics.
 - Added disabled-by-default `xai_image_to_video` with pinned create/status polling, DNS-pinned unauthenticated MP4 download, bounded streamed private storage, and honest remote-job cancellation semantics.
 - Added ModelRuntime re-registration coverage, a store-backed models-store precedence regression (discard stale overlays when the local catalog is newer), and request-auth tests that prefer `ModelRuntime.getAuth` over the legacy `getApiKeyAndHeaders` projection.
+- Added opt-in network-tool and OAuth-only usage support for Pi's built-in `xai` provider, with active-provider credential preference, subscription/API-key provenance routing, and explicit isolation from package-owned catalog, stream, vision, and local-adapter behavior.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and
 - **Reasoning support** — parses supplied reasoning capability and thinking levels while preserving known model compatibility
 - **Bounded last-known-good cache** — avoids routine startup delay and falls back safely when discovery is offline or unavailable
 - **Custom xAI tools** — generate text, web search, X/Twitter search, multi-agent research, code analysis
-- **Credential-aware Responses routing** — OAuth/session traffic uses the official `https://cli-chat-proxy.grok.com/v1` endpoint for every Grok model; the public `api.x.ai` Responses endpoint is reserved for a future explicit API-key path
+- **Credential-aware Responses routing** — OAuth/session traffic uses the official `https://cli-chat-proxy.grok.com/v1` endpoint; built-in `xai` API-key tool traffic uses the public `api.x.ai` Responses endpoint
 - **Revision-pinned wire contract** — route-specific headers, truthful package identity, protected request metadata, redirect rejection, and the upstream Grok Build review procedure are documented without impersonating the official client
 
 > **✅ Verified (May 2026)**: All custom xAI tools (`xai_generate_text`, `xai_x_search`, `web_search`, `xai_code_execution`, `xai_critique`, `xai_multi_agent`, `xai_deep_research`, image tools, etc.) have been tested end-to-end after the OAuth + payload repair. The provider now correctly handles mixed-model requests and native xAI tool shapes.
@@ -268,9 +268,9 @@ Run an explicit one-shot usage lookup from pi:
 
 The command displays only validated fields that xAI actually returned, such as included usage percentage, legacy included-credit totals, current reset time, on-demand usage/cap, prepaid balance, and bounded history count. Missing optional fields stay omitted.
 
-The billing surface is **not a stable public xAI API**. This implementation is pinned to [`xai-org/grok-build@b189869`](https://github.com/xai-org/grok-build/blob/b189869b7755d2b482969acf6c92da3ecfeffd36/crates/codegen/xai-grok-shell/src/extensions/billing.rs): it first makes authenticated `GET /v1/user`, uses the returned validated `userId` only for the immediately following `GET /v1/billing?format=credits`, then discards it. The command requires a current Pi-stored OAuth credential and rejects stored or runtime `--api-key` provenance. Account identity, bearer/authenticated headers, and raw response bodies are never logged, displayed, cached, or persisted. If identity cannot be resolved safely, billing is not requested.
+The billing surface is **not a stable public xAI API**. This implementation is pinned to [`xai-org/grok-build@b189869`](https://github.com/xai-org/grok-build/blob/b189869b7755d2b482969acf6c92da3ecfeffd36/crates/codegen/xai-grok-shell/src/extensions/billing.rs): it first makes authenticated `GET /v1/user`, uses the returned validated `userId` only for the immediately following `GET /v1/billing?format=credits`, then discards it. The command accepts a current Pi-stored OAuth credential under this package's `xai-auth` provider or Pi's built-in `xai` SuperGrok/X Premium provider, and rejects stored, environment, or runtime API-key provenance. Account identity, bearer/authenticated headers, and raw response bodies are never logged, displayed, cached, or persisted. If identity cannot be resolved safely, billing is not requested.
 
-The compact footer status is off by default and requires a separate per-session opt-in while an `xai-auth` model is active:
+The compact footer status is off by default and requires a separate per-session opt-in while an `xai-auth` or built-in `xai` model is active with Pi-managed OAuth:
 
 ```text
 /xai-usage status
@@ -413,15 +413,15 @@ The direct `read_file`, `search_replace`, `list_dir`, and `grep` adapters accept
 
 `run_terminal_command` is deliberately outside that direct-adapter containment policy: it delegates the command to pi's `bash` tool and may access paths outside the workspace. These checks are defense-in-depth for the direct file adapters, not a complete filesystem sandbox for the coding agent.
 
-Legacy Cursor names (`Read`, `Shell`, `WebSearch`, and similar) are no longer registered by this package. Local Grok-native adapters enable automatically for `xai-auth` and clear when you leave xAI models without mutating same-named public tools owned by other extensions. Internally they use collision-free `xai_grok_*` dispatcher names, then expose the official public names only in the current xAI request, so unrelated extensions can keep their own public tools. `web_search` stays opt-in because it makes an additional authenticated xAI request.
+Legacy Cursor names (`Read`, `Shell`, `WebSearch`, and similar) are no longer registered by this package. Local Grok-native adapters enable automatically only for `xai-auth` and clear when you leave that provider without mutating same-named public tools owned by other extensions. Internally they use collision-free `xai_grok_*` dispatcher names, then expose the official public names only in the current package-owned xAI request, so unrelated extensions can keep their own public tools. The network-backed `web_search` remains opt-in and also supports Pi's built-in `xai` models.
 
 ---
 
 ## Custom Tools
 
-This package registers OAuth-backed custom tools that make additional xAI API requests. They appear alongside your other agent tools in the pi TUI, but all of them are **inactive by default**.
+This package registers credential-backed custom tools that make additional xAI API requests. They appear alongside your other agent tools in the pi TUI, but all of them are **inactive by default**. For Pi's built-in `xai` provider, SuperGrok/X Premium OAuth uses the subscription session route while API-key provenance uses the public `api.x.ai` route.
 
-This opt-in boundary applies only to the extra tools below. Normal conversation with the selected `xai-auth` model works without enabling any of them.
+This opt-in boundary applies only to the extra tools below. Normal conversation continues through the selected provider: this package owns `xai-auth` chat/catalog/stream behavior and does not replace or intercept Pi's built-in `xai` transport.
 
 | Tool | Category | Additional usage / cost risk |
 |------|----------|------------------------------|
@@ -437,11 +437,11 @@ This opt-in boundary applies only to the extra tools below. Normal conversation 
 | `xai_critique` | Reasoning | Separate high-reasoning model-token usage |
 | `web_search` | Search | Model tokens plus native tool usage |
 
-**How to use them:** Select an `xai-auth` model, enable only the tool you want through `/xai-tools`, then explicitly request that tool in your prompt or agent workflow. Enabling a tool makes it available; it is not permission for the model to call it without user intent.
+**How to use them:** Select an `xai-auth` model or Pi built-in `xai` model, enable only the tool you want through `/xai-tools`, then explicitly request that tool in your prompt or agent workflow. Credential lookup prefers the active provider and can reuse `xai-auth` OAuth, built-in `xai` OAuth or API keys, and the existing Grok CLI credential fallback. Enabling a tool makes it available; it is not permission for the model to call it without user intent.
 
-Every new session resets all network-backed tools to inactive. Switching to a non-xAI model disables them immediately, and switching back does not restore them. Grok-native local filesystem and shell tools are automatic because they do not create a separate xAI API request.
+Every new session resets all network-backed tools to inactive. Switching to a non-xAI model disables them immediately, and switching back does not restore them. Grok-native local filesystem and shell tools remain automatic only for `xai-auth`; built-in `xai` models receive no package-owned local adapters.
 
-In the pi TUI, select an `xai-auth` model and run:
+In the pi TUI, select an `xai-auth` or built-in `xai` model and run:
 
 ```text
 /xai-tools
@@ -598,7 +598,7 @@ Opt-in research using the active xAI model plus native web and X search tools. E
 }
 ```
 
-> **Note:** Every tool in this section makes a separate xAI request and can consume subscription allowances, credits, or rate limits. Responses-based helpers use the OAuth session proxy. Image generation and image editing are intentional exceptions: matching official Grok Build behavior, they send the OAuth bearer directly to the pinned public Images routes at `https://api.x.ai/v1/images/generations` and `https://api.x.ai/v1/images/edits`. See [xAI pricing](https://docs.x.ai/developers/pricing) for current rates.
+> **Note:** Every tool in this section makes a separate xAI request and can consume subscription allowances, credits, or rate limits. OAuth-backed Responses helpers use the session proxy; built-in `xai` API-key helpers use the public API. Image generation and image editing are intentional OAuth transport exceptions: matching official Grok Build behavior, they send the OAuth bearer directly to the pinned public Images routes at `https://api.x.ai/v1/images/generations` and `https://api.x.ai/v1/images/edits`. See [xAI pricing](https://docs.x.ai/developers/pricing) for current rates.
 
 ---
 
@@ -692,9 +692,9 @@ This re-runs the full OAuth flow and replaces your stored tokens.
 
 ### "Does this need an xAI API key?"
 
-**No.** This uses OAuth — the same authentication as the official Grok CLI and chat interface. You sign in with your xAI / Grok account credentials. No API key required. Responses requests use the OAuth session proxy; this package does not fall back to `XAI_API_KEY` or expose an API-key provider.
+**Not for the package-owned `xai-auth` provider.** It uses OAuth—the same authentication family as the official Grok CLI and chat interface—and does not expose an API-key chat provider. Responses requests for `xai-auth` use the OAuth session proxy.
 
-The paid `xai_generate_image` helper is a deliberate transport exception: the official Grok Build client sends both OAuth and BYOK Imagine requests directly to the public Images endpoint. This does not change normal chat or Responses-helper routing.
+The opt-in network tools can also run while Pi's built-in `xai` provider is active. Built-in SuperGrok/X Premium OAuth is tagged as a subscription session; a built-in xAI API key is tagged as `api-key` and sent only to the public `api.x.ai` route. `/xai-usage` remains OAuth-only and rejects API-key provenance.
 
 If you have the official Grok CLI installed and authenticated (`~/.grok/auth.json`), this package detects and reuses those credentials automatically.
 

--- a/extensions/xai/auth.ts
+++ b/extensions/xai/auth.ts
@@ -6,11 +6,15 @@ import { homedir } from "os";
 import { join } from "path";
 import {
   DEFAULT_XAI_MODEL,
+  XAI_BUNDLED_PROVIDER_ID,
   XAI_GROK_CLI_AUTH_SCOPE_KEY,
   XAI_GROK_CLI_LEGACY_AUTH_SCOPE_KEY,
   XAI_OAUTH_ISSUER,
   XAI_OAUTH_REFRESH_SKEW_MS,
   XAI_PROVIDER_ID,
+  XAI_TOOL_COMPATIBLE_PROVIDER_IDS,
+  isXaiToolCompatibleProvider,
+  type XaiToolCompatibleProviderId,
 } from "./constants";
 import { getXaiRuntimeModels } from "./models";
 import { ensureFreshXaiCredentials } from "./oauth";
@@ -140,9 +144,19 @@ export function getStartupXaiCatalogAuth(now = Date.now()): StartupXaiCatalogAut
   return { credential: null, needsRegistryRefresh, credentialChangedAt };
 }
 
-function xaiRegistryCandidateIds(ctx: any): string[] {
+function xaiRegistryProviderIds(ctx: any): XaiToolCompatibleProviderId[] {
+  const activeProvider = isXaiToolCompatibleProvider(ctx?.model?.provider)
+    ? ctx.model.provider
+    : undefined;
+  return [activeProvider, ...XAI_TOOL_COMPATIBLE_PROVIDER_IDS].filter(
+    (providerId, index, values): providerId is XaiToolCompatibleProviderId =>
+      typeof providerId === "string" && values.indexOf(providerId) === index,
+  );
+}
+
+function xaiRegistryCandidateIds(ctx: any, providerId: XaiToolCompatibleProviderId): string[] {
   return [
-    ctx?.model?.provider === XAI_PROVIDER_ID ? ctx.model.id : undefined,
+    ctx?.model?.provider === providerId ? ctx.model.id : undefined,
     DEFAULT_XAI_MODEL,
     ...getXaiRuntimeModels().map((model) => model.id),
   ].filter(
@@ -151,52 +165,83 @@ function xaiRegistryCandidateIds(ctx: any): string[] {
   );
 }
 
-function legacyStoredOAuthAccess(registry: any): string | null | undefined {
-  if (typeof registry?.authStorage?.get !== "function") return undefined;
+type LegacyStoredAuth =
+  | { state: "unavailable" | "missing" | "non-oauth" }
+  | { state: "oauth"; access: string };
+
+function legacyStoredAuth(registry: any, providerId: XaiToolCompatibleProviderId): LegacyStoredAuth {
+  if (typeof registry?.authStorage?.get !== "function") return { state: "unavailable" };
   try {
-    const stored = registry.authStorage.get(XAI_PROVIDER_ID);
+    const stored = registry.authStorage.get(providerId);
+    if (stored === undefined) return { state: "missing" };
     return stored?.type === "oauth"
       && typeof stored.access === "string"
       && stored.access
-      ? stored.access
-      : null;
+      ? { state: "oauth", access: stored.access }
+      : { state: "non-oauth" };
   } catch {
-    return null;
+    return { state: "non-oauth" };
   }
 }
 
-function hasRuntimeApiKeyOverride(registry: any): boolean {
+function hasRuntimeApiKeyOverride(registry: any, providerId: XaiToolCompatibleProviderId): boolean {
   if (typeof registry?.getProviderAuthStatus !== "function") return false;
   try {
-    return registry.getProviderAuthStatus(XAI_PROVIDER_ID)?.source === "runtime";
+    return registry.getProviderAuthStatus(providerId)?.source === "runtime";
   } catch {
     return true;
   }
 }
 
-function registryModelUsesOAuth(registry: any, model: any): boolean {
+function registryModelUsesOAuth(
+  registry: any,
+  providerId: XaiToolCompatibleProviderId,
+  model: any,
+): boolean {
   try {
     if (registry.isUsingOAuth(model) !== true) return false;
-    const legacyAccess = legacyStoredOAuthAccess(registry);
-    if (legacyAccess !== undefined) return legacyAccess !== null;
+    const stored = legacyStoredAuth(registry, providerId);
+    if (stored.state !== "unavailable") return stored.state === "oauth";
     if (typeof registry.getProviderAuthStatus !== "function") return false;
-    const status = registry.getProviderAuthStatus(XAI_PROVIDER_ID);
+    const status = registry.getProviderAuthStatus(providerId);
     return status?.configured === true && status.source === "stored";
   } catch {
     return false;
   }
 }
 
-function credentialFromResolvedAuth(auth: any): XaiCredential | null {
+function providerHasNonOAuthCredential(
+  registry: any,
+  providerId: XaiToolCompatibleProviderId,
+  models: readonly any[],
+): boolean {
+  if (hasRuntimeApiKeyOverride(registry, providerId)) return true;
+  const stored = legacyStoredAuth(registry, providerId);
+  if (stored.state === "non-oauth") return true;
+  if (stored.state === "oauth") return false;
+  if (typeof registry?.getProviderAuthStatus !== "function") return false;
+  try {
+    const status = registry.getProviderAuthStatus(providerId);
+    return status?.configured === true
+      && !models.some((model) => registryModelUsesOAuth(registry, providerId, model));
+  } catch {
+    return true;
+  }
+}
+
+function credentialFromResolvedAuth(
+  auth: any,
+  kind: XaiCredential["kind"] = "oauth-session",
+): XaiCredential | null {
   if (auth?.ok && typeof auth.apiKey === "string" && auth.apiKey) {
-    return { kind: "oauth-session", token: auth.apiKey };
+    return { kind, token: auth.apiKey };
   }
   const authorization =
     auth?.ok && typeof auth.headers?.Authorization === "string"
       ? auth.headers.Authorization
       : "";
   return authorization.toLowerCase().startsWith("bearer ")
-    ? { kind: "oauth-session", token: authorization.slice("bearer ".length) }
+    ? { kind, token: authorization.slice("bearer ".length) }
     : null;
 }
 
@@ -263,7 +308,8 @@ export async function resolveRegistryRequestAuth(
   }
   if (typeof registry?.getProviderAuth === "function") {
     try {
-      return requestAuthFromResolution(await registry.getProviderAuth(XAI_PROVIDER_ID));
+      const providerId = typeof model?.provider === "string" ? model.provider : XAI_PROVIDER_ID;
+      return requestAuthFromResolution(await registry.getProviderAuth(providerId), providerId);
     } catch (error) {
       return {
         ok: false,
@@ -287,12 +333,22 @@ export async function resolvePiManagedXaiCredential(ctx: any): Promise<XaiCreden
   if (typeof registry?.find !== "function" || !registrySupportsRequestAuth(registry, modelRuntime)) {
     return null;
   }
-  for (const modelId of xaiRegistryCandidateIds(ctx)) {
-    const registryModel = registry.find(XAI_PROVIDER_ID, modelId);
-    if (!registryModel) continue;
-    const auth = await resolveRegistryRequestAuth(registry, registryModel, modelRuntime);
-    const credential = credentialFromResolvedAuth(auth);
-    if (credential) return credential;
+  for (const providerId of xaiRegistryProviderIds(ctx)) {
+    for (const modelId of xaiRegistryCandidateIds(ctx, providerId)) {
+      const registryModel = registry.find(providerId, modelId);
+      if (!registryModel) continue;
+      const auth = await resolveRegistryRequestAuth(registry, registryModel, modelRuntime);
+      const kind = providerId === XAI_BUNDLED_PROVIDER_ID
+        && !registryModelUsesOAuth(registry, providerId, registryModel)
+        ? "api-key"
+        : "oauth-session";
+      const credential = credentialFromResolvedAuth(auth, kind);
+      if (credential) {
+        return kind === "oauth-session" && ctx?.model?.provider === XAI_BUNDLED_PROVIDER_ID
+          ? { ...credential, catalogScope: "host" }
+          : credential;
+      }
+    }
   }
   return null;
 }
@@ -311,25 +367,35 @@ export async function resolvePiManagedXaiOAuthCredential(ctx: any): Promise<XaiC
   ) {
     return null;
   }
-  const legacyAccessBefore = legacyStoredOAuthAccess(registry);
-  if (legacyAccessBefore === null || hasRuntimeApiKeyOverride(registry)) {
-    return null;
-  }
-  for (const modelId of xaiRegistryCandidateIds(ctx)) {
-    const registryModel = registry.find(XAI_PROVIDER_ID, modelId);
-    if (!registryModel || !registryModelUsesOAuth(registry, registryModel)) continue;
-    const credential = credentialFromResolvedAuth(
-      await resolveRegistryRequestAuth(registry, registryModel, modelRuntime),
-    );
-    const legacyAccessAfter = legacyStoredOAuthAccess(registry);
-    if (
-      credential
-      && !hasRuntimeApiKeyOverride(registry)
-      && registryModelUsesOAuth(registry, registryModel)
-      && legacyAccessAfter !== null
-      && (legacyAccessAfter === undefined || credential.token === legacyAccessAfter)
-    ) {
-      return credential;
+  for (const providerId of xaiRegistryProviderIds(ctx)) {
+    const registryModels = xaiRegistryCandidateIds(ctx, providerId)
+      .map((modelId) => registry.find(providerId, modelId))
+      .filter(Boolean);
+    if (registryModels.length === 0) continue;
+    const activeProvider = ctx?.model?.provider === providerId;
+    if (providerHasNonOAuthCredential(registry, providerId, registryModels)) {
+      if (activeProvider) return null;
+      continue;
+    }
+    for (const registryModel of registryModels) {
+      if (!registryModelUsesOAuth(registry, providerId, registryModel)) continue;
+      const storedBefore = legacyStoredAuth(registry, providerId);
+      const credential = credentialFromResolvedAuth(
+        await resolveRegistryRequestAuth(registry, registryModel, modelRuntime),
+      );
+      const storedAfter = legacyStoredAuth(registry, providerId);
+      const storedCredentialMatches = storedAfter.state === "unavailable"
+        || (storedAfter.state === "oauth" && credential?.token === storedAfter.access);
+      if (
+        credential
+        && !hasRuntimeApiKeyOverride(registry, providerId)
+        && registryModelUsesOAuth(registry, providerId, registryModel)
+        && storedBefore.state !== "non-oauth"
+        && storedBefore.state !== "missing"
+        && storedCredentialMatches
+      ) {
+        return credential;
+      }
     }
   }
   return null;
@@ -338,32 +404,48 @@ export async function resolvePiManagedXaiOAuthCredential(ctx: any): Promise<XaiC
 /**
  * Return whether Pi currently identifies an xAI registry model as stored OAuth.
  *
- * This uses the public registry facade available across Pi 0.80.1–0.81.0.
+ * This uses the public registry facade available across Pi 0.80.1–0.81.1.
  */
 export function hasPiManagedXaiOAuth(ctx: any): boolean {
   const registry = ctx?.modelRegistry;
-  if (
-    typeof registry?.find !== "function"
-    || typeof registry?.isUsingOAuth !== "function"
-    || hasRuntimeApiKeyOverride(registry)
-  ) {
+  if (typeof registry?.find !== "function" || typeof registry?.isUsingOAuth !== "function") {
     return false;
   }
-  const legacyAccess = legacyStoredOAuthAccess(registry);
-  if (legacyAccess === null) return false;
-  return xaiRegistryCandidateIds(ctx).some((modelId) => {
-    const registryModel = registry.find(XAI_PROVIDER_ID, modelId);
-    return !!registryModel && registryModelUsesOAuth(registry, registryModel);
-  });
+  for (const providerId of xaiRegistryProviderIds(ctx)) {
+    const registryModels = xaiRegistryCandidateIds(ctx, providerId)
+      .map((modelId) => registry.find(providerId, modelId))
+      .filter(Boolean);
+    if (registryModels.length === 0) continue;
+    const activeProvider = ctx?.model?.provider === providerId;
+    if (providerHasNonOAuthCredential(registry, providerId, registryModels)) {
+      if (activeProvider) return false;
+      continue;
+    }
+    if (registryModels.some((model) => registryModelUsesOAuth(registry, providerId, model))) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /** Resolve a tagged xAI OAuth credential from pi context or reusable Grok CLI credentials. */
 export async function resolveXaiCredential(ctx: any): Promise<XaiCredential | null> {
   const managedCredential = await resolvePiManagedXaiCredential(ctx);
   if (managedCredential) return managedCredential;
-  if (ctx?.apiKey) return { kind: "oauth-session", token: ctx.apiKey };
+  if (ctx?.apiKey) {
+    return {
+      kind: ctx?.model?.provider === XAI_BUNDLED_PROVIDER_ID ? "api-key" : "oauth-session",
+      token: ctx.apiKey,
+    };
+  }
 
   const credentials = getGrokAuthCredentials();
   if (!credentials?.access) return null;
-  return { kind: "oauth-session", token: (await ensureFreshXaiCredentials(credentials)).access };
+  const credential: XaiCredential = {
+    kind: "oauth-session",
+    token: (await ensureFreshXaiCredentials(credentials)).access,
+  };
+  return ctx?.model?.provider === XAI_BUNDLED_PROVIDER_ID
+    ? { ...credential, catalogScope: "host" }
+    : credential;
 }

--- a/extensions/xai/constants.ts
+++ b/extensions/xai/constants.ts
@@ -58,6 +58,20 @@ export const XAI_CLIENT_VERSION = XAI_PROXY_CLIENT_VERSION;
 export const XAI_USER_AGENT = `${XAI_CLIENT_IDENTIFIER}/${XAI_PACKAGE_VERSION}`;
 export const XAI_GROK_BUILD_REVIEWED_REVISION = "b189869b7755d2b482969acf6c92da3ecfeffd36";
 export const XAI_PROVIDER_ID = "xai-auth";
+export const XAI_BUNDLED_PROVIDER_ID = "xai";
+export const XAI_TOOL_COMPATIBLE_PROVIDER_IDS = [
+  XAI_PROVIDER_ID,
+  XAI_BUNDLED_PROVIDER_ID,
+] as const;
+
+export type XaiToolCompatibleProviderId = (typeof XAI_TOOL_COMPATIBLE_PROVIDER_IDS)[number];
+
+/** Return whether a provider can use this package's opt-in network tools. */
+export function isXaiToolCompatibleProvider(
+  provider: unknown,
+): provider is XaiToolCompatibleProviderId {
+  return XAI_TOOL_COMPATIBLE_PROVIDER_IDS.some((providerId) => provider === providerId);
+}
 export const DEFAULT_XAI_MODEL = "grok-4.5";
 export const DEFAULT_XAI_IMAGE_MODEL = "grok-imagine-image-quality";
 

--- a/extensions/xai/responses.ts
+++ b/extensions/xai/responses.ts
@@ -345,16 +345,16 @@ export async function createXaiResponse(
   const canonicalBody = canonicalizeXaiResponsesPayload(body);
   const requestedModel = typeof canonicalBody.model === "string" ? canonicalBody.model : undefined;
   const model = xaiModelForRequest(requestedModel, credential.kind);
-  const runtimeModel = credential.kind === "oauth-session"
-    ? getXaiRuntimeModel(model.id)
-    : undefined;
-  if (credential.kind === "oauth-session" && !runtimeModel) {
+  const usesPackageCatalog = credential.kind === "oauth-session"
+    && credential.catalogScope !== "host";
+  const runtimeModel = usesPackageCatalog ? getXaiRuntimeModel(model.id) : undefined;
+  if (usesPackageCatalog && !runtimeModel) {
     throw new Error(`xAI OAuth model ${model.id} is not present in the authenticated model catalog`);
   }
   const selectedModelId = runtimeModel?.id ?? model.id;
   const requestModel = selectedModelId === model.id ? model : { ...model, id: selectedModelId };
   const route = resolveXaiRoute(credential.kind, "responses");
-  if (credential.kind === "oauth-session") {
+  if (usesPackageCatalog) {
     assertXaiRuntimeModelAcceptsPayload(selectedModelId, canonicalBody);
   }
   const rewritten = rewriteXaiResponsesPayload(canonicalBody, requestModel);
@@ -362,11 +362,11 @@ export async function createXaiResponse(
     ? applyXaiOAuthResponsesPolicy(rewritten as Record<string, unknown>)
     : rewritten;
   pinXaiPayloadModel(selectedModelId, policyPayload);
-  if (credential.kind === "oauth-session") {
+  if (usesPackageCatalog) {
     assertXaiRuntimeModelAcceptsPayload(selectedModelId, policyPayload);
   }
   const payload = (await compactXaiInlineImages(policyPayload)) as Record<string, any>;
-  if (credential.kind === "oauth-session") {
+  if (usesPackageCatalog) {
     assertXaiRuntimeModelAcceptsPayload(selectedModelId, payload);
   }
   beforeSend?.();

--- a/extensions/xai/routing.ts
+++ b/extensions/xai/routing.ts
@@ -14,6 +14,8 @@ export type XaiCredentialKind = "oauth-session" | "api-key";
 export interface XaiCredential {
   kind: XaiCredentialKind;
   token: string;
+  /** Host means the active model belongs to Pi's built-in catalog, not this package's catalog. */
+  catalogScope?: "host";
 }
 
 export type XaiRequestKind =

--- a/extensions/xai/tools/model-scope.ts
+++ b/extensions/xai/tools/model-scope.ts
@@ -2,7 +2,7 @@ import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import {
   XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME,
-  XAI_PROVIDER_ID,
+  isXaiToolCompatibleProvider,
 } from "../constants";
 
 /** Network-backed xAI tools that make an additional authenticated API request. */
@@ -44,7 +44,7 @@ function activeToolsWithExplicitNetworkSelection(
 /** Return the active xAI model, or undefined when the session is using another provider. */
 export function activeXaiModel(ctx: Pick<ExtensionContext, "model"> | undefined): Model<Api> | undefined {
   const model = ctx?.model;
-  if (model?.provider !== XAI_PROVIDER_ID || typeof model.id !== "string" || !model.id.trim()) return undefined;
+  if (!isXaiToolCompatibleProvider(model?.provider) || typeof model.id !== "string" || !model.id.trim()) return undefined;
   return model as Model<Api>;
 }
 

--- a/extensions/xai/usage.ts
+++ b/extensions/xai/usage.ts
@@ -11,7 +11,7 @@ import {
 import {
   XAI_CLI_BILLING_URL,
   XAI_CLI_USER_URL,
-  XAI_PROVIDER_ID,
+  isXaiToolCompatibleProvider,
   XAI_USAGE_MAX_HISTORY_PERIODS,
   XAI_USAGE_MAX_JSON_ARRAY_ITEMS,
   XAI_USAGE_MAX_JSON_DEPTH,
@@ -367,7 +367,7 @@ function httpError(status: number): XaiUsageError {
   if (status === 401 || status === 403) {
     return new XaiUsageError(
       "auth",
-      "xAI authentication was rejected. Run /login xai-auth and try again.",
+      "xAI authentication was rejected. Run /login xai or /login xai-auth and try again.",
       status,
     );
   }
@@ -391,7 +391,10 @@ async function requestBoundedJson(
   signal?: AbortSignal,
 ): Promise<unknown> {
   if (credential.kind !== "oauth-session" || !credential.token) {
-    throw new XaiUsageError("auth", "xAI OAuth credentials are required. Run /login xai-auth first.");
+    throw new XaiUsageError(
+      "auth",
+      "xAI OAuth credentials are required. Run /login xai or /login xai-auth first.",
+    );
   }
   const controller = new AbortController();
   let timedOut = false;
@@ -594,10 +597,16 @@ export function registerXaiUsage(
     try {
       credential = await dependencies.resolveCredential(ctx);
     } catch {
-      throw new XaiUsageError("auth", "xAI OAuth credentials could not be resolved. Run /login xai-auth first.");
+      throw new XaiUsageError(
+        "auth",
+        "xAI OAuth credentials could not be resolved. Run /login xai or /login xai-auth first.",
+      );
     }
     if (!credential) {
-      throw new XaiUsageError("auth", "xAI OAuth credentials are required. Run /login xai-auth first.");
+      throw new XaiUsageError(
+        "auth",
+        "xAI OAuth credentials are required. Run /login xai or /login xai-auth first.",
+      );
     }
     return dependencies.fetchUsage(credential, signal);
   };
@@ -609,7 +618,7 @@ export function registerXaiUsage(
     lastUi = ctx.ui;
     if (
       !statusEnabled
-      || ctx.model?.provider !== XAI_PROVIDER_ID
+      || !isXaiToolCompatibleProvider(ctx.model?.provider)
       || !hasPiManagedXaiOAuth(ctx)
     ) {
       reset(ctx);
@@ -630,7 +639,7 @@ export function registerXaiUsage(
         if (
           refreshGeneration === generation
           && statusEnabled
-          && ctx.model?.provider === XAI_PROVIDER_ID
+          && isXaiToolCompatibleProvider(ctx.model?.provider)
           && !controller.signal.aborted
         ) {
           ctx.ui.setStatus(XAI_USAGE_STATUS_KEY, renderXaiUsageStatus(usage));
@@ -703,7 +712,7 @@ export function registerXaiUsage(
         ctx.ui.notify("xAI usage status is off for this session.", "info");
         return;
       }
-      if (ctx.model?.provider !== XAI_PROVIDER_ID) {
+      if (!isXaiToolCompatibleProvider(ctx.model?.provider)) {
         reset(ctx);
         ctx.ui.notify("Select an xAI/Grok model before enabling xAI usage status.", "error");
         return;
@@ -725,7 +734,7 @@ export function registerXaiUsage(
     reset,
     clearIfInactive(ctx) {
       if (
-        ctx.model?.provider !== XAI_PROVIDER_ID
+        !isXaiToolCompatibleProvider(ctx.model?.provider)
         || !hasPiManagedXaiOAuth(ctx)
       ) {
         reset(ctx);

--- a/tests/fixtures/models.ts
+++ b/tests/fixtures/models.ts
@@ -14,13 +14,40 @@ export const TEST_MODEL = {
   maxTokens: 131_072,
 } as unknown as Model<Api>;
 
-/** Create a model-registry context returning one OAuth bearer. */
-export function authContext(model: any = TEST_MODEL, token = "oauth-token") {
+export const BUILTIN_XAI_TEST_MODEL = {
+  ...TEST_MODEL,
+  provider: "xai",
+  api: "openai-responses",
+  baseUrl: "https://api.x.ai/v1",
+} as unknown as Model<Api>;
+
+/** Create a model-registry context returning one tagged credential. */
+export function authContext(
+  model: any = TEST_MODEL,
+  token = "oauth-token",
+  credentialType: "oauth" | "api_key" = "oauth",
+) {
+  const storedCredential = credentialType === "oauth"
+    ? { type: "oauth", access: token, refresh: "refresh", expires: Date.now() + 60_000 }
+    : { type: "api_key", key: token };
   return {
     model,
     modelRegistry: {
+      authStorage: {
+        get(provider: string) {
+          return provider === model.provider ? storedCredential : undefined;
+        },
+      },
       find(provider: string, id: string) {
-        return { ...model, provider, id };
+        return provider === model.provider ? { ...model, provider, id } : undefined;
+      },
+      isUsingOAuth(registryModel: any) {
+        return registryModel?.provider === model.provider && credentialType === "oauth";
+      },
+      getProviderAuthStatus(provider: string) {
+        return provider === model.provider
+          ? { configured: true, source: "stored" }
+          : { configured: false };
       },
       async getApiKeyAndHeaders() {
         return { ok: true, apiKey: token };

--- a/tests/provider/credentials.test.ts
+++ b/tests/provider/credentials.test.ts
@@ -6,6 +6,7 @@ import {
   getGrokAuthCredentials,
   getStartupXaiCatalogAuth,
   resolveXaiCredential,
+  resolvePiManagedXaiCredential,
   resolvePiManagedXaiOAuthCredential,
 } from "../../extensions/xai/auth";
 import {
@@ -13,7 +14,7 @@ import {
   setXaiRuntimeModels,
 } from "../../extensions/xai/models";
 import { createTempDir } from "../fixtures/temp";
-import { TEST_MODEL } from "../fixtures/models";
+import { BUILTIN_XAI_TEST_MODEL, TEST_MODEL } from "../fixtures/models";
 let temp: Awaited<ReturnType<typeof createTempDir>>;
 
 const boundaryProviderConfig = {
@@ -181,6 +182,69 @@ describe("credential resolution", () => {
       token: "composer-only-token",
     });
   });
+  it("prefers active built-in OAuth and preserves OAuth-session provenance", async () => {
+    const stored = {
+      type: "oauth",
+      access: "builtin-oauth",
+      refresh: "refresh",
+      expires: Date.now() + 60_000,
+    };
+    const lookups: string[] = [];
+    const ctx = {
+      model: BUILTIN_XAI_TEST_MODEL,
+      modelRegistry: {
+        authStorage: {
+          get: (provider: string) => provider === "xai" ? stored : { ...stored, access: "package-oauth" },
+        },
+        find: (provider: string, id: string) => {
+          lookups.push(provider);
+          return { ...BUILTIN_XAI_TEST_MODEL, provider, id };
+        },
+        isUsingOAuth: () => true,
+        getApiKeyAndHeaders: async (model: any) => ({
+          ok: true,
+          apiKey: model.provider === "xai" ? "builtin-oauth" : "package-oauth",
+        }),
+      },
+    };
+
+    await expect(resolvePiManagedXaiCredential(ctx)).resolves.toEqual({
+      catalogScope: "host",
+      kind: "oauth-session",
+      token: "builtin-oauth",
+    });
+    expect(lookups[0]).toBe("xai");
+    await expect(resolvePiManagedXaiOAuthCredential(ctx)).resolves.toEqual({
+      kind: "oauth-session",
+      token: "builtin-oauth",
+    });
+  });
+  it("tags an active built-in API key for public API routing and rejects it for usage", async () => {
+    const getApiKeyAndHeaders = vi.fn(async () => ({
+      ok: true,
+      apiKey: "BUILTIN_API_KEY",
+    }));
+    const ctx = {
+      model: BUILTIN_XAI_TEST_MODEL,
+      modelRegistry: {
+        authStorage: {
+          get: (provider: string) => provider === "xai"
+            ? { type: "api_key", key: "BUILTIN_API_KEY" }
+            : { type: "oauth", access: "package-oauth" },
+        },
+        find: (provider: string, id: string) => ({ ...BUILTIN_XAI_TEST_MODEL, provider, id }),
+        isUsingOAuth: (model: any) => model.provider === "xai-auth",
+        getApiKeyAndHeaders,
+      },
+    };
+
+    await expect(resolvePiManagedXaiCredential(ctx)).resolves.toEqual({
+      kind: "api-key",
+      token: "BUILTIN_API_KEY",
+    });
+    await expect(resolvePiManagedXaiOAuthCredential(ctx)).resolves.toBeNull();
+    expect(getApiKeyAndHeaders).toHaveBeenCalledTimes(1);
+  });
   it("uses Authorization bearer when registry omits apiKey", async () => {
     const credential = await resolveXaiCredential({
       model: TEST_MODEL,
@@ -246,14 +310,16 @@ describe("credential resolution", () => {
       model: TEST_MODEL,
       modelRegistry: {
         authStorage: {
-          get: () => ({
-            type: "oauth",
-            access: "stored-oauth-access",
-            refresh: "refresh",
-            expires: Date.now() + 60_000,
-          }),
+          get: (provider: string) => provider === "xai-auth"
+            ? {
+                type: "oauth",
+                access: "stored-oauth-access",
+                refresh: "refresh",
+                expires: Date.now() + 60_000,
+              }
+            : undefined,
         },
-        find: () => TEST_MODEL,
+        find: (provider: string) => provider === "xai-auth" ? TEST_MODEL : undefined,
         isUsingOAuth: () => true,
         getApiKeyAndHeaders,
       },

--- a/tests/provider/registration.test.ts
+++ b/tests/provider/registration.test.ts
@@ -27,6 +27,7 @@ describe("provider registration", () => {
     await extension(harness.api);
     const provider = harness.providers.get("xai-auth");
     expect(provider).toBeDefined();
+    expect(harness.providers.has("xai")).toBe(false);
     expect(provider).toMatchObject({
       api: "xai-responses",
       baseUrl: "https://cli-chat-proxy.grok.com/v1",

--- a/tests/tools/commands.test.ts
+++ b/tests/tools/commands.test.ts
@@ -22,7 +22,7 @@ import {
   commandContext,
   createExtensionHarness,
 } from "../fixtures/extension-api";
-import { TEST_MODEL } from "../fixtures/models";
+import { BUILTIN_XAI_TEST_MODEL, TEST_MODEL } from "../fixtures/models";
 
 function setup() {
   const h = createExtensionHarness();
@@ -79,6 +79,13 @@ describe("/xai-tools command", () => {
     await run("disable vision-routing");
     expect(routing.status(model as any).state).toBe("eligible");
     expect(h.getActiveTools()).not.toContain("vision-routing");
+
+    const builtInModel = { ...model, provider: "xai" };
+    await h.commands
+      .get("xai-tools")
+      .handler("enable vision-routing", commandContext(builtInModel, notices));
+    expect(routing.status(builtInModel as any).state).toBe("unavailable");
+    expect(notices.at(-1).message).toMatch(/Select an xAI\/Grok model first/);
   });
 
   it("registers and enables/disables one eligible tool with cost warning", async () => {
@@ -135,6 +142,14 @@ describe("/xai-tools command", () => {
     await run("enable xai_web_search");
     expect(isXaiNetworkToolActive(h.api, XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME)).toBe(true);
     expect(notices.at(-1).message).toMatch(/Enabled web_search/);
+  });
+  it("enables web_search for Pi's built-in xAI provider", async () => {
+    const { h, notices, run } = setup();
+
+    await run("enable web_search", BUILTIN_XAI_TEST_MODEL);
+
+    expect(isXaiNetworkToolActive(h.api, XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME)).toBe(true);
+    expect(notices.at(-1).message).toMatch(/Enabled web_search.*may use xAI credits/s);
   });
   it("fails closed when registry reads or writes fail", async () => {
     const { h, notices, run } = setup();

--- a/tests/tools/grok-native.test.ts
+++ b/tests/tools/grok-native.test.ts
@@ -19,7 +19,7 @@ import {
 } from "../../extensions/xai/tools/grok-native";
 import { setXaiNetworkToolActive } from "../../extensions/xai/tools/model-scope";
 import { createExtensionHarness } from "../fixtures/extension-api";
-import { authContext, TEST_MODEL } from "../fixtures/models";
+import { authContext, BUILTIN_XAI_TEST_MODEL, TEST_MODEL } from "../fixtures/models";
 import { jsonResponse, requestBody } from "../fixtures/http";
 import { createTempDir } from "../fixtures/temp";
 
@@ -607,6 +607,38 @@ describe("Grok-native tools", () => {
     expect(stale.content[0].text).toMatch(/requires an active xAI/);
     expect(requests).toHaveLength(1);
   });
+  it("routes built-in xAI OAuth outside the package catalog and API keys through the public API", async () => {
+    setXaiRuntimeModels(CURATED_FALLBACK_MODELS);
+    const builtInModel = { ...BUILTIN_XAI_TEST_MODEL, id: "grok-4.3" } as any;
+    expect(
+      setXaiNetworkToolActive(
+        h.api,
+        builtInModel,
+        XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME,
+        true,
+      ),
+    ).toEqual({ ok: true, active: true });
+
+    const execute = (credentialType: "oauth" | "api_key") => h.tools
+      .get(XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME)
+      .execute(
+        "call",
+        { query: `built-in ${credentialType}` },
+        new AbortController().signal,
+        () => {},
+        {
+          cwd: temp.path,
+          ...authContext(builtInModel, `${credentialType}-token`, credentialType),
+        },
+      );
+
+    expect((await execute("oauth")).content[0].text).toBe("OK");
+    expect((await execute("api_key")).content[0].text).toBe("OK");
+    expect(requests.map(({ url }) => url)).toEqual([
+      "https://cli-chat-proxy.grok.com/v1/responses",
+      "https://api.x.ai/v1/responses",
+    ]);
+  });
 
   it("returns an explicit fallback for a successful web_search response without text", async () => {
     const model = { ...TEST_MODEL, id: "grok-4.5" };
@@ -637,7 +669,7 @@ describe("Grok-native tools", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("activates native local tools without mutating unrelated public tools", () => {
+  it("activates native local tools only for xai-auth without mutating unrelated public tools", () => {
     const foreignNames = Object.values(XAI_GROK_NATIVE_TOOL_NAME_MAP);
     h.setActiveTools(["read", "bash", ...foreignNames]);
     syncGrokNativeToolsForModel(h.api, TEST_MODEL);
@@ -654,6 +686,12 @@ describe("Grok-native tools", () => {
     for (const name of XAI_GROK_NATIVE_AUTO_TOOL_NAMES) {
       expect(h.getActiveTools()).toContain(name);
     }
+
+    syncGrokNativeToolsForModel(h.api, BUILTIN_XAI_TEST_MODEL);
+    for (const name of XAI_GROK_NATIVE_AUTO_TOOL_NAMES) {
+      expect(h.getActiveTools()).not.toContain(name);
+    }
+    for (const name of foreignNames) expect(h.getActiveTools()).toContain(name);
 
     syncGrokNativeToolsForModel(h.api, { provider: "anthropic", id: "claude" } as any);
     for (const name of XAI_GROK_NATIVE_AUTO_TOOL_NAMES) {

--- a/tests/tools/model-scope.test.ts
+++ b/tests/tools/model-scope.test.ts
@@ -10,7 +10,7 @@ import {
   XAI_NETWORK_TOOL_NAMES,
 } from "../../extensions/xai/tools/model-scope";
 import { createExtensionHarness } from "../fixtures/extension-api";
-import { TEST_MODEL } from "../fixtures/models";
+import { BUILTIN_XAI_TEST_MODEL, TEST_MODEL } from "../fixtures/models";
 
 describe("network-tool lifecycle", () => {
   it("requires an active xAI model for web_search", () => {
@@ -38,18 +38,22 @@ describe("network-tool lifecycle", () => {
     ).toBe(true);
     expect(h.getActiveTools()).toContain("read");
   });
-  it("preserves explicit selections but removes them outside xAI", () => {
+  it("preserves explicit selections for both xAI providers but removes them outside xAI", () => {
     const h = createExtensionHarness();
-    setXaiNetworkToolActive(h.api, TEST_MODEL, "xai_generate_image", true);
-    syncXaiNetworkToolsForModel(h.api, TEST_MODEL);
+    setXaiNetworkToolActive(h.api, BUILTIN_XAI_TEST_MODEL, "xai_generate_image", true);
+    syncXaiNetworkToolsForModel(h.api, BUILTIN_XAI_TEST_MODEL);
     expect(isXaiNetworkToolActive(h.api, "xai_generate_image")).toBe(true);
     syncXaiNetworkToolsForModel(h.api, {
       provider: "anthropic",
       id: "claude",
     } as any);
     expect(h.getActiveTools()).not.toContain("xai_generate_image");
-    syncXaiNetworkToolsForModel(h.api, TEST_MODEL);
+    syncXaiNetworkToolsForModel(h.api, BUILTIN_XAI_TEST_MODEL);
     expect(h.getActiveTools()).not.toContain("xai_generate_image");
+
+    expect(
+      setXaiNetworkToolActive(h.api, TEST_MODEL, "xai_generate_image", true),
+    ).toEqual({ ok: true, active: true });
   });
   it("does not mutate another extension's public web_search activation", () => {
     const h = createExtensionHarness(["read", XAI_GROK_NATIVE_WEB_SEARCH_NAME]);

--- a/tests/usage/status.test.ts
+++ b/tests/usage/status.test.ts
@@ -4,7 +4,7 @@ import {
   type XaiUsageSnapshot,
 } from "../../extensions/xai/usage";
 import { commandContext, createExtensionHarness } from "../fixtures/extension-api";
-import { TEST_MODEL } from "../fixtures/models";
+import { BUILTIN_XAI_TEST_MODEL, TEST_MODEL } from "../fixtures/models";
 
 const usage: XaiUsageSnapshot = {
   creditUsagePercent: 25,
@@ -35,10 +35,15 @@ function setup(model: any = TEST_MODEL) {
     signal: undefined,
     modelRegistry: {
       authStorage: {
-        get: () => storedCredential,
+        get: (provider: string) => provider === model.provider ? storedCredential : undefined,
       },
-      find: () => TEST_MODEL,
-      isUsingOAuth: () => storedCredential?.type === "oauth",
+      find: (provider: string, id: string) =>
+        provider === model.provider ? { ...model, provider, id } : undefined,
+      isUsingOAuth: (registryModel: any) =>
+        registryModel?.provider === model.provider && storedCredential?.type === "oauth",
+      getProviderAuthStatus: (provider: string) => provider === model.provider
+        ? { configured: !!storedCredential, source: "stored" }
+        : { configured: false },
     },
     ui: {
       notify(message: string, type?: string) {
@@ -86,6 +91,25 @@ describe("/xai-usage command and status lifecycle", () => {
     await run("enable");
     expect(notifications.at(-1)?.message).toBe("Usage: /xai-usage [status [on|off]]");
   });
+  it("enables status for a built-in xAI model with SuperGrok OAuth", async () => {
+    const state = setup(BUILTIN_XAI_TEST_MODEL);
+
+    await state.run("status on");
+
+    expect(state.fetchUsage).toHaveBeenCalledTimes(1);
+    expect(state.statuses.at(-1)?.text).toBe("xAI 25% used · reset 2026-08-01");
+    expect(state.notifications.at(-1)?.message).toMatch(/status is on/);
+  });
+  it("rejects built-in API-key provenance before usage resolution", async () => {
+    const state = setup(BUILTIN_XAI_TEST_MODEL);
+    state.setStoredCredential({ type: "api_key", key: "BUILTIN_API_KEY" });
+
+    await state.run("status on");
+
+    expect(state.resolveCredential).not.toHaveBeenCalled();
+    expect(state.fetchUsage).not.toHaveBeenCalled();
+    expect(state.notifications.at(-1)?.message).toMatch(/could not be refreshed/);
+  });
 
   it("never treats an unrelated active-model API key as an xAI OAuth bearer", async () => {
     const harness = createExtensionHarness();
@@ -107,7 +131,7 @@ describe("/xai-usage command and status lifecycle", () => {
 
     expect(ctx.modelRegistry.getApiKeyAndHeaders).not.toHaveBeenCalled();
     expect(notifications.at(-1)).toEqual({
-      message: "xAI OAuth credentials are required. Run /login xai-auth first.",
+      message: "xAI OAuth credentials are required. Run /login xai or /login xai-auth first.",
       type: "error",
     });
   });


### PR DESCRIPTION
## Summary
- Treat active built-in `xai/*` models as tool-compatible for `/xai-tools` and network-backed tools
- Resolve SuperGrok OAuth / API-key credentials from the built-in `xai` provider with correct provenance
- Keep Grok-native local adapters and package-owned catalog/stream on `xai-auth` only
- Allow `/xai-usage` status gating for built-in SuperGrok OAuth sessions

## Test plan
- [x] `npm test` (506 tests + loader)
- [x] `npm run typecheck`
- [x] Focused credentials / model-scope / commands / usage / grok-native tests

Closes #132
