### PR TITLE
fix: seed native xai chat defaults instead of forcing xai-auth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 > **For AI coding agents only.** Keep this file machine-readable and concise. Human-facing docs live in README.md.
 
 ## Project Overview
-pi-xai-oauth is a pi-package that registers the xAI OAuth provider (`xai-auth`) and the authenticated account's OAuth-visible Grok model catalog for the pi coding agent framework, with Grok 4.5 as the curated offline fallback.
+pi-xai-oauth is a pi-package that registers the optional xAI OAuth provider (`xai-auth`) and the authenticated account's OAuth-visible Grok model catalog, with Grok 4.5 as the curated offline fallback. Opt-in network tools and `/xai-usage` also work with Pi's built-in `xai` SuperGrok/X Premium chat provider; setup seeds `defaultProvider: xai` only when unset and never overwrites an existing provider choice.
 
 Core flow: `bin/setup.js` → `pi install` → bounded catalog selection in `extensions/xai/catalog.ts` → provider registration in `extensions/xai-oauth.ts` → browser PKCE or bounded device authorization in `extensions/xai/oauth.ts` / `extensions/xai/device-auth.ts` → pinned browser OIDC/JWKS validation in `extensions/xai/oidc.ts` → streaming via xAI API helpers in `extensions/xai/responses.ts`; explicit revision-pinned subscription usage lives in `extensions/xai/usage.ts`.
 
@@ -58,7 +58,7 @@ Core flow: `bin/setup.js` → `pi install` → bounded catalog selection in `ext
 ```
 pi-xai-oauth/
 ├── bin/
-│   └── setup.js          # One-command installer + settings seeder
+│   └── setup.js          # Installer + settings seeder (native xai default when unset)
 ├── extensions/
 │   ├── xai-oauth.ts      # Thin entrypoint: provider registration + tool orchestration
 │   └── xai/              # Focused implementation modules
@@ -157,5 +157,5 @@ This repo is a **pi extension package (a library/CLI), not a standalone server**
 
 - Build / typecheck gate: `npm run typecheck` (`tsc --noEmit`). There is **no separate lint tool** configured; typecheck is the static gate.
 - Tests: `npm test` runs compatibility policy, focused Vitest regressions, and the small real Pi loader smoke. Use `npm run test:coverage` for V8 output and `npm run test:unit -- <path> -t <name>` for focus.
-- Running the "app": full end-to-end use (`pi`, `/login xai-auth`, live Grok streaming) needs the external `pi` CLI, an interactive browser OAuth flow, and a real xAI/Grok account, so it is **not runnable headless** here. Offline behavior lives in focused `tests/` suites with isolated fixtures; `npm run test:loader` exercises the real Pi loader without live xAI access. Catalog fixtures live under `tests/fixtures/models-v2/`.
+- Running the "app": full end-to-end use (`pi`, `/login xai` and/or `/login xai-auth`, live Grok streaming) needs the external `pi` CLI, an interactive browser OAuth flow, and a real xAI/Grok account, so it is **not runnable headless** here. Offline behavior lives in focused `tests/` suites with isolated fixtures; `npm run test:loader` exercises the real Pi loader without live xAI access. Catalog fixtures live under `tests/fixtures/models-v2/`.
 - Any temporary demo script that imports deps must live inside the repo root (so it resolves `node_modules`), not `/tmp`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 
 ## Unreleased
 
+### Changed
+
+- Setup no longer forces `defaultProvider: xai-auth`. When no provider is configured it seeds Pi's built-in `xai` chat provider, preserves any existing provider choice (including package-owned `xai-auth`), and still installs opt-in tools plus `/xai-usage` for both providers.
+
 ## 1.4.0 - 2026-07-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -124,9 +124,11 @@ npx pi-xai-oauth
 
 This runs the setup script which:
 1. Installs `npm:pi-xai-oauth` into pi
