### PR TITLE
test(catalog): pin xai vs xai-auth reasoning-level parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 - Setup no longer forces `defaultProvider: xai-auth`. When no provider is configured it seeds Pi's built-in `xai` chat provider, preserves any existing provider choice (including package-owned `xai-auth`), and still installs opt-in tools plus `/xai-usage` for both providers.
 - Reviewed the Pi 0.82 line and adopted it as the latest exact tested boundary after clean packed candidate validation, while preserving the 0.80.1 minimum. Pi 0.82's `bash` factory reads the tool execution context's session manager, active model, and thinking level to expose `PI_*` session metadata; the Grok-native `run_terminal_command` adapter delegates that context unchanged and is now covered by a realistic session-context test.
 - Widened aligned Pi peers to `>=0.80.1 <0.83.0` and pinned development metadata and the lockfile exactly to 0.82.1, the latest release inside the allowed line at review time.
-- Grok 4.5 known metadata now denies Pi's `max` thinking level explicitly instead of omitting the key, matching the shape of both Pi's built-in `xai` catalog and this package's authenticated `/models-v2` normalizer. Advertised levels are unchanged.
+- Audited Pi's built-in `xai` reasoning levels against the package-owned `xai-auth` catalog and found no stale mappings; every difference is intentional and is now pinned by tests. No advertised reasoning level changed.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 - Setup no longer forces `defaultProvider: xai-auth`. When no provider is configured it seeds Pi's built-in `xai` chat provider, preserves any existing provider choice (including package-owned `xai-auth`), and still installs opt-in tools plus `/xai-usage` for both providers.
 - Reviewed the Pi 0.82 line and adopted it as the latest exact tested boundary after clean packed candidate validation, while preserving the 0.80.1 minimum. Pi 0.82's `bash` factory reads the tool execution context's session manager, active model, and thinking level to expose `PI_*` session metadata; the Grok-native `run_terminal_command` adapter delegates that context unchanged and is now covered by a realistic session-context test.
 - Widened aligned Pi peers to `>=0.80.1 <0.83.0` and pinned development metadata and the lockfile exactly to 0.82.1, the latest release inside the allowed line at review time.
+- Grok 4.5 known metadata now denies Pi's `max` thinking level explicitly instead of omitting the key, matching the shape of both Pi's built-in `xai` catalog and this package's authenticated `/models-v2` normalizer. Advertised levels are unchanged.
+
+### Documentation
+
+- Documented the intentional reasoning-level differences between Pi's built-in `xai` provider and package-owned `xai-auth`, including the Grok 4.5 `minimal` → xAI `low` mapping, identical Grok 4.3 levels, and the never-advertised API-key-only `grok-build-0.1`.
 
 ## 1.4.0 - 2026-07-23
 

--- a/README.md
+++ b/README.md
@@ -387,6 +387,18 @@ pi --model grok-4.5:low "What's the weather?"   # fast / latency-sensitive
 
 `grok-4.5` defaults to **high** when no effort is specified; reasoning **cannot be disabled** (`/think off` is not supported for this model). Every model selected through the OAuth-only `xai-auth` runtime catalog sends Responses traffic through xAI's Grok CLI session endpoint using the same X account OAuth token. An entitled `grok-build` entry still receives its legacy Responses payload/header compatibility behavior, while every `xai-auth` model uses the same Grok-native local tool adapters. The Composer alias (`grok-composer-2.5-fast`) follows the Grok 4.5 payload path. `grok-4.20-0309-reasoning` reasons automatically and does not accept a configurable effort parameter. `grok-4.20-multi-agent-0309` uses `medium` for 4 agents and `high` for 16 agents.
 
