### PR TITLE
Publish 1.4.2 to npmjs and GitHub Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
         run: npm run typecheck
       - name: Verify packed manifest and contents
         run: node scripts/verify-compatibility.js pack
+      - name: Verify scoped GitHub Packages mirror
+        run: node scripts/verify-github-package.js
       - name: Verify unsupported peer diagnostics
         run: node scripts/verify-compatibility.js unsupported
       - name: Inspect package dry run

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish npm package
+name: Publish npm and GitHub packages
 
 on:
   release:
@@ -8,9 +8,10 @@ on:
 permissions:
   contents: read
   id-token: write
+  packages: write
 
 concurrency:
-  group: npm-publish-${{ github.event.release.tag_name }}
+  group: package-publish-${{ github.event.release.tag_name }}
   cancel-in-progress: false
 
 env:
@@ -40,6 +41,9 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: npm
 
+      - name: Remove deprecated setup-node npm setting
+        run: sed -i '/^always-auth=/d' "$NPM_CONFIG_USERCONFIG"
+
       - name: Pin npm with trusted-publishing support
         run: npm install --global npm@${NPM_VERSION}
 
@@ -68,5 +72,61 @@ jobs:
       - name: Verify exact packed Pi boundaries
         run: npm run compatibility:boundaries
 
+      - name: Pack the canonical release archive once
+        run: |
+          mkdir -p "$RUNNER_TEMP/release"
+          PACK_RESULT="$(npm pack --json --pack-destination "$RUNNER_TEMP/release")"
+          PACK_FILENAME="$(PACK_RESULT="$PACK_RESULT" node --input-type=commonjs --eval '
+            const path = require("path");
+            const parsed = JSON.parse(process.env.PACK_RESULT);
+            const entries = Array.isArray(parsed) ? parsed : Object.values(parsed);
+            if (entries.length !== 1 || path.basename(entries[0].filename) !== entries[0].filename) process.exit(1);
+            process.stdout.write(entries[0].filename);
+          ')"
+          echo "CANONICAL_TARBALL=$RUNNER_TEMP/release/$PACK_FILENAME" >> "$GITHUB_ENV"
+
       - name: Publish to npm with trusted publishing
-        run: npm publish --access public
+        run: |
+          PACKAGE_VERSION="$(node --print 'require("./package.json").version')"
+          if npm view "pi-xai-oauth@$PACKAGE_VERSION" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
+            echo "pi-xai-oauth@$PACKAGE_VERSION is already published; skipping npmjs publish"
+          else
+            npm publish "$CANONICAL_TARBALL" --access public --registry https://registry.npmjs.org
+          fi
+
+      - name: Prepare scoped GitHub Packages mirror from the canonical archive
+        run: node scripts/prepare-github-package.js "$CANONICAL_TARBALL" "$RUNNER_TEMP/github-package"
+
+      - name: Pack the scoped mirror archive
+        run: |
+          MIRROR_RESULT="$(npm pack "$RUNNER_TEMP/github-package/package" --json --pack-destination "$RUNNER_TEMP/release")"
+          MIRROR_FILENAME="$(MIRROR_RESULT="$MIRROR_RESULT" node --input-type=commonjs --eval '
+            const path = require("path");
+            const parsed = JSON.parse(process.env.MIRROR_RESULT);
+            const entries = Array.isArray(parsed) ? parsed : Object.values(parsed);
+            if (entries.length !== 1 || path.basename(entries[0].filename) !== entries[0].filename) process.exit(1);
+            process.stdout.write(entries[0].filename);
+          ')"
+          echo "GITHUB_TARBALL=$RUNNER_TEMP/release/$MIRROR_FILENAME" >> "$GITHUB_ENV"
+
+      - name: Set up the GitHub Packages registry
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://npm.pkg.github.com
+          scope: "@blockedpath"
+
+      - name: Remove deprecated GitHub registry setting
+        run: sed -i '/^always-auth=/d' "$NPM_CONFIG_USERCONFIG"
+
+      - name: Publish scoped mirror to GitHub Packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PACKAGE_VERSION="$(node --print 'require("./package.json").version')"
+          PACKAGE_NAME="@blockedpath/pi-xai-oauth"
+          if npm view "$PACKAGE_NAME@$PACKAGE_VERSION" version --registry https://npm.pkg.github.com >/dev/null 2>&1; then
+            echo "$PACKAGE_NAME@$PACKAGE_VERSION is already published; skipping GitHub Packages publish"
+          else
+            npm publish "$GITHUB_TARBALL" --registry https://npm.pkg.github.com
+          fi

--- a/.npmignore
+++ b/.npmignore
@@ -21,7 +21,10 @@ pi-session-*.html
 cat.svg
 .agent-task.md
 
-# Local research and live-probe artifacts are never part of the extension package.
+# Local agent configuration and generated research artifacts are never published.
+.agents/
+skills-lock.json
+docs/diagrams/
 docs/research/
 prototype/
 probe-*

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -22,7 +22,7 @@ Publish each validated release to both npmjs as `pi-xai-oauth` and GitHub Packag
 4. [x] Extend CI and GitHub Release publishing to validate and publish both registries idempotently.
 5. [x] Bump and document release 1.4.2, including authenticated GitHub Packages installation.
 6. [x] Run full local gates, exact packed boundaries, and independent review.
-7. [ ] Commit, push, and open the 1.4.2 dual-publishing pull request.
+7. [x] Commit, push, and open the 1.4.2 dual-publishing pull request.
 
 ## Non-goals
 

--- a/.scaffold/plan.md
+++ b/.scaffold/plan.md
@@ -1,28 +1,32 @@
-# Implementation Plan — Pi 0.84.1 compatibility
+# Implementation Plan — GitHub Packages mirror
 
-**Branch:** `feature/pi-0.84.1-compat`
+**Branch:** `feature/github-packages-mirror`
 
 ## Goal
 
-Support aligned `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` releases through exact Pi 0.84.1 while preserving the exact Pi 0.80.1 minimum boundary.
+Publish each validated release to both npmjs as `pi-xai-oauth` and GitHub Packages as `@blockedpath/pi-xai-oauth`, without changing extension behavior or allowing duplicate registry aliases to register conflicting tools.
 
 ## Confirmed public seams
 
