### PR TITLE
Prepare 1.4.1 release and trusted npm publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,72 @@
-name: Publish
+name: Publish npm package
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types:
+      - published
 
 permissions:
   contents: read
+  id-token: write
+
+concurrency:
+  group: npm-publish-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: "24"
+  NPM_VERSION: "11.6.2"
 
 jobs:
   publish:
+    if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Publish
-        run: echo "Publishing..."
+      - name: Check out the released tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Require a release commit from main
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor HEAD origin/main
+
+      - name: Set up Node and the npm registry
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - name: Pin npm with trusted-publishing support
+        run: npm install --global npm@${NPM_VERSION}
+
+      - name: Require the release tag to match package.json
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          PACKAGE_VERSION="$(node --print 'require("./package.json").version')"
+          if [ "$RELEASE_TAG" != "v$PACKAGE_VERSION" ]; then
+            echo "Release tag $RELEASE_TAG does not match package version v$PACKAGE_VERSION" >&2
+            exit 1
+          fi
+
+      - name: Install locked development dependencies
+        run: npm ci --strict-peer-deps
+
+      - name: Run policy, unit, and loader gates
+        run: NODE_OPTIONS=--unhandled-rejections=strict npm test
+
+      - name: Type-check production and tests
+        run: npm run typecheck
+
+      - name: Verify registry policy and package contents
+        run: npm run compatibility:check
+
+      - name: Verify exact packed Pi boundaries
+        run: npm run compatibility:boundaries
+
+      - name: Publish to npm with trusted publishing
+        run: npm publish --access public

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,20 +1,20 @@
-# Execution Progress — Pi 0.84.1 compatibility
+# Release Progress — 1.4.1
 
-**Branch:** `feature/pi-0.84.1-compat`
+**Branch:** `release/1.4.1`
 
 ## Completed
 
-- [x] Confirmed all three public acceptance seams with the user: OAuth persistence/cancellation, catalog publication, and exact packed matrices.
-- [x] Reproduced the pre-fix Pi 0.84.1 candidate result and isolated its cancellation/catalog compatibility failures.
-- [x] Added a red-green regression proving Pi's concrete refresh signal reaches the xAI token exchange, then forwarded it through `createXaiOAuth().refreshToken`.
-- [x] Added a real file-backed rollover regression proving request preparation persists refreshed access and rotated refresh credentials before use on both the legacy 0.80.1 registry and current 0.84.1 ModelRuntime.
-- [x] Adapted cancellation and stored-catalog publication tests across the 0.80.1 and 0.84.1 contracts.
-- [x] Widened aligned peers to `>=0.80.1 <0.85.0`, pinned exact development dependencies/policy to 0.84.1, and updated the lockfile, README, changelog, and package exclusions.
-- [x] Excluded caller-owned local research, prototype, and probe artifacts from npm tarballs without deleting or tracking them.
-- [x] Independent review found no blocker. Addressed all three notes: rejection-sensitive cancellation assertion, minimum-boundary file persistence coverage, and local artifact packaging exclusions.
-- [x] Final local `npm test` passes: 50 files / 613 tests plus loader smoke.
-- [x] `npm run typecheck`, `npm run compatibility:check`, `git diff --check`, and edited-file LSP diagnostics pass.
-- [x] Clean packed exact Pi 0.80.1 and 0.84.1 boundaries each pass all 613 tests, loader smoke, and TypeScript.
+- [x] Merged Pi 0.84.1 OAuth refresh and catalog lifecycle compatibility in PR #171.
+- [x] Bumped `package.json` and `package-lock.json` from 1.4.0 to 1.4.1.
+- [x] Finalized the 1.4.1 changelog and README release text.
+- [x] Replaced the placeholder publish workflow with a GitHub Release-triggered npm trusted-publishing workflow using OIDC, least-privilege permissions, release-tag/version validation, main-ancestry validation, and the full release gates.
+- [x] Documented npmjs.com trusted-publisher setup and the GitHub Release procedure.
+- [x] Removed live built-in catalog I/O from the Pi 0.84 store-publication test, kept credential refresh outside the test's scope, and awaited the exact registration-triggered publication promise.
+- [x] Stress-ran the focused registry suite 15 times after isolation; all runs passed.
+- [x] Independent follow-up review confirmed the publication test and trusted-publishing workflow are correct with no blocker.
+- [x] Local `npm test` passes: 50 files / 613 tests plus loader smoke.
+- [x] `npm run typecheck`, `npm run compatibility:check`, `npm pack --dry-run --json`, `git diff --check`, LSP, and pi-lens diagnostics pass.
+- [x] Clean packed exact Pi 0.80.1 and 0.84.1 boundaries each pass all 613 tests, loader smoke, and TypeScript at package version 1.4.1.
 
 ## In Progress
 
