### PR TITLE
Support Pi 0.84.1 OAuth refresh and catalog lifecycle

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -20,3 +20,8 @@ auth.json
 pi-session-*.html
 cat.svg
 .agent-task.md
+
+# Local research and live-probe artifacts are never part of the extension package.
+docs/research/
+prototype/
+probe-*

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,28 +1,28 @@
-# Implementation Plan — Issue #132: Built-in xAI network tools
+# Implementation Plan — Pi 0.84.1 compatibility
 
-**Branch:** `feat/132-builtin-xai-tools`
-**Issue:** https://github.com/BlockedPath/pi-xai-oauth/issues/132
-**Linear:** BLO-15
+**Branch:** `feature/pi-0.84.1-compat`
 
 ## Goal
 
-Support Pi's built-in `xai` SuperGrok/X Premium credentials for opt-in network tools and subscription usage without taking over Pi's built-in chat, catalog, stream, vision routing, or package-owned local Grok adapters.
+Support aligned `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` releases through exact Pi 0.84.1 while preserving the exact Pi 0.80.1 minimum boundary.
 
-## Phases
+## Confirmed public seams
 
-1. [x] Read the task, GitHub/Linear context, required entrypoints, auth/tool/usage modules, tests, and Pi 0.81.1 provider/runtime behavior.
-2. [x] Add the narrow `xai-auth`/`xai` network-tool provider boundary.
-3. [x] Resolve both providers active-first with OAuth/API-key provenance and strict usage rejection.
-4. [x] Add network lifecycle, command, credential, usage, and non-takeover regressions.
-5. [x] Update README/changelog and persistent state.
-6. [ ] Run diagnostics, focused/full tests, typecheck, exact Pi boundaries, and independent review.
-7. [ ] Commit, push, open a PR closing #132, and update BLO-15.
+1. OAuth refresh accepts Pi's concrete abort signal, uses it for token exchange, and lets Pi atomically persist rotated credentials.
+2. Provider catalog re-registration/publication remains exact across the minimum and newest ModelRuntime contracts.
+3. A clean packed package passes full tests, loader smoke, and TypeScript at exact 0.80.1 and 0.84.1.
 
-## Validation Contract
+## Vertical slices
 
-- Active `xai/grok-*` models can opt into and execute network-backed tools.
-- Built-in OAuth resolves as `oauth-session`; built-in API keys resolve as `api-key`.
-- Usage accepts Pi-managed OAuth only and rejects an active built-in API-key credential.
-- Switching to a non-xAI provider clears network opt-ins.
-- `xai-auth` remains the only package-registered/catalog/stream provider.
-- Automatic local Grok adapters and vision routing remain `xai-auth`-only.
+1. [x] Add a failing refresh-signal regression; propagate the signal through `refreshToken`.
+2. [x] Adapt real-runtime cancellation/catalog tests to the public Pi 0.80.1 and 0.84.1 contracts without weakening credential/catalog assertions.
+3. [x] Widen aligned peers to `<0.85.0`, pin exact development dependencies/latest policy to 0.84.1, and update the lockfile.
+4. [x] Update README, changelog, compatibility guidance, and persistent progress.
+5. [x] Run focused diagnostics/tests, full gates, and both exact packed boundaries.
+6. [x] Run independent correctness and standards/spec review; address confirmed findings and rerun affected gates.
+
+## Non-goals
+
+- No changes to xAI endpoints, scopes, catalog entitlement policy, or Responses routing.
+- No core Pi modifications.
+- No claim beyond Pi 0.84.x until a later line passes the same candidate process.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,17 +1,20 @@
-# Execution Progress — Code review follow-up
+# Execution Progress — Pi 0.84.1 compatibility
 
-**Branch:** `fix/setup-seeding-and-catalog-catch`
-**Scope:** Fixes for two findings from a full read-only review of the extension, plus the dependency drift that was blocking the boundary gate.
+**Branch:** `feature/pi-0.84.1-compat`
 
 ## Completed
 
