### PR TITLE
docs(tools): defer unverified constrained sampling

### DIFF
--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -16,13 +16,14 @@
 - [x] Passed the focused custom-tool suite (34 tests), full `npm test` (45 files / 545 tests), root typecheck, and loader smoke.
 - [x] Passed exact packed Pi 0.80.1 and 0.82.1 boundaries, including each boundary's full tests, loader smoke, and typecheck. The first 0.82.1 run hit an unrelated 30-second real-registry timeout; the clean rerun passed in 296 ms.
 - [x] Passed pi-lens diagnostics, `git diff --check`, and independent read-only review with no findings.
+- [x] Created two focused commits: `09e649e` (evidence/decision docs) and `cc7f42f` (custom-tool omission regression).
 
 
 ## In Progress
 
-- [ ] Create focused commits.
+- None.
 
 
 ## Next
 
-Commit the documentation/evidence decision and focused regression, then report evidence, decision, validation, and residual risk.
+Report evidence, decision, validation, and residual risk.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -17,6 +17,9 @@
 - [x] Passed exact packed Pi 0.80.1 and 0.82.1 boundaries, including each boundary's full tests, loader smoke, and typecheck. The first 0.82.1 run hit an unrelated 30-second real-registry timeout; the clean rerun passed in 296 ms.
 - [x] Passed pi-lens diagnostics, `git diff --check`, and independent read-only review with no findings.
 - [x] Created two focused commits: `09e649e` (evidence/decision docs) and `cc7f42f` (custom-tool omission regression).
+- [x] Independent standards/spec review found no implementation or acceptance gaps.
+- [x] Re-ran both exact packed boundaries during review: 0.80.1 and 0.82.1 each pass all 545 tests, loader smoke, and typecheck.
+- [x] Added the Unreleased changelog documentation entry for the evidence-based no-go decision.
 
 
 ## In Progress
@@ -26,4 +29,4 @@
 
 ## Next
 
-Report evidence, decision, validation, and residual risk.
+Push the branch and open a PR closing #146.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,30 +1,28 @@
-# Execution Progress — Issue #145
+# Execution Progress — Issue #146
 
-**Branch:** `issue/145-pi-session-env`
-**Issue:** https://github.com/BlockedPath/pi-xai-oauth/issues/145
+**Branch:** `issue/146-constrained-sampling`
+**Issue:** https://github.com/BlockedPath/pi-xai-oauth/issues/146
 
 ## Completed
 
-- [x] Read issue #145 and confirmed the active branch and scoped files.
-- [x] Installed dependencies with `npm install`.
-- [x] Chose to suppress Pi session metadata from Grok-native terminal children.
-- [x] Implemented the policy with the cross-range bash `spawnHook`, removing injected Pi 0.82 values and stale Pi 0.80.1 parent values.
-- [x] Added a focused real-child-process regression that preserves an unrelated environment value without printing session paths or metadata.
-- [x] Documented the privacy rationale and preserved shell behavior in README.
-- [x] Focused Grok-native tests pass (23 tests); edited-file LSP diagnostics are clean.
-- [x] TypeScript passes.
-- [x] Exact packed Pi 0.80.1 boundary passes all 544 tests, loader smoke, and typecheck.
-- [x] Issue-owned Grok-native tests pass repeatedly on exact packed Pi 0.82.1.
-- [x] Committed implementation and regression as `368fc4f`.
-- [x] Independent standards/spec review found no implementation or acceptance gaps.
-- [x] Full local suite passes (45 files / 544 tests), loader smoke and TypeScript pass.
-- [x] Exact packed Pi 0.80.1 and 0.82.1 boundaries both pass all 544 tests, loader smoke, and typecheck.
-- [x] Added the missing Unreleased changelog entry for the user-visible privacy behavior.
+- [x] Confirmed the requested branch and clean baseline.
+- [x] Read issue #146, the provider entrypoint, custom-tool implementation, setup script, README, Pi 0.82 constrained-sampling implementation, and current xAI model metadata.
+- [x] Ran `npm install` without changing the protected package or compatibility files.
+- [x] Reviewed first-party xAI function-calling and structured-output documentation.
+- [x] Ran a bounded live probe against the pinned OAuth Responses proxy without logging credentials or raw bodies; every valid, invalid, strict, non-strict, and no-tool variant stopped at the same HTTP 402 entitlement gate before schema behavior could be distinguished.
+- [x] Confirmed Pi 0.82's OpenAI Responses adapter defaults `supportsStrictMode` to false and safely omits `strict` for `strict: "prefer"` unless verified model compatibility metadata opts in.
+- [x] Recorded the no-runtime-flag decision in ADR 0002 and linked it from README.
+- [x] Added a focused custom-tool registration regression that rejects unverified `constrainedSampling` advertisement.
+- [x] Passed the focused custom-tool suite (34 tests), full `npm test` (45 files / 545 tests), root typecheck, and loader smoke.
+- [x] Passed exact packed Pi 0.80.1 and 0.82.1 boundaries, including each boundary's full tests, loader smoke, and typecheck. The first 0.82.1 run hit an unrelated 30-second real-registry timeout; the clean rerun passed in 296 ms.
+- [x] Passed pi-lens diagnostics, `git diff --check`, and independent read-only review with no findings.
+
 
 ## In Progress
 