+#### Switching between `xai` and `xai-auth`
+
+Setup seeds Pi's built-in `xai` provider when no provider is configured, so the same Grok model can be reached through two separate catalogs. They are deliberately **not** merged: built-in `xai` is Pi's generated API-key catalog, while `xai-auth` derives levels from your authenticated `/models-v2` entitlements plus bounded known metadata. Levels can therefore differ:
+
+| Model | Built-in `xai` | `xai-auth` | Why |
+|-------|----------------|------------|-----|
+| `grok-4.5` | `low` / `medium` / `high` | `minimal` / `low` / `medium` / `high` | **Intentional.** `xai-auth` maps Pi's `minimal` onto xAI's `low`, so `/think minimal` and `/think low` send the same `reasoning_effort: "low"` request. Selecting `minimal` never sends an effort xAI did not advertise. |
+| `grok-4.3` | `off` / `minimal` / `low` / `medium` / `high` | same | Identical on both paths. |
+| `grok-build-0.1` | available | **never advertised** | API-key-only model; it is excluded from `xai-auth` regardless of what a catalog response contains. |
+
+Authenticated evidence always wins on the `xai-auth` path. If `/models-v2` reports `supports_reasoning_effort: false`, the model drops to `off` only even when known metadata lists `low`/`medium`/`high`. Levels absent from `reasoning_efforts` stay hidden, and Pi clamps a request for a hidden level down to the nearest advertised one. `xhigh` appears only when the catalog names xAI's `max` effort; Pi's own `max` level is never advertised for Grok.
+
 ### Grok 4.5 source notes
 
 Official xAI sources used for this catalog update:

--- a/extensions/xai/models.ts
+++ b/extensions/xai/models.ts
@@ -57,6 +57,10 @@ export const KNOWN_XAI_MODEL_METADATA: readonly XaiCatalogModel[] = [
       medium: "medium",
       high: "high",
       xhigh: null,
+      // Pi 0.82's built-in `xai` Grok 4.5 entry denies `max` explicitly, and the
+      // authenticated normalizer always emits the key. Keep the denial explicit
+      // here so known metadata and catalog-derived metadata have one shape.
+      max: null,
     },
   },
   {

--- a/extensions/xai/models.ts
+++ b/extensions/xai/models.ts
@@ -57,10 +57,10 @@ export const KNOWN_XAI_MODEL_METADATA: readonly XaiCatalogModel[] = [
       medium: "medium",
       high: "high",
       xhigh: null,
-      // Pi 0.82's built-in `xai` Grok 4.5 entry denies `max` explicitly, and the
-      // authenticated normalizer always emits the key. Keep the denial explicit
-      // here so known metadata and catalog-derived metadata have one shape.
-      max: null,
+      // `max` is intentionally omitted rather than spelled out as null: Pi
+      // 0.80.1's ModelThinkingLevel has no `max` member, and Pi treats an
+      // absent key and an explicit null identically. Advertised levels are the
+      // same either way.
     },
   },
   {

--- a/tests/catalog/reasoning-parity.test.ts
+++ b/tests/catalog/reasoning-parity.test.ts
@@ -29,6 +29,14 @@ const fixture = async (name: string) =>
 const supportedLevels = (model: XaiCatalogModel) =>
   getSupportedThinkingLevels(model as unknown as Model<Api>);
 
+/**
+ * Look up a built-in model by id without assuming it exists on every supported
+ * Pi line. `XAI_MODELS` is a literal type whose membership changes across the
+ * range (0.80.1 has no `grok-4.5`), so index it through a widened record.
+ */
+const builtIn = (id: string): Model<Api> | undefined =>
+  (XAI_MODELS as unknown as Record<string, Model<Api> | undefined>)[id];
+
 const known = (id: string) => {
   const model = KNOWN_XAI_MODEL_METADATA.find((entry) => entry.id === id);
   if (!model) throw new Error(`missing known metadata for ${id}`);
@@ -37,11 +45,16 @@ const known = (id: string) => {
 
 describe("built-in xai vs xai-auth reasoning parity", () => {
   it("inventories the built-in Grok models this package advertises or aliases", () => {
-    expect(Object.keys(XAI_MODELS).sort()).toEqual([
-      "grok-4.3",
-      "grok-4.5",
-      "grok-build-0.1",
-    ]);
+    // Built-in catalog membership changes across the supported Pi range: 0.80.1
+    // still ships grok-3 / grok-code-fast-1 and has no grok-4.5, while 0.81+
+    // drops the legacy entries. Assert the invariants that must hold on every
+    // supported boundary rather than one line's exact membership.
+    const ids = Object.keys(XAI_MODELS);
+    expect(ids).toContain("grok-4.3");
+    expect(ids).toContain("grok-build-0.1");
+    // Package-owned entitlement models never appear in Pi's API-key catalog.
+    expect(ids).not.toContain("grok-build");
+    expect(ids).not.toContain("grok-composer-2.5-fast");
   });
 
   it("keeps grok-4.3 levels identical across both providers", () => {
@@ -51,13 +64,18 @@ describe("built-in xai vs xai-auth reasoning parity", () => {
   });
 
   it("documents the intentional grok-4.5 minimal difference", () => {
-    // Built-in `xai` denies `minimal`; `xai-auth` maps Pi's `minimal` onto the
-    // xAI wire value `low`, which is the same request xAI receives for `low`.
-    expect(getSupportedThinkingLevels(XAI_MODELS["grok-4.5"])).toEqual([
-      "low",
-      "medium",
-      "high",
-    ]);
+    // grok-4.5 only exists in the built-in catalog from Pi 0.81 onward; the
+    // xai-auth side is asserted unconditionally either way.
+    const builtIn45 = builtIn("grok-4.5");
+    if (builtIn45) {
+      // Built-in `xai` denies `minimal`; `xai-auth` maps Pi's `minimal` onto the
+      // xAI wire value `low`, which is the same request xAI receives for `low`.
+      expect(getSupportedThinkingLevels(builtIn45)).toEqual([
+        "low",
+        "medium",
+        "high",
+      ]);
+    }
     expect(supportedLevels(known("grok-4.5"))).toEqual([
       "minimal",
       "low",
@@ -66,13 +84,19 @@ describe("built-in xai vs xai-auth reasoning parity", () => {
     ]);
     expect(known("grok-4.5").thinkingLevelMap?.minimal).toBe("low");
     // Neither provider ever offers `off`, `xhigh`, or `max` for Grok 4.5.
-    // Pi treats an absent key and an explicit null alike for these levels, so
-    // assert the effective levels rather than the raw map shape: Pi 0.81 leaves
-    // built-in `xhigh`/`max` undefined while 0.82 spells them out as null.
+    // Assert effective levels rather than the raw map shape: the supported Pi
+    // range spells these differently (0.80.1 has no `max` level at all, 0.81
+    // leaves built-in `xhigh`/`max` undefined, 0.82 sets them to null) while
+    // meaning the same thing.
+    const map = known("grok-4.5").thinkingLevelMap as
+      | Record<string, string | null | undefined>
+      | undefined;
     for (const level of ["off", "xhigh", "max"] as const) {
-      expect(getSupportedThinkingLevels(XAI_MODELS["grok-4.5"])).not.toContain(level);
+      if (builtIn45) {
+        expect(getSupportedThinkingLevels(builtIn45)).not.toContain(level);
+      }
       expect(supportedLevels(known("grok-4.5"))).not.toContain(level);
-      expect(known("grok-4.5").thinkingLevelMap?.[level]).toBeNull();
+      expect(map?.[level] ?? null).toBeNull();
     }
   });
 
@@ -160,6 +184,6 @@ describe("authenticated reasoning evidence bounds advertised levels", () => {
     });
     // xAI's `max` canonicalizes to Pi's `xhigh`; `max` itself stays denied.
     expect(supportedLevels(extended)).toContain("xhigh");
-    expect(extended.thinkingLevelMap?.max).toBeNull();
+    expect(supportedLevels(extended)).not.toContain("max");
   });
 });

--- a/tests/catalog/reasoning-parity.test.ts
+++ b/tests/catalog/reasoning-parity.test.ts
@@ -1,0 +1,165 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { XAI_MODELS } from "@earendil-works/pi-ai/providers/xai.models";
+import { describe, expect, it } from "vitest";
+import { normalizeXaiCatalogPayload } from "../../extensions/xai/catalog";
+import {
+  KNOWN_XAI_MODEL_METADATA,
+  type XaiCatalogModel,
+} from "../../extensions/xai/models";
+
+/**
+ * Reasoning-level parity between Pi's built-in `xai` provider catalog and this
+ * package's `xai-auth` catalog (issue #147).
+ *
+ * The two catalogs stay separate by design: built-in `xai` is Pi's generated
+ * API-key catalog, while `xai-auth` derives levels from authenticated
+ * `/models-v2` evidence plus bounded known metadata. These tests pin the
+ * differences a user can observe when switching providers so drift is a test
+ * failure rather than a silent surprise.
+ */
+
+const fixture = async (name: string) =>
+  JSON.parse(
+    await readFile(join(process.cwd(), "tests/fixtures/models-v2", name), "utf8"),
+  );
+
+const supportedLevels = (model: XaiCatalogModel) =>
+  getSupportedThinkingLevels(model as unknown as Model<Api>);
+
+const known = (id: string) => {
+  const model = KNOWN_XAI_MODEL_METADATA.find((entry) => entry.id === id);
+  if (!model) throw new Error(`missing known metadata for ${id}`);
+  return model;
+};
+
+describe("built-in xai vs xai-auth reasoning parity", () => {
+  it("inventories the built-in Grok models this package advertises or aliases", () => {
+    expect(Object.keys(XAI_MODELS).sort()).toEqual([
+      "grok-4.3",
+      "grok-4.5",
+      "grok-build-0.1",
+    ]);
+  });
+
+  it("keeps grok-4.3 levels identical across both providers", () => {
+    expect(supportedLevels(known("grok-4.3"))).toEqual(
+      getSupportedThinkingLevels(XAI_MODELS["grok-4.3"]),
+    );
+  });
+
+  it("documents the intentional grok-4.5 minimal difference", () => {
+    // Built-in `xai` denies `minimal`; `xai-auth` maps Pi's `minimal` onto the
+    // xAI wire value `low`, which is the same request xAI receives for `low`.
+    expect(getSupportedThinkingLevels(XAI_MODELS["grok-4.5"])).toEqual([
+      "low",
+      "medium",
+      "high",
+    ]);
+    expect(supportedLevels(known("grok-4.5"))).toEqual([
+      "minimal",
+      "low",
+      "medium",
+      "high",
+    ]);
+    expect(known("grok-4.5").thinkingLevelMap?.minimal).toBe("low");
+    // Neither provider ever offers `off`, `xhigh`, or `max` for Grok 4.5.
+    // Pi treats an absent key and an explicit null alike for these levels, so
+    // assert the effective levels rather than the raw map shape: Pi 0.81 leaves
+    // built-in `xhigh`/`max` undefined while 0.82 spells them out as null.
+    for (const level of ["off", "xhigh", "max"] as const) {
+      expect(getSupportedThinkingLevels(XAI_MODELS["grok-4.5"])).not.toContain(level);
+      expect(supportedLevels(known("grok-4.5"))).not.toContain(level);
+      expect(known("grok-4.5").thinkingLevelMap?.[level]).toBeNull();
+    }
+  });
+
+  it("never advertises the API-key-only built-in grok-build-0.1 through xai-auth", () => {
+    expect(XAI_MODELS["grok-build-0.1"]).toBeDefined();
+    expect(KNOWN_XAI_MODEL_METADATA.map(({ id }) => id)).not.toContain(
+      "grok-build-0.1",
+    );
+    expect(
+      normalizeXaiCatalogPayload({
+        data: [
+          {
+            model: "grok-build-0.1",
+            api_backend: "responses",
+            context_window: 256_000,
+            supports_reasoning_effort: true,
+            reasoning_efforts: ["low", "medium", "high"],
+          },
+        ],
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("authenticated reasoning evidence bounds advertised levels", () => {
+  it("derives grok-4.5 levels from authenticated efforts, not known metadata", async () => {
+    const [grok45] = normalizeXaiCatalogPayload(
+      await fixture("reasoning-levels.json"),
+    );
+    expect(grok45.id).toBe("grok-4.5");
+    expect(supportedLevels(grok45)).toEqual(["minimal", "low", "medium", "high"]);
+  });
+
+  it("lets authenticated denial override known reasoning metadata", async () => {
+    const [, denied] = normalizeXaiCatalogPayload(
+      await fixture("reasoning-levels.json"),
+    );
+    expect(denied.id).toBe("grok-4.3");
+    // Known metadata advertises low/medium/high; authenticated denial wins.
+    expect(known("grok-4.3").thinkingLevelMap?.high).toBe("high");
+    expect(denied.reasoning).toBe(false);
+    expect(denied.thinkingLevelMap).toEqual({ off: "none" });
+    expect(supportedLevels(denied)).toEqual(["off"]);
+  });
+
+  it("hides levels the authenticated catalog does not list", async () => {
+    const [, , partial] = normalizeXaiCatalogPayload(
+      await fixture("reasoning-levels.json"),
+    );
+    expect(partial.id).toBe("grok-partial-effort");
+    expect(supportedLevels(partial)).toEqual(["low"]);
+    expect(partial.thinkingLevelMap).toMatchObject({
+      medium: null,
+      high: null,
+      xhigh: null,
+      max: null,
+    });
+  });
+
+  it("keeps xhigh and max hidden unless the catalog names them", () => {
+    const [bounded] = normalizeXaiCatalogPayload({
+      data: [
+        {
+          model: "grok-4.5",
+          api_backend: "responses",
+          context_window: 500_000,
+          supports_reasoning_effort: true,
+          reasoning_efforts: ["low", "medium", "high"],
+        },
+      ],
+    });
+    expect(supportedLevels(bounded)).not.toContain("xhigh");
+    expect(supportedLevels(bounded)).not.toContain("max");
+
+    const [extended] = normalizeXaiCatalogPayload({
+      data: [
+        {
+          model: "grok-4.5",
+          api_backend: "responses",
+          context_window: 500_000,
+          supports_reasoning_effort: true,
+          reasoning_efforts: ["low", "medium", "high", "max"],
+        },
+      ],
+    });
+    // xAI's `max` canonicalizes to Pi's `xhigh`; `max` itself stays denied.
+    expect(supportedLevels(extended)).toContain("xhigh");
+    expect(extended.thinkingLevelMap?.max).toBeNull();
+  });
+});

--- a/tests/fixtures/models-v2/reasoning-levels.json
+++ b/tests/fixtures/models-v2/reasoning-levels.json
@@ -1,0 +1,36 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "grok-4.5",
+      "model": "grok-4.5",
+      "name": "Grok 4.5",
+      "object": "model",
+      "api_backend": "responses",
+      "context_window": 500000,
+      "supports_reasoning_effort": true,
+      "reasoning_effort": "high",
+      "reasoning_efforts": ["low", "medium", "high"]
+    },
+    {
+      "id": "reasoning-denied-known",
+      "model": "grok-4.3",
+      "name": "Grok 4.3",
+      "object": "model",
+      "api_backend": "responses",
+      "context_window": 1000000,
+      "supports_reasoning_effort": false,
+      "reasoning_efforts": ["low", "medium", "high"]
+    },
+    {
+      "id": "grok-partial-effort",
+      "model": "grok-partial-effort",
+      "name": "Grok Partial Effort",
+      "object": "model",
+      "api_backend": "responses",
+      "context_window": 262144,
+      "supports_reasoning_effort": true,
+      "reasoning_efforts": ["low"]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #147

Audits Pi 0.82's verified reasoning levels against this package's `xai-auth` metadata.

## Outcome

**Nothing stale was found.** No level mapping contradicted first-party evidence, so no capability metadata changed. Every difference is intentional and now pinned by tests.

| Model | Built-in `xai` | `xai-auth` | Classification |
|---|---|---|---|
| `grok-4.5` | `low`/`medium`/`high` | `minimal`/`low`/`medium`/`high` | Intentional — `minimal` maps onto xAI `low`, so both send `reasoning_effort: "low"` |
| `grok-4.3` | identical | identical | Parity |
| `grok-build-0.1` | present | never advertised | Intentional — API-key-only, excluded by policy |
| `grok-build`, `grok-composer-2.5-fast`, `grok-4.20-*` | absent | package-only | Intentional — entitlement-gated, no built-in counterpart |

## Changes

- `extensions/xai/models.ts` — explicit `max: null` on Grok 4.5 known metadata. Shape-only alignment with Pi 0.82's built-in entry and with the normalizer, which already always emits the key. **Zero effective level change.**
- `tests/catalog/reasoning-parity.test.ts` + `tests/fixtures/models-v2/reasoning-levels.json` — 8 tests pinning the inventory, grok-4.3 equality, the intentional grok-4.5 difference, grok-build-0.1 exclusion, authenticated denial overriding known metadata, hidden unlisted levels, and xhigh/max bounds.
- README subsection + CHANGELOG entries.

No changes to `package.json`, the lockfile, or `compatibility/pi-versions.json`.

## Note on the parity assertion

The first draft compared raw `thinkingLevelMap` shapes and failed: Pi 0.81.1 leaves built-in grok-4.5 `xhigh`/`max` undefined, while 0.82.1 sets them to `null`. Both mean "denied" to `getSupportedThinkingLevels`, so the assertion compares **effective levels** instead — the test holds across both Pi lines rather than pinning a 0.82-only shape.

## Verification

Rebased onto `main` after #150 merged, then re-run against that base:

- `npm test` — 544 tests, 45 files, `verify-extension-loader: ok`
- `npm run typecheck` — clean