-- [x] Reviewed the extension across four parallel read-only domains (OAuth/security, catalog/provider, tools/media, usage/hygiene) and independently verified every high-severity claim against the source before accepting it.
-- [x] Downgraded two overstated reviewer findings after verification: `savePrivateStreamedOutput` path escape (both shipped callers pass literals) and the `search_replace` no-follow gap (requires a hostile process already inside the workspace).
-- [x] `fix(setup)` `c293641`..`9b1b73a`: scoped `defaultModel`/`defaultThinkingLevel` seeding by ownership so an existing non-xAI provider keeps its own model selection. Corrected the regression that asserted the destructive overwrite; added blank-fill vs deliberate-choice coverage.
-- [x] `fix(catalog)` `2e5bbb9`: moved the login `onProgress` call out of the `try` whose `catch` swaps in the curated fallback, so a throwing host UI callback can no longer discard a validated remote entitlement snapshot. Confirmed the new regression fails against the previous control flow.
-- [x] `fix(deps)` `c293641`: widened the `@napi-rs/wasm-runtime` override from exact `1.1.6` to `^1.2.0`. Upstream `@rolldown/binding-wasm32-wasi@1.2.1` now requires `@emnapi/core@2.0.0-alpha.3` + `@napi-rs/wasm-runtime@^1.2.0`, which ERESOLVE-failed every clean boundary install under `--strict-peer-deps`. Verified the failure reproduced on unmodified `main`, so it was pre-existing drift and not caused by this work. Resynced `package-lock.json` for CI's `npm ci`.
-- [x] Caught and reverted an editor auto-format that had rewritten all of `extensions/xai-oauth.ts` from spaces to tabs (537-line diff, and a suite slowdown from 6.3s to 21s). Re-applied the logical change as a minimal 21-line diff.
-- [x] Gates: `npm test` 50 files / **605 tests** pass, `npm run typecheck` clean, loader smoke ok, `npm run compatibility:check` ok (205-file packed manifest, unsupported peers correctly rejected), and **both exact boundaries pass** — Pi 0.80.1 ok and Pi 0.82.1 ok. `git diff --check` clean.
+- [x] Confirmed all three public acceptance seams with the user: OAuth persistence/cancellation, catalog publication, and exact packed matrices.
+- [x] Reproduced the pre-fix Pi 0.84.1 candidate result and isolated its cancellation/catalog compatibility failures.
+- [x] Added a red-green regression proving Pi's concrete refresh signal reaches the xAI token exchange, then forwarded it through `createXaiOAuth().refreshToken`.
+- [x] Added a real file-backed rollover regression proving request preparation persists refreshed access and rotated refresh credentials before use on both the legacy 0.80.1 registry and current 0.84.1 ModelRuntime.
+- [x] Adapted cancellation and stored-catalog publication tests across the 0.80.1 and 0.84.1 contracts.
+- [x] Widened aligned peers to `>=0.80.1 <0.85.0`, pinned exact development dependencies/policy to 0.84.1, and updated the lockfile, README, changelog, and package exclusions.
+- [x] Excluded caller-owned local research, prototype, and probe artifacts from npm tarballs without deleting or tracking them.
+- [x] Independent review found no blocker. Addressed all three notes: rejection-sensitive cancellation assertion, minimum-boundary file persistence coverage, and local artifact packaging exclusions.
+- [x] Final local `npm test` passes: 50 files / 613 tests plus loader smoke.
+- [x] `npm run typecheck`, `npm run compatibility:check`, `git diff --check`, and edited-file LSP diagnostics pass.
+- [x] Clean packed exact Pi 0.80.1 and 0.84.1 boundaries each pass all 613 tests, loader smoke, and TypeScript.
 
 ## In Progress
 
@@ -19,14 +22,4 @@
 
 ## Next
 
-Push the branch and open a PR. Reviewed-but-unfixed findings, in priority order, are available to pick up:
-
-1. `extensions/xai/images.ts:91-171` — inline-image budget is output-side only; no cap on per-image encoded size, image count, or clone recursion depth before `Buffer.from` decodes each original. (medium)
-2. `extensions/xai/images.ts:78-80` — `http(s)` image URLs forwarded to the backend with no host/IP/redirect policy, unlike the well-pinned `video-download.ts`. (medium)
-3. `extensions/xai/bounded-body.ts:129-159` — byte-bounded but has no signal or wall-clock deadline, so a slow drip can hang forever. (medium)
-4. `extensions/xai/media/output-storage.ts:91-112` — constrain `stemPrefix`/`extension` to a safe filename token; latent, not currently reachable. (low)
-5. `extensions/xai/tools/grok-native.ts:822-828`, `:624-638` — write/read through the checked descriptor instead of reopening by pathname. (low)
-6. `oauth.ts:164-165,574-579` (`expires === 0` truthiness), `oauth.ts:345-356` / `oidc.ts:60-68` (no timeout/bounded reader), `catalog.ts:428-439` (cached `thinkingLevelMap` values unvalidated), `responses.ts:187-198` (two terminal events). (low)
-7. `.github/workflows/ci.yml:22-23,60-61` — actions on mutable major tags; no `github-actions` Dependabot entry. (low)
-
-Local note: `npm run compatibility:check` walks the working tree and will fail with `Packed package is missing tests/.DS_Store` if macOS Finder artifacts are present. They are gitignored and absent in Linux CI; `find . -name .DS_Store -not -path "./node_modules/*" -delete` clears it.
+Commit the reviewed diff, push the feature branch, and open a pull request. Do not include caller-owned untracked probe/research/prototype files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,15 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 ### Changed
 
 - Setup no longer forces `defaultProvider: xai-auth`. When no provider is configured it seeds Pi's built-in `xai` chat provider, preserves any existing provider choice (including package-owned `xai-auth`), and still installs opt-in tools plus `/xai-usage` for both providers.