@@ -22,4 +22,4 @@
 
 ## Next
 
-Commit the reviewed diff, push the feature branch, and open a pull request. Do not include caller-owned untracked probe/research/prototype files.
+Commit and merge the 1.4.1 release PR. On npmjs.com, configure the `pi-xai-oauth` trusted publisher for `BlockedPath/pi-xai-oauth`, workflow `publish.yml`, with `npm publish` allowed. Then publish a non-prerelease GitHub Release tagged `v1.4.1`; GitHub Actions will revalidate and publish to npm.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 
 ## Unreleased
 
+## 1.4.1 - 2026-08-09
+
 ### Changed
 
 - Setup no longer forces `defaultProvider: xai-auth`. When no provider is configured it seeds Pi's built-in `xai` chat provider, preserves any existing provider choice (including package-owned `xai-auth`), and still installs opt-in tools plus `/xai-usage` for both providers.

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ pi --model grok-4.5:low "Quick status check"   # fast mode
 
 This package adds xAI's **account-specific OAuth model catalog** to pi, with **Grok 4.5** as the offline fallback/default, proper OAuth login, automatic token refresh, and a suite of custom xAI tools (`xai_generate_text`, `web_search`, `xai_x_search`, etc.). The normalized cache remains exact; registration may additionally expose narrowly verified compatibility routes such as Grok 4.3 and Composer only while their required authenticated entitlement source is present.
 
-> **Latest release:** `pi-xai-oauth` **1.4.0** adds opt-in vision routing, image-to-video generation, the `pi-clickable-menu:xai-tools` bridge, built-in SuperGrok network-tool/usage support, and Pi 0.81.1 compatibility, while hardening credential isolation, local media bounds, and Grok-native path containment. Existing npm installs should run `pi update npm:pi-xai-oauth`; local checkout installs should keep only one copy with `pi remove npm:pi-xai-oauth && pi install .`.
+> **Latest release:** `pi-xai-oauth` **1.4.1** adds exact Pi 0.84.1 compatibility, forwards Pi's refresh cancellation signal through xAI token exchange, and verifies rotated OAuth credentials are persisted before request use. Setup now defaults an unset provider to Pi's built-in `xai` provider without overwriting an existing choice, while package-owned Grok terminal adapters suppress Pi session metadata. Existing npm installs should run `pi update npm:pi-xai-oauth`; local checkout installs should keep only one copy with `pi remove npm:pi-xai-oauth && pi install .`.
 >
-> **Compatibility:** aligned `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` versions `>=0.80.1 <0.85.0`. The exact tested boundaries are 0.80.1 and 0.84.1.
+> **Compatibility:** 1.4.1 supports aligned `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` versions `>=0.80.1 <0.85.0`. The exact tested boundaries are 0.80.1 and 0.84.1.
 
 See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and fix history.
 
@@ -774,7 +774,7 @@ pi update npm:pi-xai-oauth
 
 This pulls the latest version from npm and updates your installed extension.
 