-2. Sets `xai-auth` as your default provider
+2. Seeds `defaultProvider: "xai"` only when no provider is configured (never overwrites an existing choice, including package-owned `xai-auth`)
 3. Sets `grok-4.5` as your default model
 4. Enables `high` thinking level by default
+
+Chat stays on Pi's built-in `xai` provider by default. This package still registers optional `xai-auth` for its account catalog/stream path, and both providers can use `/xai-tools` plus `/xai-usage`.
 
 ### Manual install
 
@@ -134,16 +136,18 @@ This runs the setup script which:
 pi install npm:pi-xai-oauth
 ```
 
-Then optionally configure it as default:
+Recommended settings for native SuperGrok chat plus this package's tools/usage:
 
 ```bash
 # In ~/.pi/agent/settings.json:
 {
-  "defaultProvider": "xai-auth",
+  "defaultProvider": "xai",
   "defaultModel": "grok-4.5",
   "defaultThinkingLevel": "high"
 }
 ```
+
+Authenticate with `/login xai`. Use `/login xai-auth` only when you want this package's OAuth Responses catalog instead of Pi's built-in xAI chat.
 
 > **⚠️ Important: install only one copy**
 >
@@ -609,7 +613,8 @@ Opt-in research using the active xAI model plus native web and X search tools. E
 | Install | `pi install npm:pi-xai-oauth` |
 | One-command setup | `npx pi-xai-oauth` |
 | Try ephemeral | `pi -e npm:pi-xai-oauth` |
-| Authenticate | Launch `pi`, run `/login xai-auth`, then choose browser (default) or device code |
+| Authenticate (chat default) | Launch `pi`, run `/login xai` |
+| Authenticate (optional package catalog) | Launch `pi`, run `/login xai-auth`, then choose browser (default) or device code |
 | Update | `pi update npm:pi-xai-oauth` |
 | Remove | `pi remove npm:pi-xai-oauth` |
 | List packages | `pi list` |

--- a/bin/setup.js
+++ b/bin/setup.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * pi-xai-oauth — One-command installer for xAI (Grok) OAuth + Grok 4.5
+ * pi-xai-oauth — One-command installer for xAI tools/usage + optional OAuth catalog
  * Enhanced with --scaffold support for 2026 agent best practices
  */
 
@@ -12,6 +12,12 @@ const os = require("os");
 
 const PACKAGE_NAME = "pi-xai-oauth";
 const NPM_SPEC = `npm:${PACKAGE_NAME}`;
+/** Pi's built-in SuperGrok/X Premium provider used for normal chat. */
+const BUNDLED_XAI_PROVIDER = "xai";
+/** Package-owned OAuth catalog/stream provider (optional). */
+const PACKAGE_OAUTH_PROVIDER = "xai-auth";
+const DEFAULT_XAI_MODEL = "grok-4.5";
+const DEFAULT_THINKING_LEVEL = "high";
 const SETTINGS_PATH = path.join(os.homedir(), ".pi/agent/settings.json");
 
 // ANSI colors
@@ -29,8 +35,9 @@ function color(text, c) {
 }
 
 function printHeader() {
-  console.log(`\n${color("🚀  pi-xai-oauth", "cyan")} — ${color("xAI Grok + OAuth for pi", "bold")}\n`);
-  console.log("   One-command setup for Grok 4.5 plus your account's OAuth-visible xAI model catalog.\n");
+  console.log(`\n${color("🚀  pi-xai-oauth", "cyan")} — ${color("xAI tools + usage for pi", "bold")}\n`);
+  console.log("   Installs opt-in xAI tools and /xai-usage alongside Pi's built-in xAI chat.");
+  console.log(`   Optional package-owned catalog/stream remains available as ${PACKAGE_OAUTH_PROVIDER}.\n`);
 }
 
 function checkPi() {
@@ -170,22 +177,26 @@ function updateSettings(settingsPath = SETTINGS_PATH) {
     console.log(color(`   + Added ${NPM_SPEC} to packages`, "green"));
   }
 
-  if (settings.defaultProvider !== "xai-auth") {
-    settings.defaultProvider = "xai-auth";
+  // Prefer Pi's built-in xAI chat when no provider is configured. Never overwrite
+  // an existing choice — including package-owned xai-auth or any other provider.
+  if (typeof settings.defaultProvider !== "string" || !settings.defaultProvider.trim()) {
+    settings.defaultProvider = BUNDLED_XAI_PROVIDER;
     changed = true;
-    console.log(color("   + Set defaultProvider: xai-auth", "green"));
+    console.log(color(`   + Set defaultProvider: ${BUNDLED_XAI_PROVIDER}`, "green"));
+  } else if (settings.defaultProvider === PACKAGE_OAUTH_PROVIDER) {
+    console.log(color(`   (Keeping defaultProvider: ${PACKAGE_OAUTH_PROVIDER})`, "reset"));
   }
 
-  if (settings.defaultModel !== "grok-4.5") {
-    settings.defaultModel = "grok-4.5";
+  if (settings.defaultModel !== DEFAULT_XAI_MODEL) {
+    settings.defaultModel = DEFAULT_XAI_MODEL;
     changed = true;
-    console.log(color("   + Set defaultModel: grok-4.5", "green"));
+    console.log(color(`   + Set defaultModel: ${DEFAULT_XAI_MODEL}`, "green"));
   }
 
-  if (settings.defaultThinkingLevel !== "high") {
-    settings.defaultThinkingLevel = "high";
+  if (settings.defaultThinkingLevel !== DEFAULT_THINKING_LEVEL) {
+    settings.defaultThinkingLevel = DEFAULT_THINKING_LEVEL;
     changed = true;
-    console.log(color("   + Set defaultThinkingLevel: high", "green"));
+    console.log(color(`   + Set defaultThinkingLevel: ${DEFAULT_THINKING_LEVEL}`, "green"));
   }
 
   if (changed) {
@@ -207,13 +218,19 @@ function printNextSteps(nonInteractive = false) {
 
   if (!nonInteractive) {
     console.log("Next steps:\n");
-    console.log(`   ${color("1.", "bold")} Authenticate with xAI OAuth:`);
+    console.log(`   ${color("1.", "bold")} Authenticate for chat (Pi built-in xAI):`);
     console.log(`      ${color("pi", "cyan")}`);
-    console.log("      Then run /login xai-auth and choose browser (default) or device code.\n");
-    console.log(`   ${color("2.", "bold")} Start chatting with Grok 4.5 (already set as default)`);
+    console.log("      Then run /login xai\n");
+    console.log(`   ${color("2.", "bold")} Optional package-owned OAuth catalog/stream:`);
+    console.log("      Run /login xai-auth only if you want this package's Responses catalog.");
+    console.log("      Prefer browser (default) or device code.\n");
+    console.log(`   ${color("3.", "bold")} Use package tools and subscription usage on either provider:`);
+    console.log("      /xai-tools   — opt-in network tools (web/X search, images, etc.)");
+    console.log("      /xai-usage   — SuperGrok subscription usage\n");
+    console.log(`   ${color("4.", "bold")} Start chatting with Grok 4.5 (default model)`);
     console.log(`      ${color("pi", "cyan")}\n`);
   } else {
-    console.log("Grok 4.5 plus your account's OAuth-visible xAI models are now configured and ready.\n");
+    console.log("Package tools and /xai-usage are installed. Chat defaults to Pi's built-in xAI provider when unset.\n");
   }
 
   console.log("You now have access to powerful reasoning, coding models, and long context!\n");
@@ -383,9 +400,9 @@ See .scaffold/plan.md for current roadmap.`;
 }
 
 function printHelp() {
-  console.log(`\n${color("pi-xai-oauth", "cyan")} — CLI for xAI OAuth setup and agent scaffolding\n`);
+  console.log(`\n${color("pi-xai-oauth", "cyan")} — CLI for xAI tools/usage setup and agent scaffolding\n`);
   console.log("Usage:");
-  console.log("  npx pi-xai-oauth              Run interactive xAI OAuth + settings setup");
+  console.log("  npx pi-xai-oauth              Install package + seed native xAI chat defaults when unset");
   console.log("  npx pi-xai-oauth --scaffold   Generate .scaffold/ harness in current project");
   console.log("  npx pi-xai-oauth --yes        Non-interactive / automated mode");
   console.log("  npx pi-xai-oauth --help       Show this help\n");

--- a/tests/setup/settings.test.ts
+++ b/tests/setup/settings.test.ts
@@ -65,7 +65,7 @@ describe("setup settings", () => {
       addedNpmPackage: true,
     });
   });