-- Reviewed the Pi 0.82 line and adopted it as the latest exact tested boundary after clean packed candidate validation, while preserving the 0.80.1 minimum. Pi 0.82's `bash` factory reads the tool execution context's session manager, active model, and thinking level to expose `PI_*` session metadata; the Grok-native `run_terminal_command` adapter delegates that context unchanged and is now covered by a realistic session-context test.
-- Widened aligned Pi peers to `>=0.80.1 <0.83.0` and pinned development metadata and the lockfile exactly to 0.82.1, the latest release inside the allowed line at review time.
+- Reviewed Pi 0.82 through 0.84.1 and adopted 0.84.1 as the latest exact tested boundary after clean packed candidate validation, while preserving the 0.80.1 minimum. Compatibility coverage now includes Pi 0.83's proactive OAuth refresh and Pi 0.84's cross-process credential reload, abortable refresh, and generation-checked catalog publication contracts.
+- Widened aligned Pi peers to `>=0.80.1 <0.85.0` and pinned development metadata and the lockfile exactly to 0.84.1, the latest release inside the allowed line at review time. Pi 0.82's `bash` session metadata remains suppressed from Grok-native terminal children through the cross-range `spawnHook`.
 - Audited Pi's built-in `xai` reasoning levels against the package-owned `xai-auth` catalog and found no stale mappings; every difference is intentional and is now pinned by tests. No advertised reasoning level changed.
 - Suppressed Pi's `PI_SESSION_ID`, `PI_SESSION_FILE`, `PI_PROVIDER`, `PI_MODEL`, and `PI_REASONING_LEVEL` metadata from Grok-native terminal child processes, including stale parent values on older supported Pi versions, while preserving all unrelated environment variables and standard shell behavior.
+
+### Fixed
+
+- Forwarded Pi 0.84's concrete OAuth refresh abort signal through xAI discovery and token exchange so cancelled or timed-out refreshes release Pi's credential-store lock without a late network commit.
+- Kept real-runtime credential cancellation and model-catalog publication tests compatible with both the Pi 0.80.1 legacy surfaces and Pi 0.84's abort and read-only stored-catalog contracts.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This package adds xAI's **account-specific OAuth model catalog** to pi, with **G
 
 > **Latest release:** `pi-xai-oauth` **1.4.0** adds opt-in vision routing, image-to-video generation, the `pi-clickable-menu:xai-tools` bridge, built-in SuperGrok network-tool/usage support, and Pi 0.81.1 compatibility, while hardening credential isolation, local media bounds, and Grok-native path containment. Existing npm installs should run `pi update npm:pi-xai-oauth`; local checkout installs should keep only one copy with `pi remove npm:pi-xai-oauth && pi install .`.
 >
-> **Compatibility:** aligned `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` versions `>=0.80.1 <0.83.0`. The exact tested boundaries are 0.80.1 and 0.82.1.
+> **Compatibility:** aligned `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` versions `>=0.80.1 <0.85.0`. The exact tested boundaries are 0.80.1 and 0.84.1.
 
 See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and fix history.
 
@@ -182,13 +182,13 @@ Authenticate with `/login xai`. Use `/login xai-auth` only when you want this pa
 Both Pi runtime peers use the same bounded range:
 
 ```text
-@earendil-works/pi-ai:            >=0.80.1 <0.83.0
-@earendil-works/pi-coding-agent:  >=0.80.1 <0.83.0
+@earendil-works/pi-ai:            >=0.80.1 <0.85.0
+@earendil-works/pi-coding-agent:  >=0.80.1 <0.85.0
 ```
 
