### PR TITLE
fix: setup model clobbering, catalog rollback on progress failure, and boundary dependency drift

### DIFF
--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,32 +1,32 @@
-# Execution Progress — Issue #146
+# Execution Progress — Code review follow-up
 
-**Branch:** `issue/146-constrained-sampling`
-**Issue:** https://github.com/BlockedPath/pi-xai-oauth/issues/146
+**Branch:** `fix/setup-seeding-and-catalog-catch`
+**Scope:** Fixes for two findings from a full read-only review of the extension, plus the dependency drift that was blocking the boundary gate.
 
 ## Completed
 
-- [x] Confirmed the requested branch and clean baseline.
-- [x] Read issue #146, the provider entrypoint, custom-tool implementation, setup script, README, Pi 0.82 constrained-sampling implementation, and current xAI model metadata.
-- [x] Ran `npm install` without changing the protected package or compatibility files.
-- [x] Reviewed first-party xAI function-calling and structured-output documentation.
-- [x] Ran a bounded live probe against the pinned OAuth Responses proxy without logging credentials or raw bodies; every valid, invalid, strict, non-strict, and no-tool variant stopped at the same HTTP 402 entitlement gate before schema behavior could be distinguished.
-- [x] Confirmed Pi 0.82's OpenAI Responses adapter defaults `supportsStrictMode` to false and safely omits `strict` for `strict: "prefer"` unless verified model compatibility metadata opts in.
-- [x] Recorded the no-runtime-flag decision in ADR 0002 and linked it from README.
-- [x] Added a focused custom-tool registration regression that rejects unverified `constrainedSampling` advertisement.
-- [x] Passed the focused custom-tool suite (34 tests), full `npm test` (45 files / 545 tests), root typecheck, and loader smoke.
-- [x] Passed exact packed Pi 0.80.1 and 0.82.1 boundaries, including each boundary's full tests, loader smoke, and typecheck. The first 0.82.1 run hit an unrelated 30-second real-registry timeout; the clean rerun passed in 296 ms.
-- [x] Passed pi-lens diagnostics, `git diff --check`, and independent read-only review with no findings.
-- [x] Created two focused commits: `09e649e` (evidence/decision docs) and `cc7f42f` (custom-tool omission regression).
-- [x] Independent standards/spec review found no implementation or acceptance gaps.
-- [x] Re-ran both exact packed boundaries during review: 0.80.1 and 0.82.1 each pass all 545 tests, loader smoke, and typecheck.
-- [x] Added the Unreleased changelog documentation entry for the evidence-based no-go decision.
-
+- [x] Reviewed the extension across four parallel read-only domains (OAuth/security, catalog/provider, tools/media, usage/hygiene) and independently verified every high-severity claim against the source before accepting it.
+- [x] Downgraded two overstated reviewer findings after verification: `savePrivateStreamedOutput` path escape (both shipped callers pass literals) and the `search_replace` no-follow gap (requires a hostile process already inside the workspace).
+- [x] `fix(setup)` `c293641`..`9b1b73a`: scoped `defaultModel`/`defaultThinkingLevel` seeding by ownership so an existing non-xAI provider keeps its own model selection. Corrected the regression that asserted the destructive overwrite; added blank-fill vs deliberate-choice coverage.
+- [x] `fix(catalog)` `2e5bbb9`: moved the login `onProgress` call out of the `try` whose `catch` swaps in the curated fallback, so a throwing host UI callback can no longer discard a validated remote entitlement snapshot. Confirmed the new regression fails against the previous control flow.
+- [x] `fix(deps)` `c293641`: widened the `@napi-rs/wasm-runtime` override from exact `1.1.6` to `^1.2.0`. Upstream `@rolldown/binding-wasm32-wasi@1.2.1` now requires `@emnapi/core@2.0.0-alpha.3` + `@napi-rs/wasm-runtime@^1.2.0`, which ERESOLVE-failed every clean boundary install under `--strict-peer-deps`. Verified the failure reproduced on unmodified `main`, so it was pre-existing drift and not caused by this work. Resynced `package-lock.json` for CI's `npm ci`.
+- [x] Caught and reverted an editor auto-format that had rewritten all of `extensions/xai-oauth.ts` from spaces to tabs (537-line diff, and a suite slowdown from 6.3s to 21s). Re-applied the logical change as a minimal 21-line diff.
+- [x] Gates: `npm test` 50 files / **605 tests** pass, `npm run typecheck` clean, loader smoke ok, `npm run compatibility:check` ok (205-file packed manifest, unsupported peers correctly rejected), and **both exact boundaries pass** — Pi 0.80.1 ok and Pi 0.82.1 ok. `git diff --check` clean.
 
 ## In Progress
 
 - None.
 