-- None.
+- [ ] Create focused commits.
+
 
 ## Next
 
-Push the branch and open a PR closing #145.
+Commit the documentation/evidence decision and focused regression, then report evidence, decision, validation, and residual risk.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 ### Documentation
 
 - Documented the intentional reasoning-level differences between Pi's built-in `xai` provider and package-owned `xai-auth`, including the Grok 4.5 `minimal` → xAI `low` mapping, identical Grok 4.3 levels, and the never-advertised API-key-only `grok-build-0.1`.
+- Recorded the evidence-based decision to keep Pi 0.82 constrained JSON-schema sampling disabled for package custom tools until the pinned xAI OAuth Responses route has route-specific strict-tool support evidence; no runtime capability flag or catalog metadata was added.
 
 ## 1.4.0 - 2026-07-23
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and
 
 `pi-xai-oauth` owns the xAI-specific integration needed to use entitled Grok models through pi: authentication and credentials, account-specific catalogs, transport and payload behavior, Grok-native compatibility adapters, opt-in network tools, and media integrations. It intentionally does not provide generic `/goal` or `/plan` commands, autonomous continuation, a runtime plan-file protocol, generic task/subagent orchestration, or plan-mode write restriction. See [ADR 0001](docs/decisions/0001-goal-plan-package-scope.md) for the decision and alternatives.
 