-1. OAuth refresh accepts Pi's concrete abort signal, uses it for token exchange, and lets Pi atomically persist rotated credentials.
-2. Provider catalog re-registration/publication remains exact across the minimum and newest ModelRuntime contracts.
-3. A clean packed package passes full tests, loader smoke, and TypeScript at exact 0.80.1 and 0.84.1.
+1. npmjs remains the canonical, unauthenticated public installation path.
+2. GitHub Packages receives a lowercase scoped mirror built from the exact canonical tarball and authenticated with the repository `GITHUB_TOKEN`.
+3. Setup derives its active distribution name from the installed manifest and treats npmjs, GitHub Packages, and local copies as aliases of one extension.
+4. Release retries are safe when one registry succeeded and the other failed.
+5. Version 1.4.2 is the first dual-published release; immutable 1.4.1 artifacts are not rewritten.
 
 ## Vertical slices
 
-1. [x] Add a failing refresh-signal regression; propagate the signal through `refreshToken`.
-2. [x] Adapt real-runtime cancellation/catalog tests to the public Pi 0.80.1 and 0.84.1 contracts without weakening credential/catalog assertions.
-3. [x] Widen aligned peers to `<0.85.0`, pin exact development dependencies/latest policy to 0.84.1, and update the lockfile.
-4. [x] Update README, changelog, compatibility guidance, and persistent progress.
-5. [x] Run focused diagnostics/tests, full gates, and both exact packed boundaries.
-6. [x] Run independent correctness and standards/spec review; address confirmed findings and rerun affected gates.
+1. [x] Confirm GitHub Packages scope, authentication, token, and workflow permission requirements from official documentation.
+2. [x] Make setup distribution-aware and add duplicate-alias regressions.
+3. [x] Add deterministic canonical-tarball-to-scoped-mirror preparation and parity verification.
+4. [x] Extend CI and GitHub Release publishing to validate and publish both registries idempotently.
+5. [x] Bump and document release 1.4.2, including authenticated GitHub Packages installation.
+6. [x] Run full local gates, exact packed boundaries, and independent review.
+7. [ ] Commit, push, and open the 1.4.2 dual-publishing pull request.
 
 ## Non-goals
 
-- No changes to xAI endpoints, scopes, catalog entitlement policy, or Responses routing.
-- No core Pi modifications.
-- No claim beyond Pi 0.84.x until a later line passes the same candidate process.
+- No replacement or renaming of the canonical npmjs package.
+- No duplicate installation of both distributions in one Pi configuration.
+- No PAT stored in GitHub Actions; local GitHub Packages consumers manage their own classic PAT with `read:packages`.
+- No changes to OAuth, catalog entitlement, Responses routing, or xAI transport behavior.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,25 +1,29 @@
-# Release Progress — 1.4.1
+# Execution Progress — GitHub Packages mirror
 
-**Branch:** `release/1.4.1`
+**Branch:** `feature/github-packages-mirror`
 
 ## Completed
 
-- [x] Merged Pi 0.84.1 OAuth refresh and catalog lifecycle compatibility in PR #171.
-- [x] Bumped `package.json` and `package-lock.json` from 1.4.0 to 1.4.1.
-- [x] Finalized the 1.4.1 changelog and README release text.
-- [x] Replaced the placeholder publish workflow with a GitHub Release-triggered npm trusted-publishing workflow using OIDC, least-privilege permissions, release-tag/version validation, main-ancestry validation, and the full release gates.
-- [x] Documented npmjs.com trusted-publisher setup and the GitHub Release procedure.
-- [x] Removed live built-in catalog I/O from the Pi 0.84 store-publication test, kept credential refresh outside the test's scope, and awaited the exact registration-triggered publication promise.
-- [x] Stress-ran the focused registry suite 15 times after isolation; all runs passed.
-- [x] Independent follow-up review confirmed the publication test and trusted-publishing workflow are correct with no blocker.
-- [x] Local `npm test` passes: 50 files / 613 tests plus loader smoke.
-- [x] `npm run typecheck`, `npm run compatibility:check`, `npm pack --dry-run --json`, `git diff --check`, LSP, and pi-lens diagnostics pass.
-- [x] Clean packed exact Pi 0.80.1 and 0.84.1 boundaries each pass all 613 tests, loader smoke, and TypeScript at package version 1.4.1.
+- [x] Published and verified canonical npmjs release `pi-xai-oauth@1.4.1` through GitHub Actions trusted publishing.
+- [x] Confirmed GitHub Packages requires lowercase scoped npm names, creates the first package privately, and requires authenticated installs even after public visibility is enabled.
+- [x] Selected dual publishing: canonical npmjs `pi-xai-oauth` plus GitHub Packages `@blockedpath/pi-xai-oauth`.
+- [x] Selected 1.4.2 as the first mirror release rather than rewriting immutable 1.4.1 artifacts.
+- [x] Made `bin/setup.js` read the installed distribution name and treat npmjs/GitHub/local aliases as one package.
+- [x] Added setup regressions that prefer the active distribution and remove duplicate aliases.
+- [x] Added single-canonical-tarball mirror preparation and archive parity verification for version, repository, peer range, setup identity, file paths, non-manifest bytes, and file modes.
+- [x] Excluded local ignored agent, diagram, research, prototype, and probe artifacts from both package tarballs.
+- [x] Extended CI and release publishing with `packages: write`, repository `GITHUB_TOKEN` authentication, scoped registry setup, and retry-safe version checks.
+- [x] Bumped release metadata to 1.4.2 and documented first-package visibility plus authenticated GitHub Packages install/update instructions.
+- [x] Replaced the browser callback test's fixed 10 ms ordering assumption with an assertion-driven wait; 10 focused stress runs and the exact 0.84.1 packed retry passed.
+- [x] Independent review found no blocker; its medium archive-parity note was addressed and independently confirmed resolved.
+- [x] Final local `npm test` passes: 51 files / 616 tests plus loader smoke.
+- [x] `npm run typecheck`, `npm run compatibility:check`, 138-file canonical/mirror dry runs, `git diff --check`, workflow parsing, LSP, and pi-lens diagnostics pass.
+- [x] Final clean packed exact Pi 0.80.1 and 0.84.1 boundaries each pass all 616 tests, loader smoke, and TypeScript at package version 1.4.2.
 
 ## In Progress
 
-- None.
+- Commit, push, and open the 1.4.2 dual-publishing PR.
 
 ## Next
 
-Commit and merge the 1.4.1 release PR. On npmjs.com, configure the `pi-xai-oauth` trusted publisher for `BlockedPath/pi-xai-oauth`, workflow `publish.yml`, with `npm publish` allowed. Then publish a non-prerelease GitHub Release tagged `v1.4.1`; GitHub Actions will revalidate and publish to npm.
+Merge the reviewed PR, create GitHub Release `v1.4.2`, verify both registry publish steps, then change the new GitHub Package visibility to public once from its package settings.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -22,8 +22,8 @@
 
 ## In Progress
 