-
 ## Next
 
-Push the branch and open a PR closing #146.
+Push the branch and open a PR. Reviewed-but-unfixed findings, in priority order, are available to pick up:
+
+1. `extensions/xai/images.ts:91-171` — inline-image budget is output-side only; no cap on per-image encoded size, image count, or clone recursion depth before `Buffer.from` decodes each original. (medium)
+2. `extensions/xai/images.ts:78-80` — `http(s)` image URLs forwarded to the backend with no host/IP/redirect policy, unlike the well-pinned `video-download.ts`. (medium)
+3. `extensions/xai/bounded-body.ts:129-159` — byte-bounded but has no signal or wall-clock deadline, so a slow drip can hang forever. (medium)
+4. `extensions/xai/media/output-storage.ts:91-112` — constrain `stemPrefix`/`extension` to a safe filename token; latent, not currently reachable. (low)
+5. `extensions/xai/tools/grok-native.ts:822-828`, `:624-638` — write/read through the checked descriptor instead of reopening by pathname. (low)
+6. `oauth.ts:164-165,574-579` (`expires === 0` truthiness), `oauth.ts:345-356` / `oidc.ts:60-68` (no timeout/bounded reader), `catalog.ts:428-439` (cached `thinkingLevelMap` values unvalidated), `responses.ts:187-198` (two terminal events). (low)
+7. `.github/workflows/ci.yml:22-23,60-61` — actions on mutable major tags; no `github-actions` Dependabot entry. (low)
+
+Local note: `npm run compatibility:check` walks the working tree and will fail with `Packed package is missing tests/.DS_Store` if macOS Finder artifacts are present. They are gitignored and absent in Linux CI; `find . -name .DS_Store -not -path "./node_modules/*" -delete` clears it.