-The lower boundary is **0.80.1**, the first published Pi 0.80 release. It provides the `@earendil-works/pi-ai/compat` transport used by this extension and the matching Pi 0.80 extension-loader contract. The packed package's complete test and typecheck suites run against exact 0.80.1 in CI. The other matrix boundary is exact **0.82.1**, the latest release inside the allowed line when this policy was reviewed. Pi 0.80.8 introduced the unified `ModelRuntime` credential API and replaced the exported `AuthStorage` surface with `readStoredCredential()` for one-off reads; this package supports both the 0.80.1 legacy surface and the 0.81.x/0.82.x ModelRegistry projection of `ModelRuntime.getAuth` through a bounded compatibility path. Pi 0.82 additionally reads the tool execution context's session manager, active model, and thinking level to expose `PI_*` session metadata to `bash`. The Grok-native `run_terminal_command` adapter deliberately suppresses that metadata, including inherited stale parent values on Pi 0.80.1, through the bash `spawnHook` available across the entire supported range.
+The lower boundary is **0.80.1**, the first published Pi 0.80 release. It provides the `@earendil-works/pi-ai/compat` transport used by this extension and the matching Pi 0.80 extension-loader contract. The packed package's complete test and typecheck suites run against exact 0.80.1 in CI. The other matrix boundary is exact **0.84.1**, the latest release inside the allowed line when this policy was reviewed. Pi 0.80.8 introduced the unified `ModelRuntime` credential API and replaced the exported `AuthStorage` surface with `readStoredCredential()` for one-off reads. Pi 0.83 added five-minute-early OAuth refresh, and Pi 0.84 added cross-process credential reloads, bounded refresh locking, concrete refresh abort signals, and generation-checked model-catalog publication. This package supports the 0.80.1 legacy surface and the newer ModelRuntime/ModelRegistry contracts through bounded compatibility paths; its OAuth callback forwards Pi 0.84's abort signal through the pinned token exchange. Pi 0.82 also began exposing `PI_*` session metadata to `bash`; the Grok-native `run_terminal_command` adapter deliberately suppresses that metadata, including inherited stale parent values on Pi 0.80.1, through the `spawnHook` available across the entire supported range.
 
-The exclusive `<0.83.0` upper bound is deliberate. Pi is pre-1.0, so a new minor line may contain breaking API or loader changes; this project does not claim support until that line passes the packed compatibility suite. npm therefore reports a peer-resolution warning or error during installation for older releases such as 0.79.10 and for the untested 0.83 line, rather than allowing a later runtime loader failure.
+The exclusive `<0.85.0` upper bound is deliberate. Pi is pre-1.0, so a new minor line may contain breaking API or loader changes; this project does not claim support until that line passes the packed compatibility suite. npm therefore reports a peer-resolution warning or error during installation for older releases such as 0.79.10 and for the untested 0.85 line, rather than allowing a later runtime loader failure.
 
 Older `pi-xai-oauth` 1.2.4 builds supported Pi 0.79.8's then-current Responses guard. Current code uses the Pi 0.80 compat dispatcher after the 1.3.2 export migration and 1.3.3 loader-resolution fix, so that historical statement is not the current minimum.
 
@@ -774,7 +774,7 @@ pi update npm:pi-xai-oauth
 
 This pulls the latest version from npm and updates your installed extension.
 
