### PR TITLE
test: stop flaky ModelRuntime catalog refreshes from hanging the suite

### DIFF
--- a/tests/oauth/auth-storage.integration.test.ts
+++ b/tests/oauth/auth-storage.integration.test.ts
@@ -1,5 +1,5 @@
 import type { OAuthLoginCallbacks } from "@earendil-works/pi-ai";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { XAI_OAUTH_DEVICE_URL } from "../../extensions/xai/constants";
 import {
   createXaiOAuth,
@@ -75,6 +75,23 @@ function runtimeInteraction(callbacks: OAuthLoginCallbacks) {
     },
   };
 }
+
+/**
+ * Keep Pi's real credential runtime hermetic for this suite.
+ *
+ * `ModelRuntime.create` sets `modelNetworkEnabled = process.env.PI_OFFLINE === undefined`,
+ * and `ModelRuntime.login()` finishes by awaiting `refresh({ allowNetwork: modelNetworkEnabled })`
+ * with no signal and no timeout. Left unset, a *successful* login therefore fans out real,
+ * unbounded catalog requests for every builtin provider (observed: `https://pi.dev/api/models/...`),
+ * which hangs the test whenever the network is slow or unreachable. `PI_OFFLINE` keeps that
+ * post-login refresh offline, and the fetch stub guarantees no request can escape the suite.
+ */
+beforeEach(() => {
+  vi.stubEnv("PI_OFFLINE", "1");
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+    throw new Error(`Unexpected network request in an isolated test: ${String((input as Request)?.url ?? input)}`);
+  });
+});
 
 async function createPiAuthHarness(id: string, initial?: any) {
   const codingAgent = (await import("@earendil-works/pi-coding-agent")) as any;

--- a/tests/provider/credentials.test.ts
+++ b/tests/provider/credentials.test.ts
@@ -79,7 +79,15 @@ async function realBoundaryRegistry(initialCredential: any) {
     await runtime.refresh({ allowNetwork: false });
     return {
       registry,
-      setRuntimeApiKey: (key: string) => runtime.setRuntimeApiKey("xai-auth", key),
+      // Pi 0.81.0 stopped honouring `allowModelNetwork` for the runtime's persistent
+      // network flag (`modelNetworkEnabled = process.env.PI_OFFLINE === undefined`) and
+      // in the same release gave `setRuntimeApiKey` a third `refreshOptions` argument.
+      // Its trailing `await this.refresh(refreshOptions)` therefore defaults to a
+      // network-enabled, signal-less, timeout-less catalog refresh across every builtin
+      // provider. Bound it exactly like the two explicit refreshes above; older runtimes
+      // ignore the extra argument and already honour `allowModelNetwork: false`.
+      setRuntimeApiKey: (key: string) =>
+        runtime.setRuntimeApiKey("xai-auth", key, { allowNetwork: false }),
     };
   }
 
@@ -99,6 +107,11 @@ async function realBoundaryRegistry(initialCredential: any) {
 beforeEach(async () => {
   temp = await createTempDir("pi-xai-auth-");
   vi.stubEnv("HOME", temp.path);
+  // No assertion in this suite depends on a real catalog fetch. Fail fast instead of
+  // hanging if Pi ever reintroduces an implicitly network-enabled refresh.
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+    throw new Error(`Unexpected network request in an isolated test: ${String((input as Request)?.url ?? input)}`);
+  });
 });
 afterEach(async () => {
   setXaiRuntimeModels(CURATED_FALLBACK_MODELS);


### PR DESCRIPTION
## Description

Two integration tests were intermittently timing out at 30s because Pi's real `ModelRuntime` was making unbounded network catalog fetches after operations the tests already intended to keep offline.

Both hangs were the same class of bug (real `https://pi.dev/api/models/providers/*` fan-out with no signal/timeout), but different escape points:

1. **`tests/oauth/auth-storage.integration.test.ts`** — `ModelRuntime.login()` always finishes with `refresh({ allowNetwork: this.modelNetworkEnabled })`. `modelNetworkEnabled` is `process.env.PI_OFFLINE === undefined`; the harness's `allowModelNetwork: false` only bounds the *constructor* refresh. A successful device login therefore fanned out real catalog requests. The cancelled sibling never reached that path.

2. **`tests/provider/credentials.test.ts`** — `realBoundaryRegistry` already passed `{ allowNetwork: false }` to its explicit refreshes, but `setRuntimeApiKey` hid a third. Pi 0.81.0 stopped folding `allowModelNetwork` into the persistent network flag and gave `setRuntimeApiKey` a third `refreshOptions` argument that defaults to network-enabled. Calling it with two args leaked the same unbounded refresh. The sibling stored-API-key boundary test never calls `setRuntimeApiKey`.

Fixes are test-only:

- Pin `PI_OFFLINE` + stub `fetch` for the device-login harness.
- Pass `{ allowNetwork: false }` to `setRuntimeApiKey`, matching the helper's existing intent; stub `fetch` as a fail-fast net.
- Assertions unchanged; no production/compat/dependency files touched.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] `npx vitest run tests/oauth/auth-storage.integration.test.ts` x15 then x10 -> **25/25** (was ~8/10 with 30s hangs)
- [x] `npx vitest run tests/provider/credentials.test.ts` x12 -> **12/12** (was ~1 in 3 hang at suite level)
- [x] Full `npm test` x5 -> **5/5 fully green** (50 files / 605 tests)
- [x] `npm run typecheck`
- [x] `npm run test:loader`
- [x] Zero fetch attempts after the credentials fix (counting stub), so `{ allowNetwork: false }` does the work and the fetch stub is only a net

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