--- a/bin/setup.js
+++ b/bin/setup.js
@@ -181,7 +181,8 @@ function updateSettings(settingsPath = SETTINGS_PATH) {
 
   // Prefer Pi's built-in xAI chat when no provider is configured. Never overwrite
   // an existing choice — including package-owned xai-auth or any other provider.
-  if (typeof settings.defaultProvider !== "string" || !settings.defaultProvider.trim()) {
+  const hadProvider = typeof settings.defaultProvider === "string" && settings.defaultProvider.trim() !== "";
+  if (!hadProvider) {
     settings.defaultProvider = BUNDLED_XAI_PROVIDER;
     changed = true;
     console.log(color(`   + Set defaultProvider: ${BUNDLED_XAI_PROVIDER}`, "green"));
@@ -189,16 +190,34 @@ function updateSettings(settingsPath = SETTINGS_PATH) {
     console.log(color(`   (Keeping defaultProvider: ${PACKAGE_OAUTH_PROVIDER})`, "reset"));
   }
 
-  if (settings.defaultModel !== DEFAULT_XAI_MODEL) {
-    settings.defaultModel = DEFAULT_XAI_MODEL;
-    changed = true;
-    console.log(color(`   + Set defaultModel: ${DEFAULT_XAI_MODEL}`, "green"));
-  }
+  // The model/thinking defaults are only coherent alongside an xAI provider.
+  // Seeding them next to an unrelated provider (e.g. anthropic) would leave the
+  // user on an impossible provider/model pair, so scope the writes:
+  //   - provider newly seeded here  -> this package owns the whole selection
+  //   - existing xAI provider       -> only fill in blanks, never replace a choice
+  //   - existing non-xAI provider   -> leave the selection untouched
+  const usesXaiProvider =
+    settings.defaultProvider === BUNDLED_XAI_PROVIDER ||
+    settings.defaultProvider === PACKAGE_OAUTH_PROVIDER;
+  const ownsModelSelection = !hadProvider;
 
-  if (settings.defaultThinkingLevel !== DEFAULT_THINKING_LEVEL) {
-    settings.defaultThinkingLevel = DEFAULT_THINKING_LEVEL;
-    changed = true;
-    console.log(color(`   + Set defaultThinkingLevel: ${DEFAULT_THINKING_LEVEL}`, "green"));
+  if (ownsModelSelection || usesXaiProvider) {
+    const blank = (value) => typeof value !== "string" || value.trim() === "";
+
+    if ((ownsModelSelection || blank(settings.defaultModel)) && settings.defaultModel !== DEFAULT_XAI_MODEL) {
+      settings.defaultModel = DEFAULT_XAI_MODEL;
+      changed = true;
+      console.log(color(`   + Set defaultModel: ${DEFAULT_XAI_MODEL}`, "green"));
+    }
+
+    if (
+      (ownsModelSelection || blank(settings.defaultThinkingLevel)) &&
+      settings.defaultThinkingLevel !== DEFAULT_THINKING_LEVEL
+    ) {
+      settings.defaultThinkingLevel = DEFAULT_THINKING_LEVEL;
+      changed = true;
+      console.log(color(`   + Set defaultThinkingLevel: ${DEFAULT_THINKING_LEVEL}`, "green"));
+    }
   }
 
   if (changed) {

--- a/extensions/xai-oauth.ts
+++ b/extensions/xai-oauth.ts
@@ -101,6 +101,9 @@ export default async function (pi: ExtensionAPI) {
       visionRouting.reset();
       const loginGeneration = ++loginCatalogGeneration;
       activeLoginRefreshes++;
+      // Progress text is chosen here but reported only after the catalog state is
+      // committed, so a failing notification cannot roll back a good catalog.
+      let notice: string | undefined;
       try {
         const { selection, isCurrent } = await refreshCatalog(credentials.access, {
           forceRefresh: true,
@@ -111,22 +114,28 @@ export default async function (pi: ExtensionAPI) {
         if (loginGeneration !== loginCatalogGeneration || !isCurrent) return;
         applyCatalog(selection, true);
         deferredRetryAfter = selection.needsAuthenticatedRefresh ? Date.now() + 60_000 : 0;
-        callbacks.onProgress?.(
+        notice =
           selection.source === "remote"
             ? `Refreshed ${selection.models.length} OAuth-visible xAI model${selection.models.length === 1 ? "" : "s"}.`
-            : "The authenticated xAI model catalog was unavailable; using the curated fallback.",
-        );
+            : "The authenticated xAI model catalog was unavailable; using the curated fallback.";
       } catch (error) {
         if (callbacks.signal?.aborted) throw error;
         if (loginGeneration === loginCatalogGeneration) {
           applyCatalog(curatedFallbackSelection(), true);
           deferredRetryAfter = Date.now() + 60_000;
-          callbacks.onProgress?.(
-            "The authenticated xAI model catalog was unavailable; using the curated fallback.",
-          );
+          notice = "The authenticated xAI model catalog was unavailable; using the curated fallback.";
         }
       } finally {
         activeLoginRefreshes--;
+      }
+      if (notice !== undefined) {
+        // Cosmetic, like the turn_end usage footer: a host UI failure must not fail
+        // the completed login or disturb the applied entitlement snapshot.
+        try {
+          callbacks.onProgress?.(notice);
+        } catch {
+          // Ignored on purpose; the catalog above is already committed.
+        }
       }
     },
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1207,22 +1207,25 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.1.tgz",
+      "integrity": "sha512-KjZdi8Q1wh89gsVmghvbrMgWl6ZWmRmHV6wjB7/g4Zf0dyO+hH3neZUtuDNPO00qq5YE5RITVWvrIZKRaAmzGQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.3"
       },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
       }
     },
     "node_modules/@nodable/entities": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "image": "https://raw.githubusercontent.com/BlockedPath/pi-xai-oauth/main/preview.jpeg"
   },
   "overrides": {
-    "@napi-rs/wasm-runtime": "1.1.6",
+    "@napi-rs/wasm-runtime": "^1.2.0",
     "brace-expansion": "^5.0.8",
     "protobufjs": "^7.6.5"
   },

--- a/tests/provider/catalog-races.test.ts
+++ b/tests/provider/catalog-races.test.ts
@@ -79,11 +79,15 @@ function installBaseFetch(
   );
   return bearers;
 }
-async function login(provider: any, setUrl: (url: URL) => void) {
+async function login(
+  provider: any,
+  setUrl: (url: URL) => void,
+  onProgress: (message: string) => void = () => {},
+) {
   let manualCallback = "";
   return provider.oauth.login({
     onPrompt: async () => "n",
-    onProgress: () => {},
+    onProgress,
     onAuth(auth: any) {
       const url = new URL(auth.url);
       setUrl(url);
@@ -218,5 +222,55 @@ describe.sequential("catalog refresh ownership races", () => {
     expect(h.providers.get("xai-auth").models.map(({ id }: any) => id)).toEqual(
       ["login-priority"],
     );
+  });
+  it("keeps the applied remote catalog when the progress callback throws", async () => {
+    let authUrl: URL | undefined;
+    installBaseFetch(
+      [
+        async () =>
+          jsonResponse({
+            data: [
+              {
+                model: "entitled-only",
+                api_backend: "responses",
+                context_window: 100_000,
+              },
+            ],
+          }),
+      ],
+      () => authUrl,
+    );
+    const h = createExtensionHarness();
+    await extension(h.api);
+
+    // A host UI failure is cosmetic: it must not roll the validated remote
+    // entitlement snapshot back to the curated fallback. Only the catalog
+    // notice throws; earlier login-flow progress must still work.
+    const notices: string[] = [];
+    await login(
+      h.providers.get("xai-auth"),
+      (url) => {
+        authUrl = url;
+      },
+      (message) => {
+        notices.push(message);
+        if (/OAuth-visible|curated fallback/.test(message)) {
+          throw new Error("ui notification failed");
+        }
+      },
+    );
+
+    expect(notices.at(-1)).toMatch(/Refreshed 1 OAuth-visible xAI model\./);
+
+    expect(h.providers.get("xai-auth").models.map(({ id }: any) => id)).toEqual(
+      ["entitled-only"],
+    );
+    const cache = JSON.parse(
+      await readFile(
+        join(temp.path, ".pi/agent/cache/pi-xai-oauth/models-v2.json"),
+        "utf8",
+      ),
+    );
+    expect(cache.models.map(({ id }: any) => id)).toEqual(["entitled-only"]);
   });
 });

--- a/tests/setup/settings.test.ts
+++ b/tests/setup/settings.test.ts
@@ -106,6 +106,8 @@ describe("setup settings", () => {
       defaultThinkingLevel: "high",
     });
 
+    // An unrelated provider owns its own model selection. Seeding a Grok model
+    // next to it would leave the user on an impossible provider/model pair.
     await writeFile(
       settingsPath,
       JSON.stringify({
@@ -119,6 +121,39 @@ describe("setup settings", () => {
     expect(JSON.parse(await readFile(settingsPath, "utf8"))).toMatchObject({
       packages: ["npm:pi-xai-oauth"],
       defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-6",
+      defaultThinkingLevel: "medium",
+    });
+  });
+  it("fills blank xAI defaults but keeps a deliberate xAI model choice", async () => {
+    await mkdir(join(settingsPath, ".."), { recursive: true });
+    await writeFile(
+      settingsPath,
+      JSON.stringify({
+        packages: ["npm:pi-xai-oauth"],
+        defaultProvider: "xai",
+        defaultModel: "grok-4-fast",
+        defaultThinkingLevel: "low",
+      }),
+    );
+    setup.updateSettings(settingsPath);
+    expect(JSON.parse(await readFile(settingsPath, "utf8"))).toMatchObject({
+      defaultProvider: "xai",
+      defaultModel: "grok-4-fast",
+      defaultThinkingLevel: "low",
+    });
+
+    await writeFile(
+      settingsPath,
+      JSON.stringify({
+        packages: ["npm:pi-xai-oauth"],
+        defaultProvider: "xai-auth",
+        defaultModel: "",
+      }),
+    );
+    setup.updateSettings(settingsPath);
+    expect(JSON.parse(await readFile(settingsPath, "utf8"))).toMatchObject({
+      defaultProvider: "xai-auth",
       defaultModel: "grok-4.5",
       defaultThinkingLevel: "high",
     });


### PR DESCRIPTION
Follow-up to a full read-only review of the extension. Three independent fixes, each with a regression, plus the dependency drift that was already failing CI on `main`.

## 1. `fix(deps)` — unblock the boundary gate (was already red on `main`)

`@rolldown/binding-wasm32-wasi@1.2.1` shipped upstream depending on `@emnapi/core@2.0.0-alpha.3` and `@napi-rs/wasm-runtime@^1.2.0`. Our override pinned `@napi-rs/wasm-runtime` to exactly `1.1.6`, whose peer is the narrower `^1.7.1`.

Boundary jobs install from a clean pack with `--package-lock=false`, so they resolve the new upstream tree and failed with `ERESOLVE` under `--strict-peer-deps`:

```
npm error Found: @emnapi/core@2.0.0-alpha.3
npm error   from @rolldown/binding-wasm32-wasi@1.2.1
npm error peer @emnapi/core@"^1.7.1" from @napi-rs/wasm-runtime@1.1.6
```

`@napi-rs/wasm-runtime@1.2.1` widened its peer to `^1.7.1 || ^2.0.0-alpha.3`, accepting both trees, so the override moves to `^1.2.0`. Lockfile resynced for `npm ci`. The dependency stays dev-only and optional, so published consumers are unaffected.

Verified this failure reproduced on unmodified `main` before changing anything — pre-existing drift, not introduced here.

## 2. `fix(setup)` — stop overwriting a non-xAI model selection

`updateSettings` carefully preserved an existing `defaultProvider`, then two lines later unconditionally overwrote `defaultModel` and `defaultThinkingLevel`. Installing alongside an existing `anthropic` + `claude-opus-4-6` selection left the user on `anthropic` + `grok-4.5` — an incoherent pair.

Writes are now scoped by ownership:

| Existing state | Behavior |
|---|---|
| No provider set | Package owns the selection, seeds provider + model + thinking |
| Existing `xai` / `xai-auth` | Fills blanks only, a deliberate `grok-4-fast` survives |
| Existing `anthropic` etc. | Untouched |

The previous regression asserted the destructive result, so it is corrected rather than deleted, and blank-fill vs deliberate-choice coverage is added.

## 3. `fix(catalog)` — keep the applied catalog when the progress callback throws

The login catalog `try` block also wrapped `callbacks.onProgress`, and its `catch` replaces the catalog with the curated fallback. A throwing host progress callback therefore discarded an already-applied, validated remote entitlement snapshot and forced an unnecessary unregister/register cycle onto fallback models.

The notice text is now chosen inside the guarded block and reported only after catalog state is committed. The notification is cosmetic — matching the existing `turn_end` usage footer precedent — so a host UI failure must not fail a completed login or disturb the entitlement snapshot.

Confirmed the new regression **fails against the previous control flow** (reverted the source, test went red; restored, green) — it is a real guard, not a tautology.

## Verification

- `npm test` — 50 files, **605 tests** pass (was 603)
- `npm run typecheck` — clean
- `npm run test:loader` — ok
- `npm run compatibility:check` — ok, 205-file packed manifest, unsupported peers 0.79.10 / 0.83.0 correctly rejected
- **`npm run compatibility:boundaries` — Pi 0.80.1 ok and Pi 0.82.1 ok** (both were failing on `main`)
- `git diff --check` — clean

## Notes for the reviewer

- An editor auto-format briefly rewrote all of `extensions/xai-oauth.ts` from spaces to tabs (537-line diff). It was reverted and the logical change re-applied as a minimal 21-line diff. Worth checking whether a format-on-save config disagrees with this repo's space indentation.
- `npm run compatibility:check` walks the working tree and fails locally with `Packed package is missing tests/.DS_Store` when macOS Finder artifacts are present. They are gitignored and absent in Linux CI, but the script arguably should skip ignored paths.
- Seven further review findings (unbounded inline-image input budget, unpinned `http(s)` image URLs, `bounded-body` missing deadline, and four low-severity items) are recorded in priority order in `.scaffold/progress.md` and intentionally left for follow-up.