-  it("writes pruned packages and preserves configured defaults", async () => {
+  it("writes pruned packages and preserves package-owned xai-auth defaults", async () => {
     await mkdir(join(settingsPath, ".."), { recursive: true });
     await writeFile(
       settingsPath,
@@ -85,6 +85,41 @@ describe("setup settings", () => {
       defaultModel: "grok-4.5",
       defaultThinkingLevel: "high",
       unrelated: true,
+    });
+  });
+  it("defaults missing provider to native xai without overwriting other providers", async () => {
+    await mkdir(join(settingsPath, ".."), { recursive: true });
+    await writeFile(
+      settingsPath,
+      JSON.stringify({
+        packages: ["npm:other"],
+        defaultModel: "some-other-model",
+        defaultThinkingLevel: "low",
+      }),
+    );
+    setup.updateSettings(settingsPath);
+    expect(JSON.parse(await readFile(settingsPath, "utf8"))).toMatchObject({
+      packages: ["npm:other", "npm:pi-xai-oauth"],
+      defaultProvider: "xai",
+      defaultModel: "grok-4.5",
+      defaultThinkingLevel: "high",
+    });
+
+    await writeFile(
+      settingsPath,
+      JSON.stringify({
+        packages: ["npm:pi-xai-oauth"],
+        defaultProvider: "anthropic",
+        defaultModel: "claude-opus-4-6",
+        defaultThinkingLevel: "medium",
+      }),
+    );
+    setup.updateSettings(settingsPath);
+    expect(JSON.parse(await readFile(settingsPath, "utf8"))).toMatchObject({
+      packages: ["npm:pi-xai-oauth"],
+      defaultProvider: "anthropic",
+      defaultModel: "grok-4.5",
+      defaultThinkingLevel: "high",
     });
   });
 });


### PR DESCRIPTION
## Summary

- Stop forcing `defaultProvider: xai-auth` during setup; seed Pi's built-in `xai` only when no provider is configured, and preserve any existing choice (including package-owned `xai-auth`)
- Keep installing opt-in `/xai-tools` and `/xai-usage` for both `xai` and `xai-auth`
- Update README/AGENTS/CHANGELOG plus setup regression coverage for the dual-path install flow

## Why

Users who authenticate with native SuperGrok (`/login xai`) still want this package for tools and usage. Forcing `xai-auth` (and stale `enabledModels` patterns) produced startup warnings like `No models match pattern "xai-auth/grok-4.5"` even though the package loaded correctly.

## Test plan

- [x] `npm run test:unit -- tests/setup/settings.test.ts`
- [x] `npm run typecheck`
- [ ] `npm test` (optional full gate before merge)
- [ ] Fresh install path: empty settings → setup seeds `defaultProvider: xai`
- [ ] Existing `xai-auth` settings are preserved
- [ ] Existing non-xAI provider is preserved; model/thinking defaults still applied
- [ ] With package installed + `/login xai`, no `xai-auth/*` match warnings when `enabledModels` uses `xai/grok-4.5`