-- Commit, push, and open the 1.4.2 dual-publishing PR.
+- None.
 
 ## Next
 
-Merge the reviewed PR, create GitHub Release `v1.4.2`, verify both registry publish steps, then change the new GitHub Package visibility to public once from its package settings.
+Merge PR #174, create GitHub Release `v1.4.2`, verify both registry publish steps, then change the new GitHub Package visibility to public once from its package settings.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Core flow: `bin/setup.js` → `pi install` → bounded catalog selection in `ext
 - Run TypeScript: `npm run typecheck` (production, tests, fixtures, config)
 - Verify Pi policy/package metadata: `npm run compatibility:check`
 - Verify exact packed Pi boundaries: `npm run compatibility:boundaries`
+- Verify the scoped GitHub Packages mirror: `node scripts/verify-github-package.js`
 - Evaluate an unadvertised Pi candidate: `node scripts/run-compatibility-matrix.js X.Y.Z --candidate`
 - Git: Always work on feature branches and confirm the active branch before edits.
 
@@ -35,6 +36,7 @@ Core flow: `bin/setup.js` → `pi install` → bounded catalog selection in `ext
 - Keep the normalized token-free catalog cache atomic and apply the documented TTL/stale/fallback policy
 - Preserve known model metadata and compatibility behavior without inventing unentitled model families; known aliases and independently verified OAuth request slugs may be advertised only while their entitlement source is present at registration/runtime (cache stays exact)
 - Keep both Pi peers aligned to the checked-in bounded range in `compatibility/pi-versions.json`
+- Keep npmjs `pi-xai-oauth` canonical and publish GitHub Packages only as the exact scoped mirror `@blockedpath/pi-xai-oauth`; setup must treat both names as aliases and prevent duplicate registration
 - Install/report exact Pi matrix versions from a clean packed package; never reuse the repository lockfile for boundary jobs
 - Keep normal Pi dev dependencies exact at the policy's latest tested release and review candidate releases before widening support
 - Resolve `x-userid` transiently from the pinned authenticated CLI-proxy `/user` endpoint before any billing request
@@ -85,6 +87,8 @@ pi-xai-oauth/
 ├── scripts/
 │   ├── verify-extension-loader.mjs # Small real Pi loader smoke
 │   ├── verify-compatibility.js # Policy/range/registry/pack/unsupported-peer checks
+│   ├── prepare-github-package.js # Exact scoped mirror staging for GitHub Packages
+│   ├── verify-github-package.js # Mirror name/registry/version/setup parity gate
 │   └── run-compatibility-matrix.js # Clean packed exact-version test/typecheck runner
 ├── .github/workflows/
 │   └── ci.yml           # PR/main policy and exact Pi boundary matrix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 
 ## Unreleased
 
+## 1.4.2 - 2026-08-09
+
+### Added
+
+- Added an `@blockedpath/pi-xai-oauth` GitHub Packages mirror alongside the canonical `pi-xai-oauth` npmjs package. GitHub Release publishing now validates once and publishes the same release contents to both registries with registry-specific authentication; after the first publication, a package administrator can make the mirror public in GitHub's package settings.
+- Added a deterministic mirror-packaging verifier that rewrites only the distribution name and registry, preserves the exact version, repository, peer range, and package contents, and runs in CI and release validation.
+
+### Changed
+
+- Made the setup CLI distribution-aware so npmjs, GitHub Packages, and local installs are treated as aliases of one extension; setup preserves the selected registry and removes duplicate aliases before they can register conflicting tools.
+- Made both registry publish steps idempotent so a retry can finish a partially successful release without attempting to overwrite an immutable package version.
+
 ## 1.4.1 - 2026-08-09
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ node bin/setup.js --help
 
 ## Pi Compatibility and Release Changes
 
-The compatibility contract lives in `compatibility/pi-versions.json`. Both Pi peer ranges must remain aligned, normal development dependencies must be exact at the policy's `latest` release, and CI derives its two exact matrix cells from that policy.
+The compatibility contract lives in `compatibility/pi-versions.json`. Both Pi peer ranges must remain aligned, normal development dependencies must be exact at the policy's `latest` release, and CI derives its two exact matrix cells from that policy. Each release keeps npmjs `pi-xai-oauth` canonical and derives the GitHub Packages mirror `@blockedpath/pi-xai-oauth` from that exact tarball; `node scripts/verify-github-package.js` checks version, repository, peer, setup-name, and file-path parity.
 
 To evaluate a future Pi release without advertising it prematurely:
 
@@ -95,6 +95,7 @@ NODE_OPTIONS=--unhandled-rejections=strict npm test
 npm run test:coverage
 npm run typecheck
 npm run compatibility:check
+node scripts/verify-github-package.js
 npm run compatibility:boundaries
 npm pack --dry-run --json
 git diff --check

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ pi --model grok-4.5:low "Quick status check"   # fast mode
 
 This package adds xAI's **account-specific OAuth model catalog** to pi, with **Grok 4.5** as the offline fallback/default, proper OAuth login, automatic token refresh, and a suite of custom xAI tools (`xai_generate_text`, `web_search`, `xai_x_search`, etc.). The normalized cache remains exact; registration may additionally expose narrowly verified compatibility routes such as Grok 4.3 and Composer only while their required authenticated entitlement source is present.
 
-> **Latest release:** `pi-xai-oauth` **1.4.1** adds exact Pi 0.84.1 compatibility, forwards Pi's refresh cancellation signal through xAI token exchange, and verifies rotated OAuth credentials are persisted before request use. Setup now defaults an unset provider to Pi's built-in `xai` provider without overwriting an existing choice, while package-owned Grok terminal adapters suppress Pi session metadata. Existing npm installs should run `pi update npm:pi-xai-oauth`; local checkout installs should keep only one copy with `pi remove npm:pi-xai-oauth && pi install .`.
+> **Latest release:** `pi-xai-oauth` **1.4.2** publishes the canonical `pi-xai-oauth` package on npmjs and a scoped `@blockedpath/pi-xai-oauth` mirror on GitHub Packages from the same validated GitHub Release. Setup treats both registry names as one extension and removes duplicate aliases before they can register conflicting tools. Existing npmjs installs should run `pi update npm:pi-xai-oauth`; GitHub Packages installs should run `pi update npm:@blockedpath/pi-xai-oauth`.
 >
-> **Compatibility:** 1.4.1 supports aligned `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` versions `>=0.80.1 <0.85.0`. The exact tested boundaries are 0.80.1 and 0.84.1.
+> **Compatibility:** 1.4.2 supports aligned `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` versions `>=0.80.1 <0.85.0`. The exact tested boundaries are 0.80.1 and 0.84.1.
 
 See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and fix history.
 
@@ -138,6 +138,23 @@ Chat stays on Pi's built-in `xai` provider by default. This package still regist
 pi install npm:pi-xai-oauth
 ```
 
