### PR TITLE
fix(bounded-body): abort truncated body reads on deadline

### DIFF
--- a/extensions/xai/bounded-body.ts
+++ b/extensions/xai/bounded-body.ts
@@ -125,10 +125,13 @@ export async function readBoundedResponseText(
 /**
  * Read at most `maxBytes` of a body for classification only, truncating instead
  * of failing and returning `""` whenever the body is missing or unreadable.
+ * When `signal` aborts, cancel the reader and reject so a stalled peer under
+ * the byte cap cannot hang the request past the caller deadline.
  */
 export async function readTruncatedResponseText(
   response: Response,
   maxBytes: number,
+  signal?: AbortSignal,
 ): Promise<string> {
   if (exceedsDeclaredLength(response, maxBytes)) {
     await response.body?.cancel().catch(() => {});
@@ -139,9 +142,27 @@ export async function readTruncatedResponseText(
   const reader = response.body.getReader();
   const chunks: Uint8Array[] = [];
   let total = 0;
+  const abortError = () => signal?.reason ?? cancellationError();
+  let rejectOnAbort: ((reason: unknown) => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    rejectOnAbort = reject;
+  });
+  const onAbort = () => {
+    // Reject before cancelling: cancellation settles the pending read as
+    // `done`, which would otherwise race the abort into a truncated success.
+    rejectOnAbort?.(abortError());
+    cancelReader(reader);
+  };
+  signal?.addEventListener("abort", onAbort, { once: true });
+
   try {
+    // Cancellation can land between the completed fetch and body-reader setup.
+    // Check after subscribing, inside the cleanup boundary, so that gap neither
+    // starts an orphaned read nor retains the listener.
+    if (signal?.aborted) throw abortError();
     while (true) {
-      const { value, done } = await reader.read();
+      const read = reader.read();
+      const { value, done } = signal ? await Promise.race([read, aborted]) : await read;
       if (done) break;
       if (!value) continue;
       const remaining = maxBytes - total;
@@ -152,9 +173,14 @@ export async function readTruncatedResponseText(
         break;
       }
     }
-  } catch {
+    return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk))).toString("utf8");
+  } catch (error) {
     cancelReader(reader);
+    // Abort must surface so callers honor deadlines; other read failures stay "".
+    if (signal?.aborted) throw error;
     return "";
+  } finally {
+    signal?.removeEventListener("abort", onAbort);
+    releaseReader(reader);
   }
-  return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk))).toString("utf8");
 }

--- a/extensions/xai/responses.ts
+++ b/extensions/xai/responses.ts
@@ -67,7 +67,8 @@ function acquireRedirectGuard(url: string): () => void {
         guarded ? { ...init, redirect: "error" } : init,
       );
       if (!guarded || response.ok) return response;
-      const error = await xaiHttpErrorFromResponse(response, url);
+      const requestSignal = init?.signal ?? (input instanceof Request ? input.signal : undefined);
+      const error = await xaiHttpErrorFromResponse(response, url, requestSignal);
       const marker = error.code === "encrypted-content-mismatch"
         ? "encrypted_content"
         : error.code === "proxy-version-gate"
@@ -261,7 +262,7 @@ export async function postXaiJson(
   });
 
   if (!response.ok) {
-    throw await xaiHttpErrorFromResponse(response, url);
+    throw await xaiHttpErrorFromResponse(response, url, signal);
   }
 
   if (maxResponseBytes !== undefined) {

--- a/extensions/xai/wire.ts
+++ b/extensions/xai/wire.ts
@@ -293,7 +293,8 @@ export class XaiHttpError extends Error {
 export async function xaiHttpErrorFromResponse(
   response: Response,
   url: string,
+  signal?: AbortSignal,
 ): Promise<XaiHttpError> {
-  const detail = await readTruncatedResponseText(response, MAX_ERROR_BODY_BYTES);
+  const detail = await readTruncatedResponseText(response, MAX_ERROR_BODY_BYTES, signal);
   return new XaiHttpError(response.status, routeKindForUrl(url), detail);
 }

--- a/tests/setup/shared-primitives.test.ts
+++ b/tests/setup/shared-primitives.test.ts
@@ -146,4 +146,35 @@ describe("shared bounded body readers", () => {
     expect(cancel).toHaveBeenCalledTimes(1);
     await expect(readTruncatedResponseText(new Response(null), 8)).resolves.toBe("");
   });
+
+  it("aborts a stalled truncated body read within the caller deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const cancel = vi.fn();
+      // Peer never closes and stays under maxBytes — only the deadline unblocks.
+      const stalled = new Response(new ReadableStream<Uint8Array>({ cancel }));
+      const deadline = composeTimeoutSignal(undefined, 1_000);
+      const reading = readTruncatedResponseText(stalled, 1024, deadline.signal);
+      const settled = expect(reading).rejects.toMatchObject({ name: "AbortError" });
+      await vi.advanceTimersByTimeAsync(1_000);
+      await settled;
+      expect(cancel).toHaveBeenCalledTimes(1);
+      deadline.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels a truncated body reader immediately when the caller aborts", async () => {
+    const cancel = vi.fn();
+    const controller = new AbortController();
+    const reading = readTruncatedResponseText(
+      new Response(new ReadableStream<Uint8Array>({ cancel })),
+      1024,
+      controller.signal,
+    );
+    controller.abort();
+    await expect(reading).rejects.toMatchObject({ name: "AbortError" });
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary
- Thread `AbortSignal` through `readTruncatedResponseText` and race/cancel `reader.read()` the same way `readBoundedResponseText` does.
- Pass the existing request deadline from `xaiHttpErrorFromResponse` callers (`postXaiJson`, redirect-guard).
- Add stalled-body and immediate-abort regressions; oversized/happy-path classification still returns `""` without reflecting body bytes.

## Why
A peer could hang the process forever by slowly dripping (or never closing) under the byte cap. Other bounded readers already compose timeout signals; the truncated/error-body helper was the gap.

## Test plan
- [x] `npm run test:unit -- tests/setup/shared-primitives.test.ts`
- [x] `npm test`
- [x] `npm run typecheck`
- [x] `npm run test:loader`

Closes #162