### PR TITLE
feat: add Grok 4.6 as default OAuth model (1.5.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,11 +3,13 @@
 > **For AI coding agents only.** Keep this file machine-readable and concise. Human-facing docs live in README.md.
 
 ## Project Overview
-pi-xai-oauth is a pi-package that registers the optional xAI OAuth provider (`xai-auth`) and the authenticated account's OAuth-visible Grok model catalog, with Grok 4.5 as the curated offline fallback. Opt-in network tools and `/xai-usage` also work with Pi's built-in `xai` SuperGrok/X Premium chat provider; setup seeds `defaultProvider: xai` only when unset and never overwrites an existing provider choice.
+
+pi-xai-oauth is a pi-package that registers the optional xAI OAuth provider (`xai-auth`) and the authenticated account's OAuth-visible Grok model catalog, with Grok 4.6 as the curated offline fallback. Opt-in network tools and `/xai-usage` also work with Pi's built-in `xai` SuperGrok/X Premium chat provider; setup seeds `defaultProvider: xai` only when unset and never overwrites an existing provider choice.
 
 Core flow: `bin/setup.js` → `pi install` → bounded catalog selection in `extensions/xai/catalog.ts` → provider registration in `extensions/xai-oauth.ts` → browser PKCE or bounded device authorization in `extensions/xai/oauth.ts` / `extensions/xai/device-auth.ts` → pinned browser OIDC/JWKS validation in `extensions/xai/oidc.ts` → streaming via xAI API helpers in `extensions/xai/responses.ts`; explicit revision-pinned subscription usage lives in `extensions/xai/usage.ts`.
 
 ## Key Commands (Exact, Copy-Paste Ready)
+
 - Install / setup: `node bin/setup.js` or `npm run setup`
 - Install as pi extension: `pi install npm:pi-xai-oauth`
 - Full policy/unit/loader gate: `npm test`
@@ -22,7 +24,9 @@ Core flow: `bin/setup.js` → `pi install` → bounded catalog selection in `ext
 - Git: Always work on feature branches and confirm the active branch before edits.
 
 ## Architecture & Boundaries (MUST / MUST NOT)
+
 **MUST:**
+
 - Register providers via `pi.registerProvider("xai-auth", { ... })`
 - Keep browser PKCE S256 with local callback server as the first/default login method
 - Offer device authorization through pi's native selector/device-code callbacks for remote/headless human login
@@ -43,6 +47,7 @@ Core flow: `bin/setup.js` → `pi install` → bounded catalog selection in `ext
 - Keep `/xai-usage` explicit, and keep its optional status off by default, session-scoped, bounded, and inactive outside xAI models
 
 **MUST NOT:**
+
 - Hardcode API keys (use OAuth only)
 - Accept raw authorization codes or callbacks with missing/mismatched state
 - Trust arbitrary `*.x.ai` discovery, device, token, verification, or JWKS endpoints
@@ -57,6 +62,7 @@ Core flow: `bin/setup.js` → `pi install` → bounded catalog selection in `ext
 - Skip error handling on OAuth refresh
 
 ## File Structure & Wayfinding
+
 ```
 pi-xai-oauth/
 ├── bin/
@@ -105,12 +111,14 @@ pi-xai-oauth/
 ```
 
 Start any task by reading:
+
 1. `extensions/xai-oauth.ts` (provider entrypoint)
 2. Relevant `extensions/xai/` domain module for the task
 3. `bin/setup.js`
 4. This AGENTS.md
 
 ## Style & Quality Rules
+
 - Use TypeScript strict mode
 - Prefer async/await for OAuth and API calls
 - Add JSDoc for all exported functions
@@ -129,25 +137,30 @@ Start any task by reading:
 - Use strict peer resolution for supported versions; `--force` is allowed only in isolated negative fixtures that assert npm peer warnings
 
 ## Safety Gates
+
 - Before any file edit: run `git status` and confirm on correct branch
 - Before committing: ensure `npm test`, `npm run typecheck`, and both exact compatibility boundaries pass
 - For multi-agent work: always use the subagent tool with explicit parallel or chain mode
 - External state lives in `.scaffold/` — update progress.md after every major step
 
 ## Multi-Agent Workflow (Preferred)
+
 When complex work is needed:
+
 1. Use `subagent` in PARALLEL mode for research + planning
 2. Delegate to specialized agents (researcher, planner, reviewer, worker)
 3. Save outputs to `.scaffold/` files
 4. Review with `reviewer` agent before implementation
 
 ## Persistent State (Use These Files)
+
 - `.scaffold/plan.md` — Current implementation plan with steps and owners
 - `.scaffold/constraints.md` — Hard rules and boundaries
 - `.scaffold/progress.md` — What has been done + next actions
 - `.scaffold/context.md` — Shared context for handoff between agents
 
 ## Next Steps When Starting Fresh
+
 1. Read this AGENTS.md + README.md
 2. Run `git checkout -b feature/your-task`
 3. Check `.scaffold/plan.md` for current work

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 
 ## Unreleased
 
+## 1.5.0 - 2026-08-12
+
+### Added
+
+- Added known-model metadata and catalog support for Grok 4.6 (`grok-4.6`), including text+image input, 500K context, official standard-tier pricing, and authenticated reasoning levels `low` / `medium` / `high` / `xhigh`.
+- Mapped Pi's `minimal` thinking level onto xAI `low` for Grok 4.6 (same compatibility behavior as Grok 4.5).
+
+### Changed
+
+- Promoted `grok-4.6` to the package default model and curated offline fallback used by setup, request helpers, and permanent catalog-failure paths. Grok 4.5 remains fully supported when the authenticated catalog entitles it.
+
+### Documentation
+
+- Documented Grok 4.6 as the flagship default, kept Grok 4.5 as an entitled catalog model, and noted Grok 4.6's additional `xhigh` reasoning level.
+
 ## 1.4.2 - 2026-08-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,35 +9,36 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-Ready-blue)](https://www.typescriptlang.org/)
 [![pi compatible](https://img.shields.io/badge/pi-Compatible-blueviolet)](https://pi.dev)
 
-**xAI (Grok) OAuth provider for pi** — now with **Grok 4.5**, reasoning, long context, and custom xAI tools.
+**xAI (Grok) OAuth provider for pi** — now with **Grok 4.6**, reasoning, long context, and custom xAI tools.
 
 ```bash
 npx pi-xai-oauth
 ```
 
-## ✨ New: Grok 4.5
+## ✨ New: Grok 4.6
 
 | | |
 | --- | --- |
-| **Model ID** | `grok-4.5` |
+| **Model ID** | `grok-4.6` |
 | **Role** | xAI flagship for coding, agentic tasks, and knowledge work |
 | **Context** | 500K tokens |
 | **Input** | text + image |
-| **Reasoning** | `low` / `medium` / `high` (defaults to **high**; cannot be disabled) |
+| **Reasoning** | `low` / `medium` / `high` / `xhigh` (defaults to **high**; cannot be disabled) |
 | **Fast mode** | Same model with **`low`** reasoning effort — not a separate model ID |
 | **Pricing** | $2 / $6 per 1M input/output · $0.50 cache read |
 
 ```bash
-pi --model grok-4.5 "Ship this feature end-to-end"
-pi --model grok-4.5:high "Review this architecture for failure modes"
-pi --model grok-4.5:low "Quick status check"   # fast mode
+pi --model grok-4.6 "Ship this feature end-to-end"
+pi --model grok-4.6:high "Review this architecture for failure modes"
+pi --model grok-4.6:xhigh "Deep multi-step design review"
+pi --model grok-4.6:low "Quick status check"   # fast mode
 ```
 
-This package adds xAI's **account-specific OAuth model catalog** to pi, with **Grok 4.5** as the offline fallback/default, proper OAuth login, automatic token refresh, and a suite of custom xAI tools (`xai_generate_text`, `web_search`, `xai_x_search`, etc.). The normalized cache remains exact; registration may additionally expose narrowly verified compatibility routes such as Grok 4.3 and Composer only while their required authenticated entitlement source is present.
+This package adds xAI's **account-specific OAuth model catalog** to pi, with **Grok 4.6** as the offline fallback/default, proper OAuth login, automatic token refresh, and a suite of custom xAI tools (`xai_generate_text`, `web_search`, `xai_x_search`, etc.). The normalized cache remains exact; registration may additionally expose narrowly verified compatibility routes such as Grok 4.3 and Composer only while their required authenticated entitlement source is present. Entitled accounts that still receive `grok-4.5` keep that model as a first-class catalog entry.
 
-> **Latest release:** `pi-xai-oauth` **1.4.2** publishes the canonical `pi-xai-oauth` package on npmjs and a scoped `@blockedpath/pi-xai-oauth` mirror on GitHub Packages from the same validated GitHub Release. Setup treats both registry names as one extension and removes duplicate aliases before they can register conflicting tools. Existing npmjs installs should run `pi update npm:pi-xai-oauth`; GitHub Packages installs should run `pi update npm:@blockedpath/pi-xai-oauth`.
+> **Latest release:** `pi-xai-oauth` **1.5.0** publishes the canonical `pi-xai-oauth` package on npmjs and a scoped `@blockedpath/pi-xai-oauth` mirror on GitHub Packages from the same validated GitHub Release. Setup treats both registry names as one extension and removes duplicate aliases before they can register conflicting tools. Existing npmjs installs should run `pi update npm:pi-xai-oauth`; GitHub Packages installs should run `pi update npm:@blockedpath/pi-xai-oauth`.
 >
-> **Compatibility:** 1.4.2 supports aligned `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` versions `>=0.80.1 <0.85.0`. The exact tested boundaries are 0.80.1 and 0.84.1.
+> **Compatibility:** 1.5.0 supports aligned `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` versions `>=0.80.1 <0.85.0`. The exact tested boundaries are 0.80.1 and 0.84.1.
 
 See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and fix history.
 
@@ -45,7 +46,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and
 
 ## Table of Contents
 
-- [✨ New: Grok 4.5](#-new-grok-45)
+- [✨ New: Grok 4.6](#-new-grok-46)
 - [Features](#features)
 - [Package Scope](#package-scope)
 - [Changelog](CHANGELOG.md)
@@ -75,8 +76,9 @@ See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and
 - **Automatic browser open** — browser login opens your default browser automatically and retains the matching-state full-redirect paste fallback
 - **Token refresh** — refresh tokens are stored and rotated automatically before expiry
 - **Reuses existing credentials** — auto-detects `~/.grok/auth.json` from the official Grok CLI
-- **Grok 4.5 flagship (default)** — xAI's newest model for coding, agentic tasks, and knowledge work; 500K context, text+image input, high reasoning by default
-- **Grok 4.5 fast mode** — same model with `low` reasoning effort (`/think low` or `grok-4.5:low`); not a separate model ID
+- **Grok 4.6 flagship (default)** — xAI's newest model for coding, agentic tasks, and knowledge work; 500K context, text+image input, high reasoning by default, with optional `xhigh`
+- **Grok 4.6 fast mode** — same model with `low` reasoning effort (`/think low` or `grok-4.6:low`); not a separate model ID
+- **Grok 4.5 still supported** — remains a first-class entitled catalog model when `/models-v2` returns it
 - **Grok 4.3 OAuth compatibility** — advertises the independently verified `grok-4.3` request route only when `grok-4.5` is entitled, retaining authenticated input evidence and conservative limits
 - **Authenticated model catalog** — fetches the OAuth-visible `/models-v2` list from the official CLI proxy, so additions and removals track the signed-in account
 - **Explicit subscription usage** — `/xai-usage` performs a bounded, identity-first lookup against the revision-pinned unofficial Grok billing surface without retaining account identity
@@ -128,7 +130,7 @@ This runs the setup script which:
 
 1. Installs `npm:pi-xai-oauth` into pi
 2. Seeds `defaultProvider: "xai"` only when no provider is configured (never overwrites an existing choice, including package-owned `xai-auth`)
-3. Sets `grok-4.5` as your default model
+3. Sets `grok-4.6` as your default model
 4. Enables `high` thinking level by default
 
 Chat stays on Pi's built-in `xai` provider by default. This package still registers optional `xai-auth` for its account catalog/stream path, and both providers can use `/xai-tools` plus `/xai-usage`.
@@ -162,7 +164,7 @@ Recommended settings for native SuperGrok chat plus this package's tools/usage:
 # In ~/.pi/agent/settings.json:
 {
   "defaultProvider": "xai",
-  "defaultModel": "grok-4.5",
+  "defaultModel": "grok-4.6",
   "defaultThinkingLevel": "high"
 }
 ```
@@ -282,7 +284,7 @@ pi "Explain quantum computing like I'm 5"
 Or use a specific model:
 
 ```bash
-pi --model grok-4.5 "Write a poem about Rust"
+pi --model grok-4.6 "Write a poem about Rust"
 ```
 
 ### Subscription usage (unofficial)
@@ -315,7 +317,8 @@ Common catalog entries include:
 
 | Model ID | Description |
 | ---------- | ------------- |
-| `grok-4.5` | **Default and curated offline fallback.** xAI flagship; reasoning low (**fast**) / medium / high (default), 500K context, text+image. |
+| `grok-4.6` | **Default and curated offline fallback.** xAI flagship; reasoning low (**fast**) / medium / high (default) / xhigh, 500K context, text+image. |
+| `grok-4.5` | When entitled: previous flagship; reasoning low (**fast**) / medium / high (default), 500K context, text+image. |
 | `grok-4.3` | OAuth-compatible request model when `grok-4.5` is entitled; keeps authenticated input evidence and conservative catalog-derived limits. |
 | `grok-build` | When entitled: Grok Build coding model (same Grok-native tools as other xai-auth models). |
 | `grok-composer-2.5-fast` | Compatibility alias of entitled `grok-4.5`; uses the same Grok-native pi tool adapters and no Cursor-named shims. |
@@ -326,6 +329,7 @@ Common catalog entries include:
 The exact list is account-specific and can change independently of package releases. From the pi TUI:
 
 ```
+/model grok-4.6
 /model grok-4.5
 /model grok-4.3
 /model grok-build
@@ -337,7 +341,8 @@ The exact list is account-specific and can change independently of package relea
 From the command line:
 
 ```bash
-pi --model grok-4.5 "Your prompt here"
+pi --model grok-4.6 "Your prompt here"
+pi --model grok-4.5 "Use Grok 4.5"
 pi --model grok-4.3 "Use Grok 4.3"
 pi --model grok-build "Implement this feature"
 pi --model grok-composer-2.5-fast "Refactor this module"
@@ -377,7 +382,7 @@ The normalized, token-free last-known-good catalog is stored at:
 - **Fresh for 15 minutes:** with a usable OAuth credential (or an expired stored credential awaiting pi's lock-protected refresh), startup and `/reload` use the cache immediately and do not make a catalog request. Logged-out startup uses the curated fallback instead of exposing the previous account's cache.
 - **Stale refresh:** after 15 minutes, startup performs one authenticated GET bounded to 5 seconds.
 - **Transient fallback:** network errors, timeouts, HTTP 408/429/5xx, or a malformed successful response may reuse a validated cache no older than 7 days. A forced/deferred refresh never reuses stale account data; it uses the curated fallback and remains retryable with a one-minute in-session backoff.
-- **Auth/permanent failure:** HTTP 401/403 or other permanent 4xx responses invalidate cached entitlements and use the curated `grok-4.5` fallback.
+- **Auth/permanent failure:** HTTP 401/403 or other permanent 4xx responses invalidate cached entitlements and use the curated `grok-4.6` fallback.
 - **Login:** every successful browser, device, or reused-credential `/login xai-auth` forces a refresh with the returned credential, never reuses stale data, and updates `/model` immediately. A failed/cancelled selected login leaves existing credentials and catalog state intact. If catalog refresh alone fails after authentication, login still succeeds and the curated fallback is used.
 - **`/reload`:** recreates the extension and follows the same 15-minute policy; it is not an unconditional network refresh.
 - **Selection:** if a refresh removes the active xAI model, the next turn switches to an entitled xAI replacement when available; otherwise it aborts before sending an unentitled request.
@@ -386,29 +391,32 @@ The cache stores only normalized model definitions, bounded input-capability pro
 
 ### Reasoning / Thinking Levels
 
-Grok 4.5 and the entitlement-gated Grok 4.3 compatibility route expose configurable thinking levels via pi's `/think` command or `model:effort` syntax. There is **no separate `grok-4.5-fast` model** — on Grok 4.5, “fast mode” is **`reasoning_effort: "low"`** on the same model ID.
+Grok 4.6, Grok 4.5, and the entitlement-gated Grok 4.3 compatibility route expose configurable thinking levels via pi's `/think` command or `model:effort` syntax. There is **no separate `grok-4.6-fast` model** — on Grok 4.6, “fast mode” is **`reasoning_effort: "low"`** on the same model ID.
 
 ```
+/think xhigh    # Grok 4.6 only (when catalog advertises it)
 /think high
 /think medium
-/think low      # Grok 4.5 fast mode
+/think low      # Grok 4.6 / 4.5 fast mode
 ```
 
 Or via CLI:
 
 ```bash
-pi --model grok-4.5:high "Solve a complex math problem"
-pi --model grok-4.5:medium "Summarize this design doc"
-pi --model grok-4.5:low "What's the weather?"   # fast / latency-sensitive
+pi --model grok-4.6:high "Solve a complex math problem"
+pi --model grok-4.6:xhigh "Deep multi-step design review"
+pi --model grok-4.6:medium "Summarize this design doc"
+pi --model grok-4.6:low "What's the weather?"   # fast / latency-sensitive
 ```
 
-| Effort | Grok 4.5 behavior (per xAI docs) | Best for |
+| Effort | Grok 4.6 behavior | Best for |
 | -------- | ----------------------------------- | ---------- |
+| **`xhigh`** | Highest advertised reasoning effort | Hardest multi-step design and analysis |
 | **`high`** (default) | More reasoning tokens, deeper thinking | Hard coding, complex math, multi-step logic |
 | **`medium`** | Balanced thinking vs latency | Analysis and longer-context work |
 | **`low`** (**fast mode**) | Some reasoning, still fast | Latency-sensitive agents and simple tool calling |
 
-`grok-4.5` defaults to **high** when no effort is specified; reasoning **cannot be disabled** (`/think off` is not supported for this model). Every model selected through the OAuth-only `xai-auth` runtime catalog sends Responses traffic through xAI's Grok CLI session endpoint using the same X account OAuth token. An entitled `grok-build` entry still receives its legacy Responses payload/header compatibility behavior, while every `xai-auth` model uses the same Grok-native local tool adapters. The Composer alias (`grok-composer-2.5-fast`) follows the Grok 4.5 payload path. `grok-4.20-0309-reasoning` reasons automatically and does not accept a configurable effort parameter. `grok-4.20-multi-agent-0309` uses `medium` for 4 agents and `high` for 16 agents.
+`grok-4.6` defaults to **high** when no effort is specified; reasoning **cannot be disabled** (`/think off` is not supported for this model). Every model selected through the OAuth-only `xai-auth` runtime catalog sends Responses traffic through xAI's Grok CLI session endpoint using the same X account OAuth token. An entitled `grok-build` entry still receives its legacy Responses payload/header compatibility behavior, while every `xai-auth` model uses the same Grok-native local tool adapters. The Composer alias (`grok-composer-2.5-fast`) follows the Grok 4.5 payload path. `grok-4.20-0309-reasoning` reasons automatically and does not accept a configurable effort parameter. `grok-4.20-multi-agent-0309` uses `medium` for 4 agents and `high` for 16 agents.
 
 #### Switching between `xai` and `xai-auth`
 
@@ -416,22 +424,23 @@ Setup seeds Pi's built-in `xai` provider when no provider is configured, so the 
 
 | Model | Built-in `xai` | `xai-auth` | Why |
 | ------- | ---------------- | ------------ | ----- |
+| `grok-4.6` | follows Pi's generated catalog when present | `minimal` / `low` / `medium` / `high` / `xhigh` | **Intentional.** `xai-auth` maps Pi's `minimal` onto xAI's `low`, and advertises `xhigh` when `/models-v2` lists it. |
 | `grok-4.5` | `low` / `medium` / `high` | `minimal` / `low` / `medium` / `high` | **Intentional.** `xai-auth` maps Pi's `minimal` onto xAI's `low`, so `/think minimal` and `/think low` send the same `reasoning_effort: "low"` request. Selecting `minimal` never sends an effort xAI did not advertise. |
 | `grok-4.3` | `off` / `minimal` / `low` / `medium` / `high` | same | Identical on both paths. |
 | `grok-build-0.1` | available | **never advertised** | API-key-only model; it is excluded from `xai-auth` regardless of what a catalog response contains. |
 
-Authenticated evidence always wins on the `xai-auth` path. If `/models-v2` reports `supports_reasoning_effort: false`, the model drops to `off` only even when known metadata lists `low`/`medium`/`high`. Levels absent from `reasoning_efforts` stay hidden, and Pi clamps a request for a hidden level down to the nearest advertised one. `xhigh` appears only when the catalog names xAI's `max` effort; Pi's own `max` level is never advertised for Grok.
+Authenticated evidence always wins on the `xai-auth` path. If `/models-v2` reports `supports_reasoning_effort: false`, the model drops to `off` only even when known metadata lists `low`/`medium`/`high`. Levels absent from `reasoning_efforts` stay hidden, and Pi clamps a request for a hidden level down to the nearest advertised one. `xhigh` appears when the catalog names xAI's `xhigh` or `max` effort; Pi's own `max` level is never advertised for Grok.
 
-### Grok 4.5 source notes
+### Grok 4.6 source notes
 
 Official xAI sources used for this catalog update:
 
-- [Grok 4.5 guide](https://docs.x.ai/developers/grok-4-5) — model ID, API usage, reasoning levels, tools, and availability notes.
-- [Grok 4.5 model details](https://docs.x.ai/developers/models/grok-4.5) — text+image input, 500K context window, cached input pricing, regions, and rate-limit snapshot.
-- [Reasoning docs](https://docs.x.ai/developers/model-capabilities/text/reasoning) — `low` / `medium` / `high` reasoning effort, default `high`, and non-disableable reasoning.
-- [Launch announcement](https://x.ai/news/grok-4-5) — coding/agentic benchmark notes, Grok Build/Cursor availability, and EU availability caveat.
+- [Grok 4.6 model details](https://docs.x.ai/developers/models/grok-4.6) — text+image input, 500K context window, cached input pricing, regions, and rate-limit snapshot.
+- [Grok 4.6 announcement](https://x.ai/news/grok-4-6) — product positioning and availability notes.
+- Live authenticated `GET https://cli-chat-proxy.grok.com/v1/models-v2` — confirms OAuth entitlement of `grok-4.6` with reasoning efforts `low` / `medium` / `high` / `xhigh`.
+- Live authenticated `GET https://api.x.ai/v1/models` — confirms API model id `grok-4.6` and standard-tier pricing.
 
-No Grok 4.5-specific model card, label card, system card, paper, or official max-output-token limit was found in the xAI docs/news/data sources during this update. The package keeps the existing Grok Responses max-token ceiling as a placeholder until xAI publishes official model metadata for that field.
+No Grok 4.6-specific max-output-token limit was published in the xAI model docs during this update. The package keeps the existing Grok Responses max-token ceiling as a placeholder until xAI publishes official model metadata for that field.
 
 ### Grok-native tools
 
@@ -514,7 +523,7 @@ Opt-in text generation with full reasoning and stateful conversations. Enable it
 ```json
 {
   "prompt": "Explain neural networks",
-  "model": "grok-4.5",
+  "model": "grok-4.6",
   "reasoning_effort": "high"
 }
 ```
@@ -664,7 +673,7 @@ Opt-in research using the active xAI model plus native web and X search tools. E
 | Update | `pi update npm:pi-xai-oauth` |
 | Remove | `pi remove npm:pi-xai-oauth` |
 | List packages | `pi list` |
-| Set default model | `/model grok-4.5` (in TUI) |
+| Set default model | `/model grok-4.6` (in TUI) |
 | Set thinking level | `/think high` (in TUI) |
 | Show subscription usage | `/xai-usage` (unofficial, explicit request) |
 | Manage optional usage status | `/xai-usage status on\|off` (off by default) |
@@ -804,7 +813,7 @@ pi update npm:pi-xai-oauth
 
 This pulls the latest version from npm and updates your installed extension.
 
-Version 1.4.2 requires aligned Pi runtime packages in `>=0.80.1 <0.85.0`, with exact packed-package validation at 0.80.1 and 0.84.1. It preserves Pi 0.84.1 OAuth refresh and model-catalog lifecycle compatibility while publishing identical release contents to npmjs as `pi-xai-oauth` and GitHub Packages as `@blockedpath/pi-xai-oauth`. See [CHANGELOG.md](CHANGELOG.md) for the complete release notes. Update the registry distribution you installed; if you are testing a local checkout instead, reinstall the checkout:
+Version 1.5.0 requires aligned Pi runtime packages in `>=0.80.1 <0.85.0`, with exact packed-package validation at 0.80.1 and 0.84.1. It preserves Pi 0.84.1 OAuth refresh and model-catalog lifecycle compatibility while publishing identical release contents to npmjs as `pi-xai-oauth` and GitHub Packages as `@blockedpath/pi-xai-oauth`. See [CHANGELOG.md](CHANGELOG.md) for the complete release notes. Update the registry distribution you installed; if you are testing a local checkout instead, reinstall the checkout:
 
 ```bash
 pi remove npm:pi-xai-oauth && pi install .
@@ -917,18 +926,18 @@ Then, in the pi TUI:
 After login completes, from your shell run:
 
 ```bash
-pi -p --model grok-4.5 "Reply exactly: OAUTH_PROXY_OK"
+pi -p --model grok-4.6 "Reply exactly: OAUTH_PROXY_OK"
 pi -p --model grok-4.3 "Reply exactly: OAUTH_PROXY_OK"
 pi -p --model grok-4.20-0309-reasoning "Reply exactly: OAUTH_PROXY_OK"
 pi -p --model grok-build "Reply exactly: OAUTH_PROXY_OK"
 pi -p --model grok-composer-2.5-fast "Reply exactly: OAUTH_PROXY_OK"
 ```
 
-Expected passing result for this manual smoke test: each command returns `OAUTH_PROXY_OK` without an API-team credit or spending-limit error. Then verify the separate direct Responses helper in a Grok 4.5 TUI session:
+Expected passing result for this manual smoke test: each command returns `OAUTH_PROXY_OK` without an API-team credit or spending-limit error. Then verify the separate direct Responses helper in a Grok 4.6 TUI session:
 
 ```text
 /xai-tools enable xai_generate_text
-Use xai_generate_text with model grok-4.5 and prompt "Reply exactly: DIRECT_OAUTH_PROXY_OK".
+Use xai_generate_text with model grok-4.6 and prompt "Reply exactly: DIRECT_OAUTH_PROXY_OK".
 ```
 
 Do not enable `xai_generate_image` for this smoke test. Image generation intentionally uses the direct public Images endpoint, is billed/limited separately, and is not evidence for subscription-only Responses routing. Never print or record OAuth tokens while testing.
@@ -1047,4 +1056,4 @@ gh release create v1.4.2 --verify-tag --generate-notes
 PRs welcome! If you find issues or want to improve the OAuth flow, feel free to open an issue or pull request on [GitHub](https://github.com/BlockedPath/pi-xai-oauth).
 
 ---
-*Powered by Grok 4.5 — flagship reasoning, agentic coding, and the full xAI API.*
+*Powered by Grok 4.6 — flagship reasoning, agentic coding, and the full xAI API.*

--- a/bin/setup.js
+++ b/bin/setup.js
@@ -26,7 +26,7 @@ const NPM_SPEC = `npm:${PACKAGE_NAME}`;
 const BUNDLED_XAI_PROVIDER = "xai";
 /** Package-owned OAuth catalog/stream provider (optional). */
 const PACKAGE_OAUTH_PROVIDER = "xai-auth";
-const DEFAULT_XAI_MODEL = "grok-4.5";
+const DEFAULT_XAI_MODEL = "grok-4.6";
 const DEFAULT_THINKING_LEVEL = "high";
 const SETTINGS_PATH = path.join(os.homedir(), ".pi/agent/settings.json");
 

--- a/extensions/xai/catalog.ts
+++ b/extensions/xai/catalog.ts
@@ -250,9 +250,14 @@ function thinkingLevelMap(levels: ThinkingLevel[], modelId: string): XaiCatalogM
     else if (level === "max") map.max = "max";
     else map[level] = level;
   }
-  // Preserve pi-xai-oauth's existing Grok 4.5 compatibility: pi's minimal
-  // level is sent as xAI low when low is in the authenticated catalog.
-  if (modelId === "grok-4.5" && map.low === "low") map.minimal = "low";
+  // Preserve pi-xai-oauth's Grok 4.x compatibility: pi's minimal level is sent
+  // as xAI low when low is in the authenticated catalog.
+  if (
+    (modelId === "grok-4.5" || modelId === "grok-4.6") &&
+    map.low === "low"
+  ) {
+    map.minimal = "low";
+  }
   return map;
 }
 

--- a/extensions/xai/constants.ts
+++ b/extensions/xai/constants.ts
@@ -72,7 +72,7 @@ export function isXaiToolCompatibleProvider(
 ): provider is XaiToolCompatibleProviderId {
   return XAI_TOOL_COMPATIBLE_PROVIDER_IDS.some((providerId) => provider === providerId);
 }
-export const DEFAULT_XAI_MODEL = "grok-4.5";
+export const DEFAULT_XAI_MODEL = "grok-4.6";
 export const DEFAULT_XAI_IMAGE_MODEL = "grok-imagine-image-2.0";
 
 /** Private pi dispatch names mapped to the official Grok model-facing surface. */

--- a/extensions/xai/models.ts
+++ b/extensions/xai/models.ts
@@ -64,6 +64,34 @@ export const KNOWN_XAI_MODEL_METADATA: readonly XaiCatalogModel[] = [
     },
   },
   {
+    id: "grok-4.6",
+    name: "Grok 4.6",
+    apiBackend: "responses",
+    reasoning: true,
+    input: ["text", "image"],
+    inputProvenance: XaiModelInputProvenance.Known,
+    // Official docs/API pricing (standard tier, <200k prompt): $2/$0.50/$6 per 1M.
+    cost: { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 0 },
+    contextWindow: 500_000,
+    // xAI has not published a Grok 4.6-specific max output limit yet;
+    // keep the existing Grok Responses ceiling until official metadata is available.
+    maxTokens: 131_072,
+    thinkingLevelMap: {
+      off: null,
+      // Pi `minimal` maps onto xAI `low` (same compatibility used for Grok 4.5).
+      minimal: "low",
+      low: "low",
+      medium: "medium",
+      high: "high",
+      // Live `/models-v2` advertises `xhigh` for Grok 4.6.
+      xhigh: "xhigh",
+      // `max` is intentionally omitted rather than spelled out as null: Pi
+      // 0.80.1's ModelThinkingLevel has no `max` member, and Pi treats an
+      // absent key and an explicit null identically. Advertised levels are the
+      // same either way.
+    },
+  },
+  {
     id: "grok-4.3",
     name: "Grok 4.3",
     apiBackend: "responses",
@@ -396,6 +424,7 @@ export function grokSupportsReasoningEffort(modelId: string): boolean {
     normalized.startsWith("grok-3-mini") ||
     normalized.startsWith("grok-4.20-multi-agent") ||
     normalized.startsWith("grok-4.3") ||
-    normalized.startsWith("grok-4.5")
+    normalized.startsWith("grok-4.5") ||
+    normalized.startsWith("grok-4.6")
   );
 }

--- a/extensions/xai/tools/custom-tools.ts
+++ b/extensions/xai/tools/custom-tools.ts
@@ -65,7 +65,7 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
             type: "string",
             enum: ["none", "low", "medium", "high"],
             description:
-              "Reasoning effort. Defaults to high for grok-4.5 and medium for other models when omitted.",
+              "Reasoning effort. Defaults to high for grok-4.5/grok-4.6 and medium for other models when omitted.",
           },
           response_format: { type: "string", description: "Set to 'json' for JSON output" },
           previous_response_id: { type: "string", description: "Continue conversation" },
@@ -109,7 +109,12 @@ export function registerCustomXaiTools(pi: ExtensionAPI) {
           input,
         };
 
-        const effort = params.reasoning_effort || (normalizedXaiModelId(model) === "grok-4.5" ? "high" : "medium");
+        const normalizedModel = normalizedXaiModelId(model);
+        const effort =
+          params.reasoning_effort ||
+          (normalizedModel === "grok-4.5" || normalizedModel === "grok-4.6" || normalizedModel.startsWith("grok-4.6")
+            ? "high"
+            : "medium");
         if (grokSupportsReasoningEffort(model) && effort !== "none") {
           body.reasoning = { effort };
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-xai-oauth",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-xai-oauth",
-      "version": "1.4.3",
+      "version": "1.5.0",
       "license": "MIT",
       "bin": {
         "pi-xai-oauth": "bin/setup.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-xai-oauth",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "xAI OAuth provider with an authenticated account-specific Grok model catalog for pi",
   "keywords": [
     "pi-package",

--- a/tests/catalog/cache.test.ts
+++ b/tests/catalog/cache.test.ts
@@ -407,7 +407,7 @@ describe("catalog cache selection", () => {
       source: "curated-fallback",
       needsAuthenticatedRefresh: false,
     });
-    expect(result.models.map(({ id }) => id)).toEqual(["grok-4.5"]);
+    expect(result.models.map(({ id }) => id)).toEqual(["grok-4.6"]);
     expect(JSON.parse(await readFile(path, "utf8")).invalidated).toBe(true);
   });
 

--- a/tests/catalog/reasoning-parity.test.ts
+++ b/tests/catalog/reasoning-parity.test.ts
@@ -100,6 +100,22 @@ describe("built-in xai vs xai-auth reasoning parity", () => {
     }
   });
 
+  it("documents grok-4.6 known levels including authenticated xhigh", () => {
+    // Live `/models-v2` advertises low/medium/high/xhigh for Grok 4.6. xai-auth
+    // keeps Pi's `minimal` → xAI `low` mapping used for Grok 4.5.
+    expect(supportedLevels(known("grok-4.6"))).toEqual([
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+    expect(known("grok-4.6").thinkingLevelMap?.minimal).toBe("low");
+    expect(known("grok-4.6").thinkingLevelMap?.xhigh).toBe("xhigh");
+    expect(supportedLevels(known("grok-4.6"))).not.toContain("off");
+    expect(supportedLevels(known("grok-4.6"))).not.toContain("max");
+  });
+
   it("never advertises the API-key-only built-in grok-build-0.1 through xai-auth", () => {
     expect(XAI_MODELS["grok-build-0.1"]).toBeDefined();
     expect(KNOWN_XAI_MODEL_METADATA.map(({ id }) => id)).not.toContain(
@@ -185,5 +201,35 @@ describe("authenticated reasoning evidence bounds advertised levels", () => {
     // xAI's `max` canonicalizes to Pi's `xhigh`; `max` itself stays denied.
     expect(supportedLevels(extended)).toContain("xhigh");
     expect(supportedLevels(extended)).not.toContain("max");
+  });
+
+  it("maps authenticated grok-4.6 efforts including xhigh and minimal→low", () => {
+    const [grok46] = normalizeXaiCatalogPayload({
+      data: [
+        {
+          model: "grok-4.6",
+          name: "Grok 4.6",
+          api_backend: "responses",
+          context_window: 500_000,
+          supports_reasoning_effort: true,
+          reasoning_efforts: [
+            { value: "xhigh" },
+            { value: "high" },
+            { value: "medium" },
+            { value: "low" },
+          ],
+        },
+      ],
+    });
+    expect(grok46.id).toBe("grok-4.6");
+    expect(supportedLevels(grok46)).toEqual([
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+    expect(grok46.thinkingLevelMap?.minimal).toBe("low");
+    expect(grok46.thinkingLevelMap?.xhigh).toBe("xhigh");
   });
 });

--- a/tests/provider/credentials.test.ts
+++ b/tests/provider/credentials.test.ts
@@ -398,7 +398,7 @@ describe("credential resolution", () => {
       },
     });
     expect(runtimeOverride).toBeNull();
-    expect(getApiKeyAndHeaders).toHaveBeenCalledTimes(1);
+    expect(getApiKeyAndHeaders).toHaveBeenCalledTimes(2);
   });
   it.each([
     ["runtime override", { configured: true, source: "runtime" }],

--- a/tests/provider/models.test.ts
+++ b/tests/provider/models.test.ts
@@ -34,7 +34,33 @@ describe("model compatibility metadata", () => {
     expect(resolveXaiCanonicalModelId("grok-4.20")).toBe("grok-4.20-0309-reasoning");
     expect(resolveXaiCanonicalModelId("grok-4.20-multi-agent")).toBe("grok-4.20-multi-agent-0309");
     expect(resolveXaiCanonicalModelId("grok-4.5")).toBe("grok-4.5");
+    expect(resolveXaiCanonicalModelId("grok-4.6")).toBe("grok-4.6");
     expect(resolveXaiCanonicalModelId("unknown-model")).toBe("unknown-model");
+  });
+
+  it("curates Grok 4.6 as the offline default with xhigh reasoning metadata", () => {
+    const known = knownXaiModelMetadata("grok-4.6");
+    expect(known).toMatchObject({
+      id: "grok-4.6",
+      name: "Grok 4.6",
+      apiBackend: "responses",
+      reasoning: true,
+      input: ["text", "image"],
+      cost: { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 0 },
+      contextWindow: 500_000,
+      maxTokens: 131_072,
+    });
+    expect(known?.thinkingLevelMap).toMatchObject({
+      off: null,
+      minimal: "low",
+      low: "low",
+      medium: "medium",
+      high: "high",
+      xhigh: "xhigh",
+    });
+    expect(CURATED_FALLBACK_MODELS.map(({ id }) => id)).toEqual(["grok-4.6"]);
+    expect(grokSupportsReasoningEffort("grok-4.6")).toBe(true);
+    expect(grokSupportsReasoningEffort("xai-auth/GROK-4.6")).toBe(true);
   });
 
   it("expands only aliases of entitled models and preserves authenticated input", () => {

--- a/tests/setup/settings.test.ts
+++ b/tests/setup/settings.test.ts
@@ -97,7 +97,7 @@ describe("setup settings", () => {
       JSON.stringify({
         packages: [localXai, "npm:pi-xai-oauth"],
         defaultProvider: "xai-auth",
-        defaultModel: "grok-4.5",
+        defaultModel: "grok-4.6",
         defaultThinkingLevel: "high",
         unrelated: true,
       }),
@@ -107,7 +107,7 @@ describe("setup settings", () => {
     expect(value).toMatchObject({
       packages: ["npm:pi-xai-oauth"],
       defaultProvider: "xai-auth",
-      defaultModel: "grok-4.5",
+      defaultModel: "grok-4.6",
       defaultThinkingLevel: "high",
       unrelated: true,
     });
@@ -126,7 +126,7 @@ describe("setup settings", () => {
     expect(JSON.parse(await readFile(settingsPath, "utf8"))).toMatchObject({
       packages: ["npm:other", "npm:pi-xai-oauth"],
       defaultProvider: "xai",
-      defaultModel: "grok-4.5",
+      defaultModel: "grok-4.6",
       defaultThinkingLevel: "high",
     });
 
@@ -178,7 +178,7 @@ describe("setup settings", () => {
     setup.updateSettings(settingsPath);
     expect(JSON.parse(await readFile(settingsPath, "utf8"))).toMatchObject({
       defaultProvider: "xai-auth",
-      defaultModel: "grok-4.5",
+      defaultModel: "grok-4.6",
       defaultThinkingLevel: "high",
     });
   });

--- a/tests/tools/custom-tools.test.ts
+++ b/tests/tools/custom-tools.test.ts
@@ -144,6 +144,13 @@ describe("custom xAI tools", () => {
       reasoning: { effort: "high" },
     });
   });
+  it("uses high reasoning by default for Grok 4.6", async () => {
+    await run("xai_generate_text", { prompt: "hi", model: "grok-4.6" });
+    expect(requests.at(-1)?.body).toMatchObject({
+      model: "grok-4.6",
+      reasoning: { effort: "high" },
+    });
+  });
   it("omits reasoning for Composer and uses protected proxy metadata", async () => {
     await run("xai_generate_text", {
       prompt: "hi",


### PR DESCRIPTION
## Summary
- Add known metadata and catalog support for **Grok 4.6** (`grok-4.6`): 500K context, text+image, $2/$0.50/$6 pricing, reasoning `low`/`medium`/`high`/`xhigh`
- Promote `grok-4.6` to `DEFAULT_XAI_MODEL` and curated offline fallback (setup + permanent catalog-failure path)
- Keep **Grok 4.5** fully supported when entitled; map Pi `minimal` → xAI `low` for 4.6 (same as 4.5)
- Bump package to **1.5.0**

## Test plan
- [x] `npm run test:unit` (620/620)
- [x] Live endpoint check: `/models-v2` and `api.x.ai/v1/models` return `grok-4.6`
- [ ] CI on PR
- [ ] After merge: tag `v1.5.0` and publish GitHub Release to trigger npm + GitHub Packages workflow