### PR TITLE
chore(compat): adopt Pi 0.82 as the latest tested boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 ### Changed
 
 - Setup no longer forces `defaultProvider: xai-auth`. When no provider is configured it seeds Pi's built-in `xai` chat provider, preserves any existing provider choice (including package-owned `xai-auth`), and still installs opt-in tools plus `/xai-usage` for both providers.
+- Reviewed the Pi 0.82 line and adopted it as the latest exact tested boundary after clean packed candidate validation, while preserving the 0.80.1 minimum. Pi 0.82's `bash` factory reads the tool execution context's session manager, active model, and thinking level to expose `PI_*` session metadata; the Grok-native `run_terminal_command` adapter delegates that context unchanged and is now covered by a realistic session-context test.
+- Widened aligned Pi peers to `>=0.80.1 <0.83.0` and pinned development metadata and the lockfile exactly to 0.82.1, the latest release inside the allowed line at review time.
 
 ## 1.4.0 - 2026-07-23
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This package adds xAI's **account-specific OAuth model catalog** to pi, with **G
 
 > **Latest release:** `pi-xai-oauth` **1.4.0** adds opt-in vision routing, image-to-video generation, the `pi-clickable-menu:xai-tools` bridge, built-in SuperGrok network-tool/usage support, and Pi 0.81.1 compatibility, while hardening credential isolation, local media bounds, and Grok-native path containment. Existing npm installs should run `pi update npm:pi-xai-oauth`; local checkout installs should keep only one copy with `pi remove npm:pi-xai-oauth && pi install .`.
 >
-> **Compatibility:** 1.4.0 supports aligned `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` versions `>=0.80.1 <0.82.0`. The exact tested boundaries are 0.80.1 and 0.81.1.
+> **Compatibility:** aligned `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` versions `>=0.80.1 <0.83.0`. The exact tested boundaries are 0.80.1 and 0.82.1.
 
 See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and fix history.
 
@@ -180,13 +180,13 @@ Authenticate with `/login xai`. Use `/login xai-auth` only when you want this pa
 Both Pi runtime peers use the same bounded range:
 
 ```text
-@earendil-works/pi-ai:            >=0.80.1 <0.82.0
-@earendil-works/pi-coding-agent:  >=0.80.1 <0.82.0
+@earendil-works/pi-ai:            >=0.80.1 <0.83.0
+@earendil-works/pi-coding-agent:  >=0.80.1 <0.83.0
 ```
 
-The lower boundary is **0.80.1**, the first published Pi 0.80 release. It provides the `@earendil-works/pi-ai/compat` transport used by this extension and the matching Pi 0.80 extension-loader contract. The packed package's complete test and typecheck suites run against exact 0.80.1 in CI. The other matrix boundary is exact **0.81.1**, the latest release inside the allowed line when this policy was reviewed. Pi 0.80.8 introduced the unified `ModelRuntime` credential API and replaced the exported `AuthStorage` surface with `readStoredCredential()` for one-off reads; this package supports both the 0.80.1 legacy surface and the 0.81.x ModelRegistry projection of `ModelRuntime.getAuth` through a bounded compatibility path.
+The lower boundary is **0.80.1**, the first published Pi 0.80 release. It provides the `@earendil-works/pi-ai/compat` transport used by this extension and the matching Pi 0.80 extension-loader contract. The packed package's complete test and typecheck suites run against exact 0.80.1 in CI. The other matrix boundary is exact **0.82.1**, the latest release inside the allowed line when this policy was reviewed. Pi 0.80.8 introduced the unified `ModelRuntime` credential API and replaced the exported `AuthStorage` surface with `readStoredCredential()` for one-off reads; this package supports both the 0.80.1 legacy surface and the 0.81.x/0.82.x ModelRegistry projection of `ModelRuntime.getAuth` through a bounded compatibility path. Pi 0.82 additionally reads the tool execution context's session manager, active model, and thinking level to expose `PI_*` session metadata to `bash`; the Grok-native `run_terminal_command` adapter delegates that context unchanged and is covered by the packed 0.82 boundary run.
 
