### PR TITLE
chore: ignore generated documentation diagrams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ CLAUDE.md
 .agents/
 .claude/
 skills-lock.json
+docs/diagrams/


### PR DESCRIPTION
## Summary

- ignore local `docs/diagrams/` output
- keep generated diagrams out of repository status

## Validation

- `git check-ignore -v docs/diagrams/`