+### GitHub Packages mirror
+
+Every release is also published as `@blockedpath/pi-xai-oauth` on GitHub Packages. GitHub creates the package privately on its first publication; a package administrator must open the new package's settings and change its visibility to public once. GitHub still requires authentication when installing public npm packages: create a classic personal access token with `read:packages`, then authenticate with the token as your password. The generated user-level npm credentials must never be committed.
+
+```bash
+npm login --scope=@blockedpath --auth-type=legacy --registry=https://npm.pkg.github.com
+pi install npm:@blockedpath/pi-xai-oauth
+```
+
+The scoped setup command is also available after authentication:
+
+```bash
+npx @blockedpath/pi-xai-oauth
+```
+
+Use either the npmjs package or the GitHub Packages mirror, never both. They contain the same extension and version; npmjs remains the simpler public installation path because it does not require GitHub registry authentication.
+
 Recommended settings for native SuperGrok chat plus this package's tools/usage:
 
 ```bash
@@ -153,7 +170,7 @@ Authenticate with `/login xai`. Use `/login xai-auth` only when you want this pa
 
 > **⚠️ Important: install only one copy**
 >
-> `pi-xai-oauth` registers fixed private tool names such as `xai_generate_text`, `xai_grok_web_search`, and `xai_x_search`. If you install more than one copy — for example `npm:pi-xai-oauth` plus a local checkout, or two different local checkouts — pi will fail to start with `Tool "xai_generate_text" conflicts with ...` errors.
+> `pi-xai-oauth` registers fixed private tool names such as `xai_generate_text`, `xai_grok_web_search`, and `xai_x_search`. If you install more than one copy — for example `npm:pi-xai-oauth` plus `npm:@blockedpath/pi-xai-oauth`, a local checkout, or two different local checkouts — pi will fail to start with `Tool "xai_generate_text" conflicts with ...` errors. The setup CLI prunes npmjs/GitHub/local aliases, but manual installs must still keep only one.
 >
 > Check with:
 > ```bash
@@ -774,7 +791,7 @@ pi update npm:pi-xai-oauth
 
 This pulls the latest version from npm and updates your installed extension.
 
-Version 1.4.1 requires aligned Pi runtime packages in `>=0.80.1 <0.85.0`, with exact packed-package validation at 0.80.1 and 0.84.1. It adds Pi 0.84.1 OAuth refresh and model-catalog lifecycle compatibility, verifies file-backed rotated-token persistence across both tested boundaries, defaults previously unset setup configuration to Pi's built-in `xai` provider, and preserves the tools, media, transport, and entitlement hardening introduced in 1.4.0. See [CHANGELOG.md](CHANGELOG.md) for the complete release notes. If you installed the published npm package, update with the command above. If you are testing a local checkout instead, reinstall the checkout:
+Version 1.4.2 requires aligned Pi runtime packages in `>=0.80.1 <0.85.0`, with exact packed-package validation at 0.80.1 and 0.84.1. It preserves Pi 0.84.1 OAuth refresh and model-catalog lifecycle compatibility while publishing identical release contents to npmjs as `pi-xai-oauth` and GitHub Packages as `@blockedpath/pi-xai-oauth`. See [CHANGELOG.md](CHANGELOG.md) for the complete release notes. Update the registry distribution you installed; if you are testing a local checkout instead, reinstall the checkout:
 
 ```bash
 pi remove npm:pi-xai-oauth && pi install .
@@ -974,19 +991,22 @@ npm pack --dry-run --json
 git diff --check
 ```
 
-Normal releases publish through [`.github/workflows/publish.yml`](.github/workflows/publish.yml) with npm trusted publishing—no long-lived npm token is stored in GitHub. Configure the `pi-xai-oauth` package's trusted publisher on npmjs.com with GitHub owner `BlockedPath`, repository `pi-xai-oauth`, workflow filename `publish.yml`, no environment, and the `npm publish` action enabled. The workflow uses a GitHub-hosted runner, npm 11.6.2, and the required `id-token: write` permission.
+Normal releases publish through [`.github/workflows/publish.yml`](.github/workflows/publish.yml) to both registries. npmjs uses trusted publishing, so no long-lived npm token is stored in GitHub: configure `pi-xai-oauth` on npmjs.com with GitHub owner `BlockedPath`, repository `pi-xai-oauth`, workflow filename `publish.yml`, no environment, and `npm publish` enabled. GitHub Packages uses the repository-scoped `GITHUB_TOKEN` with `packages: write`; no additional GitHub secret is required.
 
-After the release PR is merged, create and publish a non-prerelease GitHub Release whose tag exactly matches `v` plus the version in `package.json` (for example, `v1.4.1`). The workflow refuses tags not contained in `main`, reruns the full release gates and exact packed boundaries, and then publishes the public package with OIDC-generated provenance.
+The workflow creates `@blockedpath/pi-xai-oauth` from the already validated canonical tarball by changing only its package name and registry. CI verifies that the mirror retains the same version, repository, peer dependencies, setup behavior, and contents. Both publish steps are idempotent so a failed second registry can be retried without attempting to overwrite the successful first publication. GitHub Packages creates the mirror privately on its first publication and exposes no npm-publish option for public visibility, so a package administrator must make it public once from the package settings UI; later versions retain the package's configured visibility.
+
+After the release PR is merged, create and publish a non-prerelease GitHub Release whose tag exactly matches `v` plus the version in `package.json` (for example, `v1.4.2`). The workflow refuses tags not contained in `main`, reruns the full release gates and exact packed boundaries, and then publishes npmjs with OIDC provenance plus the GitHub Packages mirror.
 
 ```bash
 git switch main
 git pull --ff-only origin main
-git tag v1.4.1
-git push origin v1.4.1
-gh release create v1.4.1 --verify-tag --generate-notes
+git tag v1.4.2
+git push origin v1.4.2
+gh release create v1.4.2 --verify-tag --generate-notes
 
-# Users update with:
+# Users update the distribution they installed with one of:
 # pi update npm:pi-xai-oauth
+# pi update npm:@blockedpath/pi-xai-oauth
 ```
 
 ---