+Pi 0.82 constrained JSON-schema sampling remains disabled for package custom tools because public xAI strict-tool documentation has not been verified for the separate OAuth CLI Responses proxy. [ADR 0002](docs/decisions/0002-xai-oauth-constrained-sampling.md) records the first-party evidence, bounded live probe, safe Pi fallback, and no-runtime-flag decision.
+
 Tool hiding, active-tool filtering, and shell-command filtering are workflow controls, not an enforced read-only boundary. Pi and its extensions run with the user's permissions; strong isolation requires an external sandbox, container, or VM that constrains every tool and extension involved.
 
 The optional [`--scaffold`](#agent-scaffolding) command is separate: it performs one-time generation of `AGENTS.md` and `.scaffold/*` guidance files in the current directory. It is not a runtime workflow controller, an authoritative plan-state protocol, or a security mechanism.

--- a/docs/decisions/0002-xai-oauth-constrained-sampling.md
+++ b/docs/decisions/0002-xai-oauth-constrained-sampling.md
@@ -1,0 +1,76 @@
+<!-- markdownlint-disable MD013 -->
+
+# ADR 0002: Defer constrained sampling for xAI OAuth custom tools
+
+- **Status:** Accepted — no runtime change
+- **Date:** 2026-07-25
+- **Issue:** [#146](https://github.com/BlockedPath/pi-xai-oauth/issues/146)
+- **Pi range reviewed:** `>=0.80.1 <0.83.0` (exact boundaries 0.80.1 and 0.82.1)
+
+## Decision
+
+Do not add `Tool.constrainedSampling`, `compat.supportsStrictMode`, or grammar-tool capability metadata to this package in this slice.
+
+Pi 0.82's `{ type: "json_schema", strict: "prefer" }` is a safe fallback mechanism only after a provider/model capability decision exists: the OpenAI Responses adapter emits `strict: true` when `model.compat.supportsStrictMode` is true and otherwise sends an ordinary function tool without a `strict` field. The package-owned `xai-auth` catalog has no verified strict-mode metadata, and Pi 0.80.1 does not expose `Tool.constrainedSampling` at all.
+
+The public xAI documentation is positive evidence for xAI's public model surfaces, but it is not sufficient evidence for the separately pinned OAuth session route at `https://cli-chat-proxy.grok.com/v1/responses`. The bounded live probe described below could not reach schema validation. Advertising the capability for the OAuth catalog would therefore turn an unverified route assumption into runtime metadata. That conflicts with this package's evidence policy.
+
+No custom tool is selected for a pilot until the OAuth route is verified. Existing JSON schemas and local validation remain unchanged. In particular, this decision does not add `strict: "require"`, grammar mode, or an inferred catalog field.
+
+## Evidence
+
+### First-party xAI documentation
+
+On 2026-07-25, the following first-party pages were reviewed:
+
+- [Function Calling](https://docs.x.ai/developers/tools/function-calling) documents JSON Schema function parameters and states that the root must be an object (or a union whose branches are objects). It also documents schema shapes rejected with HTTP 400.
+- [Structured Outputs](https://docs.x.ai/developers/model-capabilities/text/structured-outputs) states that xAI model tool-call arguments strictly conform to their input JSON Schema and that strict behavior is implicit. It also limits guarantees to xAI's supported JSON Schema subset and recommends local validation for best-effort keywords and limits.
+
+These pages describe xAI model/API behavior generally and show public SDK/API examples. They do not identify the authenticated Grok CLI proxy as a covered endpoint, do not document the OAuth proxy's compatibility contract, and do not provide a proxy-specific strict-tool fixture.
+
+### Bounded OAuth Responses probe
+
+A local one-shot probe used an existing OAuth credential only in the protected `Authorization` header and sent requests solely to the repository's pinned CLI Responses URL. It did not print or persist the credential, authenticated headers, request IDs, raw response bodies, or error text.
+
+The probe compared:
+
+1. a valid closed object tool with no `strict` member;
+2. the same tool with `strict: true`;
+3. the same tool with `strict: false`;
+4. `strict: true` with an open object schema;
+5. an invalid scalar-root tool schema that first-party documentation says should fail schema compilation;
+6. a request with no tools; and
+7. an invalid model control.
+
+Every variant returned the same HTTP 402 outcome with no output items. Because even the invalid schema and invalid model controls reached the same gate, the response occurred before the probe could distinguish tool-schema acceptance, rejection, enforcement, or fallback. HTTP status alone is retained here; raw authenticated bodies were not logged.
+
+This is evidence that the available account could not perform a valid capability probe, not evidence that the proxy supports or rejects strict tools.
+
+### Pi 0.82 transport behavior
+
+Pi 0.82.1's official constrained-sampling documentation defines `strict: "prefer"` as strict enforcement when supported and ordinary tool calling otherwise. Its OpenAI Responses implementation resolves JSON-schema constrained sampling from `model.compat.supportsStrictMode`; for that adapter the compatibility default is false. With no verified capability metadata, `strict: "prefer"` produces an ordinary function tool and omits the wire-level `strict` field. `strict: "require"` would reject locally instead, which is why it is explicitly out of scope.
+
+The authoritative Pi references reviewed were:
+
+- [Pi 0.82 constrained-sampling documentation](https://github.com/earendil-works/pi/blob/v0.82.0/packages/ai/README.md#constrained-sampling-for-tools)
+- [`resolveJsonSchemaStrictSampling` at Pi 0.82.1](https://github.com/earendil-works/pi/blob/v0.82.1/packages/ai/src/api/constrained-sampling.ts)
+- [OpenAI Responses tool conversion at Pi 0.82.1](https://github.com/earendil-works/pi/blob/v0.82.1/packages/ai/src/api/openai-responses-shared.ts)
+
+## Rejected alternatives
+
+| Alternative | Reason rejected |
+| --- | --- |
+| Add `{ type: "json_schema", strict: "prefer" }` to one tool without capability metadata | It would always take Pi's ordinary-function fallback for current `xai-auth` models, so it would not establish the requested supported pilot. It would also introduce a Pi 0.82-only field that must be hidden from the 0.80.1 type surface for no demonstrated runtime benefit. |
+| Set `compat.supportsStrictMode: true` on package models | The public xAI claim has not been verified for the pinned OAuth proxy. This would invent package catalog compatibility metadata. |
+| Treat HTTP 402 parity as schema acceptance | The invalid-schema and invalid-model controls also returned 402, showing only that an earlier entitlement gate won. |
+| Use `strict: "require"` | The issue excludes it, and it would fail requests rather than preserve fallback. |
+| Use grammar constrained sampling | No first-party evidence supports grammar tools on this route, and the issue explicitly excludes grammar mode. |
+
+## Revisit criteria
+
+A future pilot may proceed when at least one of the following is available:
+
+1. first-party documentation explicitly covering strict function-tool schemas on the pinned OAuth CLI Responses route; or
+2. a bounded live probe on that route which reaches inference and demonstrates a valid closed schema with `strict: true`, plus controls that distinguish schema validation from earlier auth, entitlement, model, and version gates.
+
+Any future pilot should use one simple, closed object schema; retain Pi/local argument validation and `prepareArguments`; use only `strict: "prefer"`; test both `supportsStrictMode: true` and false payloads; and preserve the Pi 0.80.1 typecheck through a compatibility-safe representation. Grammar support requires separate first-party evidence and review.

--- a/extensions/xai/tools/custom-tools.ts
+++ b/extensions/xai/tools/custom-tools.ts
@@ -44,7 +44,12 @@ function invalidXaiImageInputError() {
   );
 }
 
-/** Register OAuth-backed custom xAI tools. */
+/**
+ * Register OAuth-backed custom xAI tools.
+ *
+ * Registrations deliberately omit constrainedSampling until the pinned OAuth
+ * Responses route has route-specific strict-tool evidence (see ADR 0002).
+ */
 export function registerCustomXaiTools(pi: ExtensionAPI) {
     pi.registerTool({
       name: "xai_generate_text",

--- a/tests/tools/custom-tools.test.ts
+++ b/tests/tools/custom-tools.test.ts
@@ -57,6 +57,11 @@ describe("custom xAI tools", () => {
       XAI_NETWORK_TOOL_NAMES.filter((name) => !name.startsWith("xai_grok_")).sort(),
     );
   });
+  it("does not advertise unverified constrained-sampling capability", () => {
+    for (const tool of h.tools.values()) {
+      expect(tool).not.toHaveProperty("constrainedSampling");
+    }
+  });
   it.each([
     ["xai_generate_text", { prompt: "guard" }],
     ["xai_x_search", { query: "guard" }],


### PR DESCRIPTION
Closes #146

## Summary

Records an evidence-based no-go decision for Pi 0.82 constrained JSON-schema sampling on package-owned xAI OAuth custom tools.

- Reviews first-party xAI function-calling and structured-output documentation.
- Records a bounded live probe against the pinned OAuth Responses route; every strict, non-strict, valid, invalid, no-tool, and invalid-model variant stopped at the same HTTP 402 gate before schema behavior could be distinguished.
- Does **not** add `Tool.constrainedSampling`, `compat.supportsStrictMode`, grammar capability metadata, or any runtime flag.
- Adds a focused regression ensuring custom tools do not advertise unverified constrained-sampling capability.
- Documents the decision and concrete revisit criteria in ADR 0002 and README.

## Evidence decision

Public xAI documentation does not establish support on the separate pinned OAuth CLI Responses proxy. The probe could not reach schema validation, so advertising strict support would invent route capability metadata. Existing schemas, local validation, and Pi 0.80.1 compatibility remain unchanged.

## Verification

- `npm test` — 545 tests, loader smoke passed
- `npm run typecheck` — passed
- Exact packed Pi 0.80.1 boundary — 545 tests, loader, typecheck passed
- Exact packed Pi 0.82.1 boundary — 545 tests, loader, typecheck passed
- Independent standards/spec review — no implementation or acceptance gaps
