### PR TITLE
Ignore local research and probe artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ CLAUDE.md
 .claude/
 skills-lock.json
 docs/diagrams/
+
+# Local research, prototypes, and probe artifacts.
+docs/research/
+prototype/
+probe-*


### PR DESCRIPTION
## Summary

- ignore local `docs/research/` notes
- ignore local `prototype/` spikes
- ignore root `probe-*` scripts and generated media

These paths are already excluded from npm tarballs and contain local, user-owned exploratory artifacts.

## Validation

- `git diff --check`
- `git check-ignore` confirms all three groups are ignored