-The current build requires aligned Pi runtime packages in `>=0.80.1 <0.85.0`, with exact packed-package validation at 0.80.1 and 0.84.1. Version 1.4.0 added opt-in vision routing, image-to-video generation, the menu bridge, built-in SuperGrok tool/usage support, and further transport and entitlement hardening on top of authenticated model discovery, device OAuth, encrypted reasoning replay, Grok-native tools, bounded image editing, and explicit subscription usage. See [CHANGELOG.md](CHANGELOG.md) for the complete release notes. If you installed the published npm package, update with the command above. If you are testing a local checkout instead, reinstall the checkout:
+Version 1.4.1 requires aligned Pi runtime packages in `>=0.80.1 <0.85.0`, with exact packed-package validation at 0.80.1 and 0.84.1. It adds Pi 0.84.1 OAuth refresh and model-catalog lifecycle compatibility, verifies file-backed rotated-token persistence across both tested boundaries, defaults previously unset setup configuration to Pi's built-in `xai` provider, and preserves the tools, media, transport, and entitlement hardening introduced in 1.4.0. See [CHANGELOG.md](CHANGELOG.md) for the complete release notes. If you installed the published npm package, update with the command above. If you are testing a local checkout instead, reinstall the checkout:
 
 ```bash
 pi remove npm:pi-xai-oauth && pi install .
@@ -972,7 +972,18 @@ npm run compatibility:check
 npm run compatibility:boundaries
 npm pack --dry-run --json
 git diff --check
-npm publish
+```
+
+Normal releases publish through [`.github/workflows/publish.yml`](.github/workflows/publish.yml) with npm trusted publishing—no long-lived npm token is stored in GitHub. Configure the `pi-xai-oauth` package's trusted publisher on npmjs.com with GitHub owner `BlockedPath`, repository `pi-xai-oauth`, workflow filename `publish.yml`, no environment, and the `npm publish` action enabled. The workflow uses a GitHub-hosted runner, npm 11.6.2, and the required `id-token: write` permission.
+
+After the release PR is merged, create and publish a non-prerelease GitHub Release whose tag exactly matches `v` plus the version in `package.json` (for example, `v1.4.1`). The workflow refuses tags not contained in `main`, reruns the full release gates and exact packed boundaries, and then publishes the public package with OIDC-generated provenance.
+
+```bash
+git switch main
+git pull --ff-only origin main
+git tag v1.4.1
+git push origin v1.4.1
+gh release create v1.4.1 --verify-tag --generate-notes
 
 # Users update with:
 # pi update npm:pi-xai-oauth

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-xai-oauth",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-xai-oauth",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "bin": {
         "pi-xai-oauth": "bin/setup.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-xai-oauth",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "xAI OAuth provider with an authenticated account-specific Grok model catalog for pi",
   "keywords": [
     "pi-package",

--- a/tests/provider/registry-reregistration.test.ts
+++ b/tests/provider/registry-reregistration.test.ts
@@ -191,7 +191,10 @@ describe("ModelRegistry re-registration precedence", () => {
       type: "oauth",
       access: "store-oauth-access",
       refresh: "refresh",
-      expires: Date.now() + 60_000,
+      // Keep credential refresh outside this catalog-publication test. Pi 0.83+
+      // refreshes OAuth credentials five minutes early, so a one-minute lifetime
+      // races the concurrent availability checks and obscures the store assertion.
+      expires: Date.now() + 60 * 60_000,
     };
     const credentialStore = {
       async read(providerId: string) {
@@ -216,7 +219,7 @@ describe("ModelRegistry re-registration precedence", () => {
       credentials: credentialStore,
       modelsPath,
       modelsStorePath,
-      allowModelNetwork: true,
+      allowModelNetwork: false,
     });
     const registry = new codingAgent.ModelRegistry(runtime);
 
@@ -225,6 +228,16 @@ describe("ModelRegistry re-registration precedence", () => {
     const localCatalogModifiedAt = Date.now();
     let refreshCalls = 0;
     let sawStaleStore = false;
+
+    // Pi 0.84 starts registration refresh asynchronously. Capture that exact
+    // promise so the test waits for its generation-checked publication instead
+    // of racing it with a second refresh or polling an unobserved background job.
+    const runRefresh = runtime.refresh.bind(runtime);
+    let registrationRefresh: Promise<any> | undefined;
+    runtime.refresh = (options: any = {}) => {
+      registrationRefresh = runRefresh(options);
+      return registrationRefresh;
+    };
 
     registry.registerProvider("xai-auth", {
       name: "xAI store precedence",
@@ -270,14 +283,15 @@ describe("ModelRegistry re-registration precedence", () => {
       },
     });
 
-    await vi.waitFor(() => {
-      expect(refreshCalls).toBeGreaterThan(0);
-      expect(sawStaleStore).toBe(true);
-      expect(registry.find("xai-auth", "stale-from-store")).toBeUndefined();
-      expect(registry.find("xai-auth", "placeholder-model")).toBeUndefined();
-      expect(registry.find("xai-auth", "baseline-model")).toMatchObject({
-        id: "baseline-model",
-      });
+    expect(registrationRefresh).toBeDefined();
+    const refresh = await registrationRefresh!;
+    expect(refresh.errors.get("xai-auth")).toBeUndefined();
+    expect(refreshCalls).toBeGreaterThan(0);
+    expect(sawStaleStore).toBe(true);
+    expect(registry.find("xai-auth", "stale-from-store")).toBeUndefined();
+    expect(registry.find("xai-auth", "placeholder-model")).toBeUndefined();
+    expect(registry.find("xai-auth", "baseline-model")).toMatchObject({
+      id: "baseline-model",
     });
     expect(
       runtime


### PR DESCRIPTION
## Summary

Prepare `pi-xai-oauth` 1.4.1 for publication and replace the placeholder publishing workflow with a production npm trusted-publishing pipeline.

This release packages the merged Pi 0.84.1 compatibility work from #171, including OAuth refresh cancellation forwarding, file-backed rotated-token persistence coverage, and the Pi 0.84 catalog publication contract.

## Release metadata

- Bumps `package.json` to `1.4.1`.
- Keeps both root version fields in `package-lock.json` aligned at `1.4.1`.
- Finalizes `CHANGELOG.md` as `1.4.1 - 2026-08-09`.
- Updates README release and compatibility text for exact Pi 0.80.1 and 0.84.1 boundaries.
- Confirms `pi-xai-oauth@1.4.1` is not already present on npm.

## GitHub npm publishing

Replaces the existing placeholder `.github/workflows/publish.yml` with a GitHub Release-triggered npm trusted-publishing workflow.

The workflow:

- runs only for a **published, non-prerelease GitHub Release**;
- uses a GitHub-hosted `ubuntu-latest` runner;
- grants only `contents: read` and `id-token: write`;
- checks out the released tag with complete history;
- requires the tagged commit to be contained in `main`;
- requires the release tag to equal `v${package.json.version}`;
- pins Node 24 and npm 11.6.2, which supports npm trusted publishing;
- installs with `npm ci --strict-peer-deps`;
- reruns tests, typecheck, package/policy verification, and both exact packed Pi boundaries;
- publishes the public package with `npm publish --access public` using OIDC and npm-generated provenance;
- stores no long-lived npm token in GitHub.

README now documents the required npmjs.com trusted-publisher configuration and release procedure.

## Registry test stabilization

Release validation exposed an intermittent 30-second timeout in the Pi 0.84 store-publication regression. The test was enabling live built-in catalog networking even though its assertion is entirely local.

The test now:

- disables model-network access;
- keeps OAuth refresh outside this catalog-only test by using a credential beyond Pi's five-minute early-refresh window;
- captures and awaits the exact asynchronous refresh started by provider registration;
- continues to prove that the stale stored overlay is observed but rejected, the placeholder disappears, and only the fresh baseline model is published.

The focused suite passed 15 consecutive stress runs after isolation. Independent follow-up review confirmed that the prior blocker is resolved and the intended publication assertion remains intact.

## Validation

Validated on the exact 1.4.1 release tree:

- `npm test`
  - 50 test files passed
  - 613 tests passed
  - real Pi loader smoke passed
- `npm run typecheck` — passed
- `npm run compatibility:check` — passed
- `npm pack --dry-run --json`
  - package version is 1.4.1
  - 201 expected package files
  - no local probe, prototype, or research artifacts
- `npm run compatibility:boundaries`
  - exact Pi 0.80.1: 613 tests, loader smoke, and typecheck passed
  - exact Pi 0.84.1: 613 tests, loader smoke, and typecheck passed
- Publish workflow YAML parsing and LSP diagnostics — clean
- Edited-file LSP and pi-lens diagnostics — clean
- `git diff --check` — clean
- Independent release/workflow review — no blocker

## Required npm-side setup before release

After this PR is merged, configure npm trusted publishing for `pi-xai-oauth` on npmjs.com:

- **Provider:** GitHub Actions
- **Owner:** `BlockedPath`
- **Repository:** `pi-xai-oauth`
- **Workflow filename:** `publish.yml`
- **Environment:** leave blank
- **Allowed action:** `npm publish`

The workflow filename must match exactly.

## Publication after merge

Do not run local `npm publish`. Once trusted publishing is configured:

```bash
git switch main
git pull --ff-only origin main
git tag v1.4.1
git push origin v1.4.1
gh release create v1.4.1 --verify-tag --generate-notes
```

Publishing the GitHub Release triggers the workflow. Users can then update with:

```bash
pi update npm:pi-xai-oauth
```