-The current build requires aligned Pi runtime packages in `>=0.80.1 <0.83.0`, with exact packed-package validation at 0.80.1 and 0.82.1. Version 1.4.0 added opt-in vision routing, image-to-video generation, the menu bridge, built-in SuperGrok tool/usage support, and further transport and entitlement hardening on top of authenticated model discovery, device OAuth, encrypted reasoning replay, Grok-native tools, bounded image editing, and explicit subscription usage. See [CHANGELOG.md](CHANGELOG.md) for the complete release notes. If you installed the published npm package, update with the command above. If you are testing a local checkout instead, reinstall the checkout:
+The current build requires aligned Pi runtime packages in `>=0.80.1 <0.85.0`, with exact packed-package validation at 0.80.1 and 0.84.1. Version 1.4.0 added opt-in vision routing, image-to-video generation, the menu bridge, built-in SuperGrok tool/usage support, and further transport and entitlement hardening on top of authenticated model discovery, device OAuth, encrypted reasoning replay, Grok-native tools, bounded image editing, and explicit subscription usage. See [CHANGELOG.md](CHANGELOG.md) for the complete release notes. If you installed the published npm package, update with the command above. If you are testing a local checkout instead, reinstall the checkout:
 
 ```bash
 pi remove npm:pi-xai-oauth && pi install .

--- a/compatibility/pi-versions.json
+++ b/compatibility/pi-versions.json
@@ -3,11 +3,11 @@
     "@earendil-works/pi-ai",
     "@earendil-works/pi-coding-agent"
   ],
-  "peerRange": ">=0.80.1 <0.83.0",
+  "peerRange": ">=0.80.1 <0.85.0",
   "minimum": "0.80.1",
-  "latest": "0.82.1",
+  "latest": "0.84.1",
   "unsupported": {
     "older": "0.79.10",
-    "upper": "0.83.0"
+    "upper": "0.85.0"
   }
 }

--- a/extensions/xai/oauth.ts
+++ b/extensions/xai/oauth.ts
@@ -571,12 +571,15 @@ export function createXaiOAuth({
       );
     },
 
-    async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+    async refreshToken(
+      credentials: OAuthCredentials,
+      signal?: AbortSignal,
+    ): Promise<OAuthCredentials> {
       if (!credentials.refresh && credentials.expires && credentials.expires <= Date.now()) {
         throw new Error("xAI OAuth token is expired and cannot be refreshed. Please run /login xai-auth again.");
       }
       if (!credentials.refresh) return credentials;
-      return refreshXaiCredentials(credentials);
+      return refreshXaiCredentials(credentials, signal);
     },
 
     getApiKey(credentials: OAuthCredentials): string {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "pi-xai-oauth": "bin/setup.js"
       },
       "devDependencies": {
-        "@earendil-works/pi-ai": "0.82.1",
-        "@earendil-works/pi-coding-agent": "0.82.1",
+        "@earendil-works/pi-ai": "0.84.1",
+        "@earendil-works/pi-coding-agent": "0.84.1",
         "@types/node": "^26.0.0",
         "@vitest/coverage-v8": "4.1.10",
         "jiti": "^2.7.0",
@@ -21,8 +21,8 @@
         "vitest": "4.1.10"
       },
       "peerDependencies": {
-        "@earendil-works/pi-ai": ">=0.80.1 <0.83.0",
-        "@earendil-works/pi-coding-agent": ">=0.80.1 <0.83.0"
+        "@earendil-works/pi-ai": ">=0.80.1 <0.85.0",
+        "@earendil-works/pi-coding-agent": ">=0.80.1 <0.85.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -548,16 +548,17 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.82.1.tgz",
-      "integrity": "sha512-Z3kloziJIE2dmrisRckZX8zDca/gIv9/YdFAzeoqpHiLV2wsni6bL4hInNSjVKLbqT+4kqLIkph2JQLKvSepjg==",
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.1.tgz",
+      "integrity": "sha512-evyzXYWCLQGmcaBYHlmSku02r8qoN4SGI60GZABo6iV+H+nqX+P9ud8fEZ4GmRq9mUSREvvfX+w9dA9ThF9C6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.82.1",
+        "@earendil-works/pi-ai": "^0.84.1",
+        "@earendil-works/pi-telemetry": "^0.84.1",
         "diff": "8.0.4",
         "ignore": "7.0.5",
-        "typebox": "1.1.38",
+        "typebox": "1.3.7",
         "yaml": "2.9.0"
       },
       "engines": {
@@ -565,14 +566,15 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.1.tgz",
-      "integrity": "sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A==",
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.1.tgz",
+      "integrity": "sha512-wMsAdJMxuNri08vLqTyYVI201DQQezGhPSTkzYsHdw5dYX3rCNwEmSvpaAwhi7ELKI/2tE/CEgSWg/6iRxSgdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.1",
         "@google/genai": "1.52.0",
         "@mistralai/mistralai": "2.2.6",
         "@opentelemetry/api": "1.9.0",
@@ -581,7 +583,7 @@
         "https-proxy-agent": "7.0.6",
         "openai": "6.26.0",
         "partial-json": "0.1.7",
-        "typebox": "1.1.38"
+        "typebox": "1.3.7"
       },
       "bin": {
         "pi-ai": "dist/cli.js"
@@ -590,21 +592,37 @@
         "node": ">=22.19.0"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.82.1.tgz",
-      "integrity": "sha512-zbkAhoIuDPMF3pKuja0ajZabrMWU29FUMV9A/XMXT/XC1yXs5xt6t6t13GogQFsDrDqbFP4DkZQO1w8rWRAzYA==",
+    "node_modules/@earendil-works/pi-client": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.1.tgz",
+      "integrity": "sha512-/V5hGHE4Zq+jG0GtwIB9PyBUOGd6gBLZ7lkQYFKchKnxYHeH3rmWC5xw4kpnZKKBuBuFTdLVbU9vEjlAGMMb2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.82.1",
-        "@earendil-works/pi-ai": "^0.82.1",
-        "@earendil-works/pi-tui": "^0.82.1",
+        "@earendil-works/pi-protocol": "^0.84.1"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.1.tgz",
+      "integrity": "sha512-ncAqFrG+iybuPGOhMiZoEHkEzTpJgz3guYD32pD+M7ucc0WeHmauP6wa7qwP8V/KWvsZDVNa5XGsdZ7fkC7w7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.84.1",
+        "@earendil-works/pi-ai": "^0.84.1",
+        "@earendil-works/pi-client": "^0.84.1",
+        "@earendil-works/pi-protocol": "^0.84.1",
+        "@earendil-works/pi-tui": "^0.84.1",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
         "diff": "8.0.4",
         "glob": "13.0.6",
+        "grok-mermaid": "0.2.2",
         "highlight.js": "10.7.3",
         "hosted-git-info": "9.0.3",
         "ignore": "7.0.5",
@@ -612,8 +630,8 @@
         "minimatch": "10.2.5",
         "proper-lockfile": "4.1.2",
         "semver": "7.8.0",
-        "typebox": "1.1.38",
-        "undici": "8.5.0",
+        "typebox": "1.3.7",
+        "undici": "8.9.0",
         "yaml": "2.9.0"
       },
       "bin": {
@@ -1034,16 +1052,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
-      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -1060,10 +1068,33 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@earendil-works/pi-protocol": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.1.tgz",
+      "integrity": "sha512-Ox1pciyeSPGEEUcxvR0/dJcrY7C6hrEGA8y71rOsvSIUlXN1Cbp/be/eoL71OGDBk5O97TeQPfWN6Ju/2Ehjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "typebox": "1.3.7"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.1.tgz",
+      "integrity": "sha512-180/xGJtsq7IoR3p9EKWjRd0e9M4DkxInhlo9xyD7prDC7Qrhqq+nhvwrW0lFjPfXcEI2FSHmGCSyvSJE9GsaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.1.tgz",
-      "integrity": "sha512-9yN8hALfKaxZq7n54EMxqhFCWnMi6LHkraMJ/1YjHiATq75XrI6XDMVppn9EDtiK7Fks8hUe1SDXUTrIvwRWfQ==",
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.1.tgz",
+      "integrity": "sha512-udeXFbgEhJ6JiB0uguwNVNkDy2FENfmtQwPcY+/iJ8GWeq18wkal1tKqa5YyeH0IqtX1vG0cGh8zfSYzyzVuLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2663,6 +2694,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/grok-mermaid": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.2.tgz",
+      "integrity": "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3529,9 +3570,9 @@
       "license": "0BSD"
     },
     "node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3568,6 +3609,16 @@
         "@typescript/typescript-sunos-x64": "7.0.2",
         "@typescript/typescript-win32-arm64": "7.0.2",
         "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -46,12 +46,12 @@
     "protobufjs": "^7.6.5"
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": ">=0.80.1 <0.83.0",
-    "@earendil-works/pi-coding-agent": ">=0.80.1 <0.83.0"
+    "@earendil-works/pi-ai": ">=0.80.1 <0.85.0",
+    "@earendil-works/pi-coding-agent": ">=0.80.1 <0.85.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "0.82.1",
-    "@earendil-works/pi-coding-agent": "0.82.1",
+    "@earendil-works/pi-ai": "0.84.1",
+    "@earendil-works/pi-coding-agent": "0.84.1",
     "@types/node": "^26.0.0",
     "@vitest/coverage-v8": "4.1.10",
     "jiti": "^2.7.0",

--- a/tests/oauth/auth-storage.integration.test.ts
+++ b/tests/oauth/auth-storage.integration.test.ts
@@ -1,4 +1,6 @@
 import type { OAuthLoginCallbacks } from "@earendil-works/pi-ai";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { XAI_OAUTH_DEVICE_URL } from "../../extensions/xai/constants";
 import {
@@ -11,6 +13,7 @@ import {
   makeClock,
   tokenPayload,
 } from "../fixtures/device";
+import { createTempDir } from "../fixtures/temp";
 
 function oauthWithClock() {
   const clock = makeClock();
@@ -133,15 +136,23 @@ describe("Pi credential-runtime device integration", () => {
       expires: Date.now() + 60_000,
     });
     const controller = new AbortController();
-    await expect(
-      harness.login({
-        onPrompt: async () => "n",
-        onAuth: () => {},
-        onSelect: async () => XAI_DEVICE_LOGIN_METHOD,
-        onDeviceCode: () => controller.abort(),
-        signal: controller.signal,
-      } as any),
-    ).rejects.toThrow("Login cancelled");
+    let resolved = false;
+    const cancellation = await harness.login({
+      onPrompt: async () => "n",
+      onAuth: () => {},
+      onSelect: async () => XAI_DEVICE_LOGIN_METHOD,
+      onDeviceCode: () => controller.abort(),
+      signal: controller.signal,
+    } as any).then(
+      () => {
+        resolved = true;
+        return undefined;
+      },
+      (error: unknown) => error,
+    );
+    expect(resolved).toBe(false);
+    expect(cancellation).toBeInstanceOf(Error);
+    expect((cancellation as Error).message).toMatch(/Login cancelled|operation was aborted/i);
     await expect(harness.read()).resolves.toMatchObject({
       access: "existing-access",
       refresh: "existing-refresh",
@@ -161,5 +172,62 @@ describe("Pi credential-runtime device integration", () => {
       access: "device-access-token",
       refresh: "device-refresh-token",
     });
+  });
+
+  it("persists rotated credentials before preparing an authenticated request", async () => {
+    const codingAgent = (await import("@earendil-works/pi-coding-agent")) as any;
+    const temp = await createTempDir("pi-xai-refresh-store-");
+    const id = `xai-refresh-${crypto.randomUUID()}`;
+    const authPath = join(temp.path, "agent", "auth.json");
+    try {
+      await mkdir(join(authPath, ".."), { recursive: true });
+      await writeFile(authPath, JSON.stringify({
+        [id]: {
+          type: "oauth",
+          access: "expired-access",
+          refresh: "original-refresh",
+          expires: 1,
+          tokenEndpoint: "https://auth.x.ai/oauth2/token",
+        },
+      }));
+      vi.stubGlobal("fetch", vi.fn(async () => jsonResponse(tokenPayload({
+        access_token: "refreshed-access",
+        refresh_token: "rotated-refresh",
+      }))));
+
+      let requestAccess: string | undefined;
+      if (typeof codingAgent.ModelRuntime === "function") {
+        const runtime = await codingAgent.ModelRuntime.create({
+          authPath,
+          modelsPath: null,
+          allowModelNetwork: false,
+        });
+        runtime.registerProvider(id, providerConfig());
+        await runtime.refresh({ allowNetwork: false, providers: [id] });
+        const model = runtime.getModel(id, "grok-integration-test");
+        expect(model).toBeDefined();
+        requestAccess = (await runtime.prepareRequest(model, {})).options.apiKey;
+      } else {
+        const storage = codingAgent.AuthStorage.create(authPath);
+        const registry = codingAgent.ModelRegistry.create(storage);
+        registry.registerProvider(id, providerConfig());
+        const model = registry.find(id, "grok-integration-test");
+        expect(model).toBeDefined();
+        const auth = await registry.getApiKeyAndHeaders(model);
+        expect(auth).toMatchObject({ ok: true });
+        requestAccess = auth.apiKey;
+      }
+
+      const stored = JSON.parse(await readFile(authPath, "utf8"))[id];
+      expect(requestAccess).toBe("refreshed-access");
+      expect(stored).toMatchObject({
+        type: "oauth",
+        access: "refreshed-access",
+        refresh: "rotated-refresh",
+      });
+      expect(stored.expires).toBeGreaterThan(Date.now());
+    } finally {
+      await temp.cleanup();
+    }
   });
 });

--- a/tests/oauth/refresh.test.ts
+++ b/tests/oauth/refresh.test.ts
@@ -69,6 +69,32 @@ describe("OAuth refresh", () => {
     expect(headers[0].get("X-XAI-Token-Auth")).toBeNull();
   });
 
+  it("forwards Pi's concrete refresh abort signal to the token exchange", async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.fn(async (_url: any, init: RequestInit) => {
+      expect(init.signal).toBe(controller.signal);
+      return jsonResponse({
+        access_token: "signal-bound-access",
+        refresh_token: "signal-bound-refresh",
+        expires_in: 3600,
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const oauth = createXaiOAuth({ getExistingCredentials: () => null });
+    await oauth.refreshToken(
+      {
+        access: "old",
+        refresh: "old-refresh",
+        expires: 1,
+        tokenEndpoint: XAI_OAUTH_TOKEN_URL,
+      },
+      controller.signal,
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
   it("rejects missing refresh and untrusted token endpoints", async () => {
     await expect(
       refreshXaiCredentials({ access: "expired", refresh: "", expires: 1 }),

--- a/tests/provider/registry-reregistration.test.ts
+++ b/tests/provider/registry-reregistration.test.ts
@@ -243,13 +243,14 @@ describe("ModelRegistry re-registration precedence", () => {
           return credentials.access;
         },
       },
-      models: [baselineModelConfig],
+      models: [{ ...baselineModelConfig, id: "placeholder-model" }],
       async refreshModels(context: {
-        store: { read: () => Promise<any> };
+        store?: { read: () => Promise<any> };
+        stored?: any;
         allowNetwork?: boolean;
       }) {
         refreshCalls += 1;
-        const stored = await context.store.read();
+        const stored = context.stored ?? await context.store?.read();
         if (stored?.models?.some((model: { id: string }) => model.id === "stale-from-store")) {
           sawStaleStore = true;
         }
@@ -269,13 +270,14 @@ describe("ModelRegistry re-registration precedence", () => {
       },
     });
 
-    await runtime.refresh({ allowNetwork: true, force: true });
-
-    expect(refreshCalls).toBeGreaterThan(0);
-    expect(sawStaleStore).toBe(true);
-    expect(registry.find("xai-auth", "stale-from-store")).toBeUndefined();
-    expect(registry.find("xai-auth", "baseline-model")).toMatchObject({
-      id: "baseline-model",
+    await vi.waitFor(() => {
+      expect(refreshCalls).toBeGreaterThan(0);
+      expect(sawStaleStore).toBe(true);
+      expect(registry.find("xai-auth", "stale-from-store")).toBeUndefined();
+      expect(registry.find("xai-auth", "placeholder-model")).toBeUndefined();
+      expect(registry.find("xai-auth", "baseline-model")).toMatchObject({
+        id: "baseline-model",
+      });
     });
     expect(
       runtime


### PR DESCRIPTION
## Summary

This PR adds explicit support for Pi 0.84.1 while preserving the exact Pi 0.80.1 compatibility boundary.

It updates the extension across the three runtime seams affected by recent Pi releases:

- forwards Pi's concrete OAuth refresh cancellation signal through the xAI token exchange;
- verifies file-backed persistence of refreshed access tokens and rotated refresh tokens before authenticated request use;
- supports both the legacy mutable model-catalog store contract and Pi 0.84's read-only stored snapshot/generation publication contract.

The aligned Pi peer range is widened from `>=0.80.1 <0.83.0` to `>=0.80.1 <0.85.0`, with exact packed-package validation at 0.80.1 and 0.84.1.

## Motivation

A reported long-running-session failure appeared around the xAI access-token lifetime: requests began failing after roughly six hours, `~/.pi/agent/auth.json` did not show a refreshed credential, and only a manual `/login xai-auth` restored the session.

Pi owns persistence of credentials returned by provider `refreshToken`; the extension intentionally has no credential-writing path. Pi 0.84 passes a concrete abort signal into the provider refresh callback so timed-out or cancelled refresh operations can stop before a late token exchange commits while Pi's credential-store lock is held.

The extension previously exposed `refreshToken(credentials)` and therefore did not forward this newer signal contract. This PR makes that contract explicit and adds deterministic runtime coverage around the entire refresh/persist/request seam.

## Changes

### OAuth refresh lifecycle

- Changes `createXaiOAuth().refreshToken` to accept Pi's optional `AbortSignal`.
- Forwards that exact signal through `refreshXaiCredentials` to pinned discovery/token requests.
- Preserves existing behavior for runtimes that call the legacy one-argument callback.
- Adds a regression proving the concrete signal reaches the token exchange.
- Keeps cancelled login tests rejection-sensitive so a resolved `Error` cannot produce a false positive.

### Credential persistence

Adds a real file-backed integration test that starts from an expired credential and verifies:

1. Pi invokes the xAI refresh callback;
2. xAI's refreshed access token and rotated refresh token are written to `auth.json`;
3. persistence occurs before the refreshed access token is used to prepare the request;
4. the test passes through both Pi runtime generations:
   - Pi 0.80.1 `AuthStorage`/`ModelRegistry`;
   - Pi 0.84.1 `ModelRuntime`.

This confirms that successful refreshes are not intended to remain request-local or in memory only.

### Catalog publication compatibility

- Supports legacy `context.store.read()` and Pi 0.84's read-only `context.stored` refresh context in the runtime integration fixture.
- Accounts for Pi 0.84's generation-checked asynchronous catalog publication before asserting re-registration precedence.
- Verifies stale stored overlays are discarded and the fresh runtime catalog wins.

### Compatibility policy and packaging

- Widens both aligned Pi peers to `>=0.80.1 <0.85.0`.
- Pins development and policy metadata to exact Pi 0.84.1.
- Moves the unsupported upper sentinel to 0.85.0.
- Updates the lockfile, README compatibility explanation, changelog, and scaffold handoff state.
- Excludes caller-owned local `probe-*`, `prototype/`, and `docs/research/` artifacts from npm tarballs without deleting or tracking them.

## Validation

All validation was run from a clean packed package where applicable.

- `npm test`
  - 50 test files passed
  - 613 tests passed
  - real Pi extension-loader smoke passed
- `npm run typecheck`
  - passed
- `npm run compatibility:check`
  - policy and registry checks passed
  - packed manifest passed
  - unsupported 0.79.10 and 0.85.0 peer checks behaved as expected
- `node scripts/run-compatibility-matrix.js 0.80.1`
  - exact aligned Pi 0.80.1 peers resolved
  - 613 tests, loader smoke, and typecheck passed
- `node scripts/run-compatibility-matrix.js 0.84.1`
  - exact aligned Pi 0.84.1 peers resolved
  - 613 tests, loader smoke, and typecheck passed
- Edited-file LSP diagnostics and pi-lens diagnostics: clean
- `git diff --check`: clean

## Risk and follow-up

The deterministic integration tests exercise an expired credential through refresh, disk persistence, and request preparation, including refresh-token rotation. They do not wait through a real six-hour xAI session or exercise a live xAI account, so the original report should still be retested after release.

If the symptom remains, capture a sanitized `pi auth check --provider xai-auth --json` result before manually logging in again. That will help distinguish an untriggered refresh from an xAI refresh rejection or an early API-side 401.