-The exclusive `<0.82.0` upper bound is deliberate. Pi is pre-1.0, so a new minor line may contain breaking API or loader changes; this project does not claim support until that line passes the packed compatibility suite. npm therefore reports a peer-resolution warning or error during installation for older releases such as 0.79.10 and for the untested 0.82 line, rather than allowing a later runtime loader failure.
+The exclusive `<0.83.0` upper bound is deliberate. Pi is pre-1.0, so a new minor line may contain breaking API or loader changes; this project does not claim support until that line passes the packed compatibility suite. npm therefore reports a peer-resolution warning or error during installation for older releases such as 0.79.10 and for the untested 0.83 line, rather than allowing a later runtime loader failure.
 
 Older `pi-xai-oauth` 1.2.4 builds supported Pi 0.79.8's then-current Responses guard. Current code uses the Pi 0.80 compat dispatcher after the 1.3.2 export migration and 1.3.3 loader-resolution fix, so that historical statement is not the current minimum.
 
@@ -758,7 +758,7 @@ pi update npm:pi-xai-oauth
 
 This pulls the latest version from npm and updates your installed extension.
 
-Version 1.4.0 requires aligned Pi runtime packages in `>=0.80.1 <0.82.0`, with exact packed-package validation at 0.80.1 and 0.81.1. It adds opt-in vision routing, image-to-video generation, the menu bridge, built-in SuperGrok tool/usage support, and further transport and entitlement hardening on top of authenticated model discovery, device OAuth, encrypted reasoning replay, Grok-native tools, bounded image editing, and explicit subscription usage. See [CHANGELOG.md](CHANGELOG.md) for the complete release notes. If you installed the published npm package, update with the command above. If you are testing a local checkout instead, reinstall the checkout:
+The current build requires aligned Pi runtime packages in `>=0.80.1 <0.83.0`, with exact packed-package validation at 0.80.1 and 0.82.1. Version 1.4.0 added opt-in vision routing, image-to-video generation, the menu bridge, built-in SuperGrok tool/usage support, and further transport and entitlement hardening on top of authenticated model discovery, device OAuth, encrypted reasoning replay, Grok-native tools, bounded image editing, and explicit subscription usage. See [CHANGELOG.md](CHANGELOG.md) for the complete release notes. If you installed the published npm package, update with the command above. If you are testing a local checkout instead, reinstall the checkout:
 
 ```bash
 pi remove npm:pi-xai-oauth && pi install .

--- a/compatibility/pi-versions.json
+++ b/compatibility/pi-versions.json
@@ -3,11 +3,11 @@
     "@earendil-works/pi-ai",
     "@earendil-works/pi-coding-agent"
   ],
-  "peerRange": ">=0.80.1 <0.82.0",
+  "peerRange": ">=0.80.1 <0.83.0",
   "minimum": "0.80.1",
-  "latest": "0.81.1",
+  "latest": "0.82.0",
   "unsupported": {
     "older": "0.79.10",
-    "upper": "0.82.0"
+    "upper": "0.83.0"
   }
 }

--- a/compatibility/pi-versions.json
+++ b/compatibility/pi-versions.json
@@ -5,7 +5,7 @@
   ],
   "peerRange": ">=0.80.1 <0.83.0",
   "minimum": "0.80.1",
-  "latest": "0.82.0",
+  "latest": "0.82.1",
   "unsupported": {
     "older": "0.79.10",
     "upper": "0.83.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "pi-xai-oauth": "bin/setup.js"
       },
       "devDependencies": {
-        "@earendil-works/pi-ai": "0.81.1",
-        "@earendil-works/pi-coding-agent": "0.81.1",
+        "@earendil-works/pi-ai": "0.82.0",
+        "@earendil-works/pi-coding-agent": "0.82.0",
         "@types/node": "^26.0.0",
         "@vitest/coverage-v8": "4.1.10",
         "jiti": "^2.7.0",
@@ -21,8 +21,8 @@
         "vitest": "4.1.10"
       },
       "peerDependencies": {
-        "@earendil-works/pi-ai": ">=0.80.1 <0.82.0",
-        "@earendil-works/pi-coding-agent": ">=0.80.1 <0.82.0"
+        "@earendil-works/pi-ai": ">=0.80.1 <0.83.0",
+        "@earendil-works/pi-coding-agent": ">=0.80.1 <0.83.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -548,13 +548,14 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.81.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.81.1.tgz",
-      "integrity": "sha512-yqbh68CyhqxMov/jUogFJfMqlu2Gd37GAki+tr59YCmAPHfomiCA5ESzusXtpGzABeiZFC/OrRdQ4GwCCOMIHA==",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.82.1.tgz",
+      "integrity": "sha512-Z3kloziJIE2dmrisRckZX8zDca/gIv9/YdFAzeoqpHiLV2wsni6bL4hInNSjVKLbqT+4kqLIkph2JQLKvSepjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.81.1",
+        "@earendil-works/pi-ai": "^0.82.1",
+        "diff": "8.0.4",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -563,10 +564,36 @@
         "node": ">=22.19.0"
       }
     },
+    "node_modules/@earendil-works/pi-agent-core/node_modules/@earendil-works/pi-ai": {
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.1.tgz",
+      "integrity": "sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@google/genai": "1.52.0",
+        "@mistralai/mistralai": "2.2.6",
+        "@opentelemetry/api": "1.9.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.26.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.1.38"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.81.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.81.1.tgz",
-      "integrity": "sha512-hzHE7Z8l5mgJk+ke67Lge0rwS2+wbKJrFKl9o5M1R1rh33+cCT7D1AHz1OAtX5wFs90E1/BTGhyJRTUHaMxGvQ==",
+      "version": "0.82.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.0.tgz",
+      "integrity": "sha512-8MvW9+zno13sXDuT2kFMnWeTNUufUhPeZDRVO+igGoBRCDWgn7Xh2FkRQI1mRuet6QhF4ENQuLYdIAOyG6BhNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -590,15 +617,15 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.81.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.81.1.tgz",
-      "integrity": "sha512-r6ovAsZOgAqbC/aU6s+/dPnv/sGZBuWyZNvi3pXjpbuX5wvp3XvGkQI7/VLvX2o9XpmpFaPUxKNym1WfkN/P8A==",
+      "version": "0.82.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.82.0.tgz",
+      "integrity": "sha512-Qnqgn9zhJFQ2HZ8R4iNuGhyCk93XX6+eUw9i+TjTuo47amzCy93ft3bB6yaUCleCrNO58dJDHYSGNHv/GAPWKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.81.1",
-        "@earendil-works/pi-ai": "^0.81.1",
-        "@earendil-works/pi-tui": "^0.81.1",
+        "@earendil-works/pi-agent-core": "^0.82.0",
+        "@earendil-works/pi-ai": "^0.82.0",
+        "@earendil-works/pi-tui": "^0.82.0",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -865,16 +892,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -1085,9 +1102,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.81.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.81.1.tgz",
-      "integrity": "sha512-OMEe+Zt8oQYi/rCq3upxsTlIScWL0FPhXwQus34TbQb3EmTx88S7Uzx32JxvQiEeWOw8eDCdJf2PBUBE9r6wIg==",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.1.tgz",
+      "integrity": "sha512-9yN8hALfKaxZq7n54EMxqhFCWnMi6LHkraMJ/1YjHiATq75XrI6XDMVppn9EDtiK7Fks8hUe1SDXUTrIvwRWfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2442,6 +2459,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/ecdsa-sig-formatter": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "pi-xai-oauth": "bin/setup.js"
       },
       "devDependencies": {
-        "@earendil-works/pi-ai": "0.82.0",
-        "@earendil-works/pi-coding-agent": "0.82.0",
+        "@earendil-works/pi-ai": "0.82.1",
+        "@earendil-works/pi-coding-agent": "0.82.1",
         "@types/node": "^26.0.0",
         "@vitest/coverage-v8": "4.1.10",
         "jiti": "^2.7.0",
@@ -564,7 +564,7 @@
         "node": ">=22.19.0"
       }
     },
-    "node_modules/@earendil-works/pi-agent-core/node_modules/@earendil-works/pi-ai": {
+    "node_modules/@earendil-works/pi-ai": {
       "version": "0.82.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.1.tgz",
       "integrity": "sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A==",
@@ -590,42 +590,16 @@
         "node": ">=22.19.0"
       }
     },
-    "node_modules/@earendil-works/pi-ai": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.0.tgz",
-      "integrity": "sha512-8MvW9+zno13sXDuT2kFMnWeTNUufUhPeZDRVO+igGoBRCDWgn7Xh2FkRQI1mRuet6QhF4ENQuLYdIAOyG6BhNw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": "0.91.1",
-        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
-        "@opentelemetry/api": "1.9.0",
-        "@smithy/node-http-handler": "4.7.3",
-        "http-proxy-agent": "7.0.2",
-        "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
-        "partial-json": "0.1.7",
-        "typebox": "1.1.38"
-      },
-      "bin": {
-        "pi-ai": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.82.0.tgz",
-      "integrity": "sha512-Qnqgn9zhJFQ2HZ8R4iNuGhyCk93XX6+eUw9i+TjTuo47amzCy93ft3bB6yaUCleCrNO58dJDHYSGNHv/GAPWKg==",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.82.1.tgz",
+      "integrity": "sha512-zbkAhoIuDPMF3pKuja0ajZabrMWU29FUMV9A/XMXT/XC1yXs5xt6t6t13GogQFsDrDqbFP4DkZQO1w8rWRAzYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.82.0",
-        "@earendil-works/pi-ai": "^0.82.0",
-        "@earendil-works/pi-tui": "^0.82.0",
+        "@earendil-works/pi-agent-core": "^0.82.1",
+        "@earendil-works/pi-ai": "^0.82.1",
+        "@earendil-works/pi-tui": "^0.82.1",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
     "image": "https://raw.githubusercontent.com/BlockedPath/pi-xai-oauth/main/preview.jpeg"
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": ">=0.80.1 <0.82.0",
-    "@earendil-works/pi-coding-agent": ">=0.80.1 <0.82.0"
+    "@earendil-works/pi-ai": ">=0.80.1 <0.83.0",
+    "@earendil-works/pi-coding-agent": ">=0.80.1 <0.83.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "0.81.1",
-    "@earendil-works/pi-coding-agent": "0.81.1",
+    "@earendil-works/pi-ai": "0.82.0",
+    "@earendil-works/pi-coding-agent": "0.82.0",
     "@types/node": "^26.0.0",
     "@vitest/coverage-v8": "4.1.10",
     "jiti": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "@earendil-works/pi-coding-agent": ">=0.80.1 <0.83.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "0.82.0",
-    "@earendil-works/pi-coding-agent": "0.82.0",
+    "@earendil-works/pi-ai": "0.82.1",
+    "@earendil-works/pi-coding-agent": "0.82.1",
     "@types/node": "^26.0.0",
     "@vitest/coverage-v8": "4.1.10",
     "jiti": "^2.7.0",

--- a/tests/fixtures/extension-api.ts
+++ b/tests/fixtures/extension-api.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { TEST_MODEL } from "./models";
 
 export type AnyHandler = (event: any, context: any) => any;
 
@@ -94,6 +95,26 @@ export function createExtensionHarness(
       failGet = options.get === true;
       failSet = options.set === true;
     },
+  };
+}
+
+/**
+ * Build a realistic pi tool execution context. Pi 0.82's bash factory reads
+ * `sessionManager`, the active model, and the thinking level to expose `PI_*`
+ * session metadata to spawned commands.
+ */
+export function toolExecutionContext(cwd: string, overrides: any = {}) {
+  const sessionId = overrides.sessionId ?? "pi-xai-test-session";
+  const sessionFile = overrides.sessionFile ?? `${cwd}/.pi-session.jsonl`;
+  return {
+    cwd,
+    model: overrides.model ?? TEST_MODEL,
+    thinkingLevel: overrides.thinkingLevel ?? "high",
+    sessionManager: {
+      getSessionId: () => sessionId,
+      getSessionFile: () => sessionFile,
+    },
+    ...overrides,
   };
 }
 

--- a/tests/tools/grok-native.test.ts
+++ b/tests/tools/grok-native.test.ts
@@ -18,7 +18,7 @@ import {
   syncGrokNativeToolsForModel,
 } from "../../extensions/xai/tools/grok-native";
 import { setXaiNetworkToolActive } from "../../extensions/xai/tools/model-scope";
-import { createExtensionHarness } from "../fixtures/extension-api";
+import { createExtensionHarness, toolExecutionContext } from "../fixtures/extension-api";
 import { authContext, BUILTIN_XAI_TEST_MODEL, TEST_MODEL } from "../fixtures/models";
 import { jsonResponse, requestBody } from "../fixtures/http";
 import { createTempDir } from "../fixtures/temp";
@@ -63,9 +63,13 @@ function tool(name: string) {
 }
 
 async function run(name: string, params: any) {
-  return tool(name).execute("call", params, new AbortController().signal, () => {}, {
-    cwd: temp.path,
-  });
+  return tool(name).execute(
+    "call",
+    params,
+    new AbortController().signal,
+    () => {},
+    toolExecutionContext(temp.path),
+  );
 }
 
 describe("Grok-native tools", () => {
@@ -381,6 +385,24 @@ describe("Grok-native tools", () => {
     } finally {
       await outside.cleanup();
     }
+  });
+
+  it("executes the terminal adapter with a realistic pi session execution context", async () => {
+    const ctx = toolExecutionContext(temp.path);
+    expect(ctx.sessionManager.getSessionId()).toBeTruthy();
+    const result = await tool("run_terminal_command").execute(
+      "call",
+      {
+        command: "printf session-context-ok",
+        description: "verify the terminal adapter under a realistic session context",
+        background: false,
+        timeout: 1_000,
+      },
+      new AbortController().signal,
+      () => {},
+      ctx,
+    );
+    expect(result.content[0].text).toMatch(/session-context-ok/);
   });
 
   it("refuses an explicit grep symlink that escapes the workspace", async () => {


### PR DESCRIPTION
Closes #144

Adopts the Pi 0.82 line as the latest tested compatibility boundary.

## Changes

- `tests/fixtures/extension-api.ts` — new `toolExecutionContext()` supplying `sessionManager` (`getSessionId`/`getSessionFile`), active model, and thinking level. Pi 0.82's bash factory reads all three to expose `PI_*` session metadata.
- `tests/tools/grok-native.test.ts` — uses the fixture, plus an explicit test asserting the terminal adapter executes under a realistic session context.
- `package.json` / lockfile / `compatibility/pi-versions.json` — peers widened to `>=0.80.1 <0.83.0`, unsupported upper `0.83.0`, minimum `0.80.1` retained.
- README + CHANGELOG compatibility guidance.

No changes to `extensions/xai/tools/*.ts` or model/catalog metadata.

## Deviation from the issue text

The issue asked for `latest = 0.82.0`, but **0.82.1** was published afterward. The registry drift guard requires `policy.latest` to be the newest release inside the peer range, so 0.82.0 fails `compatibility:check`. `policy.latest` and both exact dev dependencies are therefore pinned to 0.82.1. The literal `0.82.0 --candidate` matrix run also passes, so that boundary is verified too.

## Verification

- `npm test` — 536 tests, 44 files, `verify-extension-loader: ok`
- `npm run typecheck` — clean
- `npm run compatibility:check` — peers `>=0.80.1 <0.83.0`; unsupported 0.79.10 and 0.83.0 fixtures both rejected under strict install
- `npm run compatibility:min` (0.80.1 packed) and `compatibility:latest` (0.82.1 packed) — ok
- `node scripts/run-compatibility-matrix.js 0.82.0 --candidate` — ok