--- a/bin/setup.js
+++ b/bin/setup.js
@@ -10,7 +10,17 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 
-const PACKAGE_NAME = "pi-xai-oauth";
+const DISTRIBUTION_PACKAGE_NAMES = Object.freeze([
+  "pi-xai-oauth",
+  "@blockedpath/pi-xai-oauth",
+]);
+const packageManifest = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8"),
+);
+if (!DISTRIBUTION_PACKAGE_NAMES.includes(packageManifest.name)) {
+  throw new Error(`Unsupported pi-xai-oauth distribution name: ${packageManifest.name}`);
+}
+const PACKAGE_NAME = packageManifest.name;
 const NPM_SPEC = `npm:${PACKAGE_NAME}`;
 /** Pi's built-in SuperGrok/X Premium provider used for normal chat. */
 const BUNDLED_XAI_PROVIDER = "xai";
@@ -96,28 +106,45 @@ function resolveLocalPackageJson(source, settingsPath = SETTINGS_PATH) {
   }
 }
 
+function packageAliasesFor(packageName) {
+  return DISTRIBUTION_PACKAGE_NAMES.includes(packageName)
+    ? new Set(DISTRIBUTION_PACKAGE_NAMES)
+    : new Set([packageName]);
+}
+
 function isLocalPackageNamed(source, packageName = PACKAGE_NAME, settingsPath = SETTINGS_PATH) {
   const packageJsonPath = resolveLocalPackageJson(source, settingsPath);
   if (!packageJsonPath) return false;
 
   try {
     const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-    return pkg.name === packageName;
+    return packageAliasesFor(packageName).has(pkg.name);
   } catch {
     return false;
   }
 }
 
 function pruneDuplicatePackageEntries(packages, settingsPath = SETTINGS_PATH, packageName = PACKAGE_NAME) {
-  let hasNpmPackage = false;
+  const aliases = packageAliasesFor(packageName);
+  const npmPackageNames = packages.map((entry) => getNpmPackageName(getPackageEntrySource(entry)));
+  const preferredName = npmPackageNames.includes(packageName)
+    ? packageName
+    : npmPackageNames.find((name) => aliases.has(name));
+  let retainedNpmPackage = false;
+  let addedNpmPackage = false;
   const removed = [];
   const next = [];
 
   for (const entry of packages) {
     const source = getPackageEntrySource(entry);
-    if (getNpmPackageName(source) === packageName) {
-      hasNpmPackage = true;
-      next.push(entry);
+    const npmPackageName = getNpmPackageName(source);
+    if (aliases.has(npmPackageName)) {
+      if (!retainedNpmPackage && npmPackageName === preferredName) {
+        retainedNpmPackage = true;
+        next.push(entry);
+      } else {
+        removed.push(source);
+      }
       continue;
     }
 
@@ -129,12 +156,12 @@ function pruneDuplicatePackageEntries(packages, settingsPath = SETTINGS_PATH, pa
     next.push(entry);
   }
 
-  if (!hasNpmPackage) {
-    next.push(NPM_SPEC);
-    hasNpmPackage = true;
+  if (!retainedNpmPackage) {
+    next.push(`npm:${packageName}`);
+    addedNpmPackage = true;
   }
 
-  return { packages: next, removed, addedNpmPackage: !packages.some((entry) => getNpmPackageName(getPackageEntrySource(entry)) === packageName) };
+  return { packages: next, removed, addedNpmPackage };
 }
 
 function updateSettings(settingsPath = SETTINGS_PATH) {
@@ -169,7 +196,7 @@ function updateSettings(settingsPath = SETTINGS_PATH) {
     settings.packages = packagePrune.packages;
     changed = true;
     for (const source of packagePrune.removed) {
-      console.log(color(`   - Removed duplicate local ${PACKAGE_NAME} package: ${source}`, "yellow"));
+      console.log(color(`   - Removed duplicate ${PACKAGE_NAME} package entry: ${source}`, "yellow"));
     }
   }
 
@@ -269,7 +296,7 @@ function printNextSteps(nonInteractive = false) {
   console.log("   • xai_analyze_image     — Image analysis");
   console.log("   • xai_critique          — Structured critique");
   console.log("   • xai_deep_research     — Deep research with web/X tools\n");
-  console.log(`   Update later: ${color("pi update npm:pi-xai-oauth", "yellow")}\n`);
+  console.log(`   Update later: ${color(`pi update ${NPM_SPEC}`, "yellow")}\n`);
 }
 
 function printScaffoldHeader() {
@@ -399,7 +426,7 @@ pi-xai-oauth — xAI OAuth provider for pi framework.
 
 ## Commands
 - Scaffold: node bin/setup.js --scaffold
-- Install: pi install npm:pi-xai-oauth
+- Install: pi install ${NPM_SPEC}
 
 ## Workflow
 - Always use feature branches
@@ -426,12 +453,12 @@ See .scaffold/plan.md for current roadmap.`;
 function printHelp() {
   console.log(`\n${color("pi-xai-oauth", "cyan")} — CLI for xAI tools/usage setup and agent scaffolding\n`);
   console.log("Usage:");
-  console.log("  npx pi-xai-oauth              Install package + seed native xAI chat defaults when unset");
-  console.log("  npx pi-xai-oauth --scaffold   Generate .scaffold/ harness in current project");
-  console.log("  npx pi-xai-oauth --yes        Non-interactive / automated mode");
-  console.log("  npx pi-xai-oauth --help       Show this help\n");
+  console.log(`  npx ${PACKAGE_NAME}              Install package + seed native xAI chat defaults when unset`);
+  console.log(`  npx ${PACKAGE_NAME} --scaffold   Generate .scaffold/ harness in current project`);
+  console.log(`  npx ${PACKAGE_NAME} --yes        Non-interactive / automated mode`);
+  console.log(`  npx ${PACKAGE_NAME} --help       Show this help\n`);
   console.log("Examples:");
-  console.log("  npx pi-xai-oauth --scaffold   # in any pi project to add agent harness\n");
+  console.log(`  npx ${PACKAGE_NAME} --scaffold   # in any pi project to add agent harness\n`);
 }
 
 function main() {
@@ -474,6 +501,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  DISTRIBUTION_PACKAGE_NAMES,
   PACKAGE_NAME,
   NPM_SPEC,
   getNpmPackageName,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-xai-oauth",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-xai-oauth",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "bin": {
         "pi-xai-oauth": "bin/setup.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-xai-oauth",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "xAI OAuth provider with an authenticated account-specific Grok model catalog for pi",
   "keywords": [
     "pi-package",
@@ -29,7 +29,7 @@
     "test:coverage": "vitest run --coverage",
     "test:loader": "node scripts/verify-extension-loader.mjs",
     "typecheck": "tsc --noEmit",
-    "compatibility:check": "node scripts/verify-compatibility.js all",
+    "compatibility:check": "node scripts/verify-compatibility.js all && node scripts/verify-github-package.js",
     "compatibility:min": "node scripts/run-compatibility-matrix.js minimum",
     "compatibility:latest": "node scripts/run-compatibility-matrix.js latest",
     "compatibility:boundaries": "npm run compatibility:min && npm run compatibility:latest"

--- a/scripts/prepare-github-package.js
+++ b/scripts/prepare-github-package.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+"use strict";
+
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const SOURCE_PACKAGE_NAME = "pi-xai-oauth";
+const GITHUB_PACKAGE_NAME = "@blockedpath/pi-xai-oauth";
+const GITHUB_REGISTRY = "https://npm.pkg.github.com";
+const REPOSITORY_URL = "git+https://github.com/BlockedPath/pi-xai-oauth.git";
+
+function rewritePackageManifest(manifest) {
+  if (manifest?.name !== SOURCE_PACKAGE_NAME) {
+    throw new Error(`Expected source package ${SOURCE_PACKAGE_NAME}, received ${manifest?.name ?? "missing name"}`);
+  }
+  const repositoryUrl = typeof manifest.repository === "string"
+    ? manifest.repository
+    : manifest.repository?.url;
+  if (repositoryUrl !== REPOSITORY_URL) {
+    throw new Error(`Expected repository ${REPOSITORY_URL}, received ${repositoryUrl ?? "missing repository"}`);
+  }
+
+  return {
+    ...manifest,
+    name: GITHUB_PACKAGE_NAME,
+    publishConfig: {
+      ...manifest.publishConfig,
+      registry: GITHUB_REGISTRY,
+    },
+  };
+}
+
+function prepareGithubPackage(sourceTarball, destination) {
+  const tarballPath = path.resolve(sourceTarball);
+  const outputRoot = path.resolve(destination);
+  const packageDirectory = path.join(outputRoot, "package");
+  const tarballStat = fs.statSync(tarballPath);
+  if (!tarballStat.isFile()) {
+    throw new Error(`Canonical package tarball is not a regular file: ${tarballPath}`);
+  }
+  if (fs.existsSync(packageDirectory)) {
+    throw new Error(`Refusing to overwrite prepared package directory: ${packageDirectory}`);
+  }
+
+  fs.mkdirSync(outputRoot, { recursive: true });
+  execFileSync("tar", ["-xzf", tarballPath, "-C", outputRoot], { stdio: "inherit" });
+
+  const manifestPath = path.join(packageDirectory, "package.json");
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  const rewritten = rewritePackageManifest(manifest);
+  fs.writeFileSync(manifestPath, `${JSON.stringify(rewritten, null, 2)}\n`, "utf8");
+  return packageDirectory;
+}
+
+if (require.main === module) {
+  const [sourceTarball, destination] = process.argv.slice(2);
+  if (!sourceTarball || !destination) {
+    console.error("Usage: node scripts/prepare-github-package.js <canonical-tarball> <output-directory>");
+    process.exit(1);
+  }
+  console.log(prepareGithubPackage(sourceTarball, destination));
+}
+
+module.exports = {
+  GITHUB_PACKAGE_NAME,
+  GITHUB_REGISTRY,
+  SOURCE_PACKAGE_NAME,
+  prepareGithubPackage,
+  rewritePackageManifest,
+};

--- a/scripts/verify-compatibility.js
+++ b/scripts/verify-compatibility.js
@@ -209,13 +209,26 @@ function verifyPackedPackage() {
       "extensions/xai/usage.ts",
       "scripts/verify-compatibility.js",
       "scripts/run-compatibility-matrix.js",
+      "scripts/prepare-github-package.js",
+      "scripts/verify-github-package.js",
       "scripts/verify-extension-loader.mjs",
       "vitest.config.ts",
       ...listFilesRecursively(path.join(repoRoot, "tests")),
     ];
     for (const file of required) assert.ok(packed.files.includes(file), `Packed package is missing ${file}`);
 
-    const forbidden = ["node_modules/", ".git/", ".scaffold/", ".pi-subagents/", "coverage/", ".env", "auth.json"];
+    const forbidden = [
+      "node_modules/",
+      ".git/",
+      ".scaffold/",
+      ".pi-subagents/",
+      ".agents/",
+      "coverage/",
+      "docs/diagrams/",
+      "skills-lock.json",
+      ".env",
+      "auth.json",
+    ];
     for (const file of packed.files) {
       assert.ok(!forbidden.some((prefix) => file === prefix || file.startsWith(prefix)), `Packed forbidden path: ${file}`);
     }

--- a/scripts/verify-github-package.js
+++ b/scripts/verify-github-package.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("assert");
+const { execFileSync } = require("child_process");
+const crypto = require("crypto");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const policy = require("../compatibility/pi-versions.json");
+const sourceManifest = require("../package.json");
+const repoRoot = path.resolve(__dirname, "..");
+const {
+  GITHUB_PACKAGE_NAME,
+  GITHUB_REGISTRY,
+  prepareGithubPackage,
+} = require("./prepare-github-package.js");
+
+function parsePackResult(stdout) {
+  const parsed = JSON.parse(stdout);
+  const entries = Array.isArray(parsed) ? parsed : Object.values(parsed);
+  assert.strictEqual(entries.length, 1, "npm pack must produce exactly one result");
+  assert.strictEqual(typeof entries[0]?.filename, "string", "npm pack must report a filename");
+  assert.strictEqual(path.basename(entries[0].filename), entries[0].filename, "npm pack filename must be safe");
+  return entries[0];
+}
+
+function packPackage(packagePath, destination, canonical = false) {
+  fs.mkdirSync(destination, { recursive: true });
+  const args = canonical
+    ? ["pack", "--json", "--pack-destination", destination]
+    : ["pack", packagePath, "--json", "--pack-destination", destination];
+  const output = execFileSync("npm", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+  const result = parsePackResult(output);
+  return {
+    result,
+    tarballPath: path.join(destination, result.filename),
+  };
+}
+
+function extractTarball(tarballPath, destination) {
+  fs.mkdirSync(destination, { recursive: true });
+  execFileSync("tar", ["-xzf", tarballPath, "-C", destination], { stdio: "inherit" });
+  return path.join(destination, "package");
+}
+
+function contentDigests(root, relative = "") {
+  const current = path.join(root, relative);
+  const entries = fs.readdirSync(current, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+  const digests = {};
+  for (const entry of entries) {
+    const entryRelative = path.join(relative, entry.name);
+    if (entryRelative === "package.json") continue;
+    const entryPath = path.join(root, entryRelative);
+    if (entry.isDirectory()) {
+      Object.assign(digests, contentDigests(root, entryRelative));
+      continue;
+    }
+    assert.ok(entry.isFile(), `Package contains unsupported non-file entry: ${entryRelative}`);
+    const stat = fs.statSync(entryPath);
+    const hash = crypto.createHash("sha256").update(fs.readFileSync(entryPath)).digest("hex");
+    digests[entryRelative] = `${(stat.mode & 0o777).toString(8)}:${hash}`;
+  }
+  return digests;
+}
+
+const outputRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-xai-github-package-check-"));
+try {
+  const canonical = packPackage(repoRoot, path.join(outputRoot, "canonical-archive"), true);
+  const canonicalPackage = extractTarball(canonical.tarballPath, path.join(outputRoot, "canonical"));
+  const preparedPackage = prepareGithubPackage(
+    canonical.tarballPath,
+    path.join(outputRoot, "prepared-mirror"),
+  );
+  const mirror = packPackage(preparedPackage, path.join(outputRoot, "mirror-archive"));
+  const mirrorPackage = extractTarball(mirror.tarballPath, path.join(outputRoot, "mirror"));
+  const manifest = JSON.parse(fs.readFileSync(path.join(mirrorPackage, "package.json"), "utf8"));
+
+  assert.strictEqual(manifest.name, GITHUB_PACKAGE_NAME);
+  assert.strictEqual(manifest.version, sourceManifest.version);
+  assert.strictEqual(manifest.publishConfig?.registry, GITHUB_REGISTRY);
+  assert.deepStrictEqual(manifest.peerDependencies, sourceManifest.peerDependencies);
+  assert.deepStrictEqual(
+    mirror.result.files.map((entry) => entry.path).sort(),
+    canonical.result.files.map((entry) => entry.path).sort(),
+    "GitHub mirror file paths must match the canonical npmjs tarball",
+  );
+  assert.deepStrictEqual(
+    contentDigests(mirrorPackage),
+    contentDigests(canonicalPackage),
+    "GitHub mirror non-manifest bytes and modes must match the canonical npmjs tarball",
+  );
+  for (const packageName of policy.packages) {
+    assert.strictEqual(manifest.peerDependencies?.[packageName], policy.peerRange);
+  }
+
+  const preparedSetup = require(path.join(mirrorPackage, "bin", "setup.js"));
+  assert.strictEqual(preparedSetup.PACKAGE_NAME, GITHUB_PACKAGE_NAME);
+  assert.strictEqual(preparedSetup.NPM_SPEC, `npm:${GITHUB_PACKAGE_NAME}`);
+  assert.ok(
+    preparedSetup.DISTRIBUTION_PACKAGE_NAMES.includes(sourceManifest.name),
+    "GitHub mirror must recognize the npmjs distribution as an alias",
+  );
+
+  console.log(
+    `GitHub package mirror: ${manifest.name}@${manifest.version} matches ${canonical.result.files.length} canonical files for ${GITHUB_REGISTRY}`,
+  );
+} finally {
+  fs.rmSync(outputRoot, { recursive: true, force: true });
+}

--- a/tests/oauth/browser-login.test.ts
+++ b/tests/oauth/browser-login.test.ts
@@ -232,7 +232,9 @@ describe("browser OAuth state and manual callbacks", () => {
             callbackDriver = trackDriver(
               controller,
               (async () => {
-                await new Promise((resolve) => setTimeout(resolve, 10));
+                await vi.waitFor(() => {
+                  expect(progress.some((message) => notice.test(message))).toBe(true);
+                });
                 const good = new URL(
                   fixture.authUrl!.searchParams.get("redirect_uri")!,
                 );

--- a/tests/setup/github-package.test.ts
+++ b/tests/setup/github-package.test.ts
@@ -1,0 +1,59 @@
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const {
+  GITHUB_PACKAGE_NAME,
+  GITHUB_REGISTRY,
+  rewritePackageManifest,
+} = require("../../scripts/prepare-github-package.js") as {
+  GITHUB_PACKAGE_NAME: string;
+  GITHUB_REGISTRY: string;
+  rewritePackageManifest(manifest: Record<string, any>): Record<string, any>;
+};
+
+function sourceManifest(overrides: Record<string, any> = {}) {
+  return {
+    name: "pi-xai-oauth",
+    version: "1.4.2",
+    repository: {
+      type: "git",
+      url: "git+https://github.com/BlockedPath/pi-xai-oauth.git",
+    },
+    publishConfig: { provenance: true },
+    peerDependencies: {
+      "@earendil-works/pi-ai": ">=0.80.1 <0.85.0",
+    },
+    ...overrides,
+  };
+}
+
+describe("GitHub Packages mirror manifest", () => {
+  it("rewrites only the distribution identity and registry", () => {
+    const source = sourceManifest();
+    const mirrored = rewritePackageManifest(source);
+
+    expect(mirrored).toMatchObject({
+      name: GITHUB_PACKAGE_NAME,
+      version: "1.4.2",
+      repository: source.repository,
+      peerDependencies: source.peerDependencies,
+      publishConfig: {
+        provenance: true,
+        registry: GITHUB_REGISTRY,
+      },
+    });
+    expect(source).toMatchObject({
+      name: "pi-xai-oauth",
+      publishConfig: { provenance: true },
+    });
+  });
+
+  it("rejects unexpected source package and repository identities", () => {
+    expect(() => rewritePackageManifest(sourceManifest({ name: "other-package" })))
+      .toThrow(/Expected source package pi-xai-oauth/);
+    expect(() => rewritePackageManifest(sourceManifest({
+      repository: { url: "https://github.com/example/fork.git" },
+    }))).toThrow(/Expected repository/);
+  });
+});

--- a/tests/setup/settings.test.ts
+++ b/tests/setup/settings.test.ts
@@ -7,7 +7,7 @@ import { createTempDir } from "../fixtures/temp";
 const require = createRequire(import.meta.url);
 const setup = require("../../bin/setup.js") as {
   getNpmPackageName(source: string): string | undefined;
-  pruneDuplicatePackageEntries(entries: any[], settingsPath: string): any;
+  pruneDuplicatePackageEntries(entries: any[], settingsPath: string, packageName?: string): any;
   updateSettings(path: string): boolean;
 };
 let temp: Awaited<ReturnType<typeof createTempDir>>;
@@ -64,6 +64,30 @@ describe("setup settings", () => {
       packages: ["npm:pi-xai-oauth"],
       removed: [localXai],
       addedNpmPackage: true,
+    });
+  });
+  it("treats npmjs and GitHub Packages distributions as one package", () => {
+    expect(
+      setup.pruneDuplicatePackageEntries(
+        ["npm:pi-xai-oauth", "npm:@blockedpath/pi-xai-oauth", localXai, "npm:other"],
+        settingsPath,
+        "@blockedpath/pi-xai-oauth",
+      ),
+    ).toEqual({
+      packages: ["npm:@blockedpath/pi-xai-oauth", "npm:other"],
+      removed: ["npm:pi-xai-oauth", localXai],
+      addedNpmPackage: false,
+    });
+
+    expect(
+      setup.pruneDuplicatePackageEntries(
+        ["npm:@blockedpath/pi-xai-oauth", "npm:other"],
+        settingsPath,
+      ),
+    ).toEqual({
+      packages: ["npm:@blockedpath/pi-xai-oauth", "npm:other"],
+      removed: [],
+      addedNpmPackage: false,
     });
   });
   it("writes pruned packages and preserves package-owned xai-auth defaults", async () => {


### PR DESCRIPTION
## Summary

Publish release 1.4.2 to both supported npm registries from one validated GitHub Release:

- npmjs: `pi-xai-oauth`
- GitHub Packages: `@blockedpath/pi-xai-oauth`

The npmjs package remains canonical and the simplest public install path. The GitHub Packages artifact is a lowercase scoped mirror derived from the exact canonical tarball, as required by GitHub's npm registry.

## Why 1.4.2

GitHub Packages requires a scoped package name and cannot safely reuse the immutable 1.4.1 release because distribution-aware setup and mirror verification were not present in that artifact. Version 1.4.2 is therefore the first dual-published release.

## Dual-registry publishing

`.github/workflows/publish.yml` now:

- triggers from a published, non-prerelease GitHub Release;
- retains npm trusted publishing with `id-token: write` and no npm token secret;
- grants `packages: write` for GitHub Packages;
- validates that the release tag matches `package.json` and is contained in `main`;
- runs all tests, typecheck, compatibility checks, mirror parity verification, and exact packed Pi boundaries;
- creates one canonical npm tarball after validation;
- publishes that exact tarball to npmjs;
- derives `@blockedpath/pi-xai-oauth` from the canonical tarball by changing only package identity/registry metadata;
- packs and publishes the scoped mirror to `npm.pkg.github.com` using the repository `GITHUB_TOKEN`;
- checks for existing versions before each publish so a partially successful release can be safely retried.

No additional GitHub secret or PAT is stored in Actions.

## Exact mirror preparation and verification

Adds:

- `scripts/prepare-github-package.js`
- `scripts/verify-github-package.js`

The verifier confirms:

- package name is exactly `@blockedpath/pi-xai-oauth`;
- version matches the canonical package;
- repository metadata and aligned Pi peers are preserved;
- registry is exactly `https://npm.pkg.github.com`;
- packed file paths match;
- every non-`package.json` byte and permission mode matches the canonical archive;
- the scoped package's setup CLI resolves its own npm spec correctly.

The mirror verifier runs in CI and as part of `npm run compatibility:check`.

## Distribution-aware setup

`bin/setup.js` now reads the installed package name from its own manifest and recognizes these as aliases of one extension:

- `pi-xai-oauth`
- `@blockedpath/pi-xai-oauth`
- local checkouts with either distribution name

When aliases coexist, setup keeps the currently selected registry distribution and removes duplicate aliases before they can register conflicting tools. Existing npmjs setup behavior remains unchanged.

## GitHub Packages installation

README documents that GitHub requires authentication even for public npm packages. Consumers use a classic PAT with `read:packages`:

```bash
npm login --scope=@blockedpath --auth-type=legacy --registry=https://npm.pkg.github.com
pi install npm:@blockedpath/pi-xai-oauth
```

GitHub creates the package privately on first publication. After the first successful 1.4.2 release, a package administrator must change its visibility to public once in GitHub Package settings. Later versions retain that visibility.

## Release hygiene

- Bumps `package.json` and `package-lock.json` to 1.4.2.
- Finalizes the 1.4.2 changelog and README release guidance.
- Excludes local `.agents/`, `skills-lock.json`, generated diagrams, research, prototypes, and probe artifacts from tarballs.
- Requires the mirror scripts and all tests in the packed compatibility manifest.

## Browser callback test stabilization

Exact 0.84.1 boundary validation exposed a pre-existing fixed-delay race in the wrong/missing-state browser callback test. The driver now waits for the rejected-state progress assertion before sending the valid HTTP callback instead of assuming 10 ms is sufficient.

- 10 focused stress runs passed.
- The exact 0.84.1 packed retry passed.
- Independent review confirmed the state-validation ordering remains intact.

## Validation

Final release-tree validation:

- `npm test`
  - 51 test files passed
  - 616 tests passed
  - real Pi loader smoke passed
- `npm run typecheck` — passed
- `npm run compatibility:check` — passed
  - canonical tarball: 138 files
  - scoped mirror: 138 matching files
  - non-manifest byte/mode parity passed
- `npm pack --dry-run --json` — `pi-xai-oauth@1.4.2`, 138 files
- Exact packed Pi 0.80.1 boundary
  - 616 tests, loader smoke, and typecheck passed
- Exact packed Pi 0.84.1 boundary
  - 616 tests, loader smoke, and typecheck passed
- Workflow YAML parsing, edited-file LSP, and pi-lens diagnostics — clean
- `git diff --check` — clean
- Independent review — no blocker or remaining medium finding

## After merge

```bash
git switch main
git pull --ff-only origin main
git tag v1.4.2
git push origin v1.4.2
gh release create v1.4.2 --verify-tag --generate-notes
```

The GitHub Release will publish both registries. After the first successful GitHub Packages publication, open the new package's settings and change visibility to public.
