### PR TITLE
fix: recover streamed encrypted reasoning mismatches

### DIFF
--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,20 +1,31 @@
-# Execution Progress — daily coverage pass 2026-08-20
+# Execution Progress — Issue #188
 
-**Branch:** `cursor/missing-test-coverage-d5a8`
+**Branch:** `feature/issue-188-triage`
 
 ## Completed
 
-- [x] Inspected recent merges and leftover gaps from the 2026-08-19 coverage pass (PR #186 still open on a different branch).
-- [x] Added catalog atomic-write failure tests: uncommitted previous-account cache is dropped, and leftover readable cache refuses remote success.
-- [x] Added browser callback CORS, 404, preflight-does-not-consume-state, and default-port fallback tests.
-- [x] Added custom-tool transport redaction, generate_image size/n validation, JSON format, and image URL/empty-result mapping.
-- [x] Added vision-routing `isEnabledFor`/`signalFor` grant scoping and video-download SSRF/timeout/MIME/byte-limit paths.
-- [x] Passed focused unit tests, `npm run typecheck`, `npm test` (642), and `npm run test:coverage` (89.79 / 83.42 / 92.61 / 93.12).
+- [x] Confirmed the clean feature branch before edits.
+- [x] Read AGENTS.md, README.md, setup/entrypoint code, scaffold state, and the full issue (no comments were present).
+- [x] Read the Responses, payload, and wire implementations plus reasoning replay, routing, streaming, and payload tests.
+- [x] Inspected Pi/pi-ai 0.84.2's real OpenAI Responses conversion and `response.failed` stream seam.
+- [x] Established the working diagnosis: streamed failures lose HTTP status and are generically redacted; canonical `xai-responses` history is not replayed through the temporary `openai-responses` delegate identity, while persisted delegate-tagged history is.
+- [x] Added deterministic real stream-seam regressions and proved both pre-fix failures.
+- [x] Implemented bounded `response.failed` mismatch classification with fixed redacted guidance and no immediate retry.
+- [x] Aligned canonical and persisted delegate-tagged history at the conversion seam while retaining exact provider/model replay checks.
+- [x] Made the next same-model turn omit rejected encrypted reasoning only, preserving visible conversation/tool history and leaving unrelated failures unchanged.
+- [x] Passed 62 focused Responses tests across recovery, routing, replay, streaming, and payload suites.
+- [x] Passed local LSP diagnostics and `npm run typecheck`.
+- [x] Passed `npm test`: compatibility policy, 627 unit tests, and the real Pi loader smoke.
+- [x] Passed `npm run compatibility:check`, including packed-manifest and registry/mirror policy checks.
+- [x] Found and fixed a Pi 0.80.1 compatibility gap where the delegate does not retain `rawStopReason: failed`; the classifier remains bounded by `invalid_request` plus `encrypted_content`.
+- [x] Passed exact packed boundaries for Pi/pi-ai 0.80.1 and 0.84.2, including each packed package's tests, loader smoke, and typecheck.
+- [x] Ran a live Herdr smoke against the worktree-only extension with authenticated `xai-auth`: Grok 4.6 completed a tool turn and same-model continuation, Grok 4.5 completed the switched-model turn, and Grok 4.6 completed the switch-back turn without a Responses failure.
+- [x] Reviewed and committed the final delta, pushed the feature branch, and opened PR #190.
 
 ## In Progress
 
-- [ ] Exact packed Pi boundary matrix.
+- [ ] Rebase PR #190 onto refreshed `main` and monitor CI/review.
 
 ## Next
 
-Commit, push, open PR, and post Slack summary. Remaining lower-priority gaps: `custom-tools.ts` edit/video generic catch branches, `vision-routing.ts` image-part normalization, `oauth.ts` leftover login-cancel lines.
+Resolve the scaffold-only rebase conflict, repush the rebased branch, and confirm PR #190 is mergeable.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -24,8 +24,9 @@
 
 ## In Progress
 
-- [ ] Rebase PR #190 onto refreshed `main` and monitor CI/review.
+- [x] Rebased PR #190 onto refreshed `main`, resolved the scaffold-only conflict, and repushed with force-with-lease.
+- [x] Confirmed PR #190 is approved and mergeable with policy, exact Pi 0.80.1/0.84.2, Socket, and CodeRabbit checks passing.
 
 ## Next
 
-Resolve the scaffold-only rebase conflict, repush the rebased branch, and confirm PR #190 is mergeable.
+PR #190 is ready for maintainer merge.

--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -26,6 +26,7 @@
 
 - [x] Rebased PR #190 onto refreshed `main`, resolved the scaffold-only conflict, and repushed with force-with-lease.
 - [x] Confirmed PR #190 is approved and mergeable with policy, exact Pi 0.80.1/0.84.2, Socket, and CodeRabbit checks passing.
+- [x] Addressed CodeRabbit's sole actionable review by expanding exported-function JSDoc without changing test helpers or runtime behavior.
 
 ## Next
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 
 ## Unreleased
 
+### Fixed
+
+- Classified encrypted-reasoning mismatches delivered through HTTP-200 `response.failed` streams, kept their details redacted and non-retryable, and made the next same-model turn recover by omitting only the rejected encrypted reasoning while preserving visible messages and tool results. Canonical and persisted delegate-tagged xAI history now follow the same replay and cross-model protections.
+
 ## 1.5.0 - 2026-08-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ On the pinned OAuth Responses route, requests default an absent `store` to `fals
 
 `store: false` disables server-side response storage, but it does **not** mean no local sensitive state. Complete encrypted reasoning items are stored in ordinary Pi session JSONL under Pi's normal permissions and retention. This package does not separately encrypt that file, copy reasoning into another cache, or protect it from the user or trusted local extensions.
 
-If xAI reports that encrypted reasoning is incompatible with the selected model, the request is not retried automatically. Start a clean session or turn and keep the same xAI model for subsequent replay.
+If xAI reports that encrypted reasoning is incompatible with the selected model, the rejected request is not retried automatically and the error remains fixed, redacted clean-session/turn guidance. A subsequent same-model turn omits the rejected encrypted reasoning chain while preserving visible conversation and tool-result history; switching targets retains the existing cross-model replay protection.
 
 ---
 

--- a/compatibility/grok-build-wire-protocol.md
+++ b/compatibility/grok-build-wire-protocol.md
@@ -24,7 +24,7 @@ The upstream sampler posts paths relative to a configured base URL. That does no
 These values have separate meanings and must not be conflated:
 
 | Value | Local policy |
-|---|---|
+| --- | --- |
 | `x-grok-client-identifier` | Always the truthful npm package name, `pi-xai-oauth`. |
 | `User-Agent` | Always `pi-xai-oauth/<package version>`. |
 | `x-grok-client-version` | The installed `pi-xai-oauth` package version. It is the only truthful controlled version available to this third-party client. |
@@ -37,7 +37,7 @@ The reviewed source treats `x-grok-client-version` as a proxy gate input, but it
 All listed headers are internally owned. Caller/model headers are scrubbed case-insensitively before the route contract is appended.
 
 | Request | Pinned route | Required contract | Explicit exclusions |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Browser authorization | `https://auth.x.ai/oauth2/authorize` | PKCE S256, state, nonce, pinned client ID/scopes/redirect | No bearer or CLI-proxy headers |
 | Device initiation | `https://auth.x.ai/oauth2/device/code` | JSON accept, form content type, truthful User-Agent, client version/surface | No bearer or CLI-proxy headers |
 | Browser/device/refresh token | `https://auth.x.ai/oauth2/token` | JSON accept, form content type, truthful User-Agent, client version/surface | No CLI-proxy headers; no response-body reflection |
@@ -94,11 +94,12 @@ Issue [#79](https://github.com/BlockedPath/pi-xai-oauth/issues/79) implements th
 - active, uncompacted multi-turn input keeps a stable serialized prefix;
 - Pi permits replay only when provider, API, and exact model match, and omits failed or aborted assistant turns;
 - API-key direct Responses, media, catalog, usage, auth, and non-Responses routes do not receive this package policy;
-- a proxy HTTP 400 containing the narrow `encrypted_content` marker produces fixed clean-session/model guidance, is redacted, and is not automatically retried.
+- a proxy HTTP 400 containing the narrow `encrypted_content` marker, or an HTTP-200 SSE `response.failed` carrying both `invalid_request` and that marker, produces fixed clean-session/model guidance, is redacted, and is not automatically retried;
+- after that fixed failure is retained in same-model history, the next request omits encrypted reasoning items from the rejected chain while preserving visible messages, function calls, tool results, and the `store:false` / encrypted-include policy; unrelated failures do not activate this omission.
 
 Encrypted content is ordinary local Pi session state. `store:false` disables server-side response storage but does not prevent Pi from writing the complete item to its session JSONL under normal permissions and retention. This package does not separately encrypt, duplicate, inspect, render, or log it. Compaction may intentionally replace older active context, and trusted local extensions or users with file access can inspect session state.
 
-Pi's delegated SSE error shape does not preserve an HTTP status for failures that arrive after a successful stream connection. The narrow HTTP 400 classifier therefore applies to initial Responses HTTP failures; later in-stream failures remain generic and redacted rather than being guessed from message text.
+Pi's delegated SSE error shape does not preserve an HTTP status for failures that arrive after a successful stream connection. The stream classifier is therefore separately bounded to a terminal `response.failed` result whose redacted delegate text contains both xAI's `invalid_request` code and the `encrypted_content` marker. Other streamed failures remain generic and redacted, and numeric status/retry wording is preserved when the delegate supplies it.
 
 ## Repeatable upstream review procedure
 

--- a/extensions/xai/constants.ts
+++ b/extensions/xai/constants.ts
@@ -8,7 +8,7 @@ export const XAI_OAUTH_TOKEN_URL = `${XAI_OAUTH_ISSUER}/oauth2/token`;
 export const XAI_OAUTH_JWKS_URL = `${XAI_OAUTH_ISSUER}/.well-known/jwks.json`;
 export const XAI_OAUTH_ID_TOKEN_ALGORITHM = "ES256";
 export const XAI_OAUTH_PKCE_METHOD = "S256";
-export const XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+export const XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"; // gitleaks:allow — public OAuth client identifier
 export const XAI_OAUTH_SCOPE =
   "openid profile email offline_access grok-cli:access api:access conversations:read conversations:write";
 export const XAI_OAUTH_REDIRECT_HOST = "127.0.0.1";

--- a/extensions/xai/constants.ts
+++ b/extensions/xai/constants.ts
@@ -15,25 +15,34 @@ export const XAI_OAUTH_REDIRECT_HOST = "127.0.0.1";
 export const XAI_OAUTH_REDIRECT_PORT = 56121;
 export const XAI_OAUTH_REDIRECT_PATH = "/callback";
 export const XAI_OAUTH_REFRESH_SKEW_MS = 2 * 60 * 1000;
-export const XAI_OAUTH_DEVICE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
+export const XAI_OAUTH_DEVICE_GRANT_TYPE =
+  "urn:ietf:params:oauth:grant-type:device_code";
 export const XAI_OAUTH_DEVICE_DEFAULT_INTERVAL_SECONDS = 5;
 export const XAI_OAUTH_DEVICE_MIN_INTERVAL_SECONDS = 1;
 export const XAI_OAUTH_DEVICE_SLOW_DOWN_SECONDS = 5;
 export const XAI_OAUTH_DEVICE_MAX_DURATION_MS = 15 * 60 * 1000;
 export const XAI_OAUTH_DEVICE_REQUEST_TIMEOUT_MS = 15 * 1000;
 export const XAI_OAUTH_DEVICE_MAX_RESPONSE_BYTES = 64 * 1024;
-export const XAI_OAUTH_DEVICE_VERIFICATION_ORIGINS = [XAI_OAUTH_ISSUER, "https://accounts.x.ai"] as const;
+export const XAI_OAUTH_DEVICE_VERIFICATION_ORIGINS = [
+  XAI_OAUTH_ISSUER,
+  "https://accounts.x.ai",
+] as const;
 
 export const XAI_API_BASE_URL = "https://api.x.ai/v1";
 export const XAI_CLI_BASE_URL = "https://cli-chat-proxy.grok.com/v1";
 export const XAI_RESPONSES_URL = "https://api.x.ai/v1/responses";
-export const XAI_CLI_RESPONSES_URL = "https://cli-chat-proxy.grok.com/v1/responses";
-export const XAI_CLI_MODELS_URL = "https://cli-chat-proxy.grok.com/v1/models-v2";
+export const XAI_CLI_RESPONSES_URL =
+  "https://cli-chat-proxy.grok.com/v1/responses";
+export const XAI_CLI_MODELS_URL =
+  "https://cli-chat-proxy.grok.com/v1/models-v2";
 export const XAI_CLI_USER_URL = "https://cli-chat-proxy.grok.com/v1/user";
-export const XAI_CLI_BILLING_URL = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
-export const XAI_IMAGES_GENERATIONS_URL = "https://api.x.ai/v1/images/generations";
+export const XAI_CLI_BILLING_URL =
+  "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
+export const XAI_IMAGES_GENERATIONS_URL =
+  "https://api.x.ai/v1/images/generations";
 export const XAI_IMAGES_EDITS_URL = "https://api.x.ai/v1/images/edits";
-export const XAI_VIDEOS_GENERATIONS_URL = "https://api.x.ai/v1/videos/generations";
+export const XAI_VIDEOS_GENERATIONS_URL =
+  "https://api.x.ai/v1/videos/generations";
 export const XAI_VIDEOS_STATUS_PREFIX = "https://api.x.ai/v1/videos/";
 
 export const XAI_MODEL_CATALOG_CACHE_SCHEMA = 2;
@@ -56,7 +65,8 @@ export const XAI_PACKAGE_VERSION = packageMetadata.version;
 export const XAI_PROXY_CLIENT_VERSION = XAI_PACKAGE_VERSION;
 export const XAI_CLIENT_VERSION = XAI_PROXY_CLIENT_VERSION;
 export const XAI_USER_AGENT = `${XAI_CLIENT_IDENTIFIER}/${XAI_PACKAGE_VERSION}`;
-export const XAI_GROK_BUILD_REVIEWED_REVISION = "b189869b7755d2b482969acf6c92da3ecfeffd36";
+export const XAI_GROK_BUILD_REVIEWED_REVISION =
+  "b189869b7755d2b482969acf6c92da3ecfeffd36";
 export const XAI_PROVIDER_ID = "xai-auth";
 export const XAI_BUNDLED_PROVIDER_ID = "xai";
 export const XAI_TOOL_COMPATIBLE_PROVIDER_IDS = [
@@ -64,13 +74,16 @@ export const XAI_TOOL_COMPATIBLE_PROVIDER_IDS = [
   XAI_BUNDLED_PROVIDER_ID,
 ] as const;
 
-export type XaiToolCompatibleProviderId = (typeof XAI_TOOL_COMPATIBLE_PROVIDER_IDS)[number];
+export type XaiToolCompatibleProviderId =
+  (typeof XAI_TOOL_COMPATIBLE_PROVIDER_IDS)[number];
 
 /** Return whether a provider can use this package's opt-in network tools. */
 export function isXaiToolCompatibleProvider(
   provider: unknown,
 ): provider is XaiToolCompatibleProviderId {
-  return XAI_TOOL_COMPATIBLE_PROVIDER_IDS.some((providerId) => provider === providerId);
+  return XAI_TOOL_COMPATIBLE_PROVIDER_IDS.some(
+    (providerId) => provider === providerId,
+  );
 }
 export const DEFAULT_XAI_MODEL = "grok-4.6";
 export const DEFAULT_XAI_IMAGE_MODEL = "grok-imagine-image-2.0";
@@ -101,7 +114,10 @@ export const XAI_GROK_NATIVE_WEB_SEARCH_NAME = "web_search";
 export const XAI_GROK_NATIVE_WEB_SEARCH_DISPATCH_NAME = "xai_grok_web_search";
 
 /** All public Grok-native model-facing tool names, including opt-in web search. */
-export const XAI_GROK_NATIVE_TOOL_NAMES = Object.values(XAI_GROK_NATIVE_TOOL_NAME_MAP);
+export const XAI_GROK_NATIVE_TOOL_NAMES = Object.values(
+  XAI_GROK_NATIVE_TOOL_NAME_MAP,
+);
 
 export const XAI_GROK_CLI_AUTH_SCOPE_KEY = `${XAI_OAUTH_ISSUER}::${XAI_OAUTH_CLIENT_ID}`;
-export const XAI_GROK_CLI_LEGACY_AUTH_SCOPE_KEY = "https://accounts.x.ai/sign-in";
+export const XAI_GROK_CLI_LEGACY_AUTH_SCOPE_KEY =
+  "https://accounts.x.ai/sign-in";

--- a/extensions/xai/responses.ts
+++ b/extensions/xai/responses.ts
@@ -82,13 +82,19 @@ function acquireRedirectGuard(url: string): () => void {
         guarded ? { ...init, redirect: "error" } : init,
       );
       if (!guarded || response.ok) return response;
-      const requestSignal = init?.signal ?? (input instanceof Request ? input.signal : undefined);
-      const error = await xaiHttpErrorFromResponse(response, url, requestSignal);
-      const marker = error.code === "encrypted-content-mismatch"
-        ? "encrypted_content"
-        : error.code === "proxy-version-gate"
-          ? "update_required"
-          : "request failed";
+      const requestSignal =
+        init?.signal ?? (input instanceof Request ? input.signal : undefined);
+      const error = await xaiHttpErrorFromResponse(
+        response,
+        url,
+        requestSignal,
+      );
+      const marker =
+        error.code === "encrypted-content-mismatch"
+          ? "encrypted_content"
+          : error.code === "proxy-version-gate"
+            ? "update_required"
+            : "request failed";
       return new Response(JSON.stringify({ error: { message: marker } }), {
         status: response.status,
         statusText: response.statusText,
@@ -137,10 +143,12 @@ function isReplayCompatibleXaiMessage(
 ): value is AssistantMessage {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const message = value as Record<string, unknown>;
-  return message.role === "assistant" &&
+  return (
+    message.role === "assistant" &&
     message.provider === model.provider &&
     message.model === selectedModelId &&
-    (message.api === model.api || message.api === XAI_RESPONSES_DELEGATE_API);
+    (message.api === model.api || message.api === XAI_RESPONSES_DELEGATE_API)
+  );
 }
 
 function prepareXaiDelegateContext(
@@ -153,7 +161,8 @@ function prepareXaiDelegateContext(
     if (
       !isReplayCompatibleXaiMessage(message, model, selectedModelId) ||
       message.api === XAI_RESPONSES_DELEGATE_API
-    ) return message;
+    )
+      return message;
     changed = true;
     return { ...message, api: XAI_RESPONSES_DELEGATE_API };
   });
@@ -167,10 +176,13 @@ function shouldOmitRejectedEncryptedReasoning(
 ): boolean {
   for (let index = context.messages.length - 1; index >= 0; index--) {
     const message = context.messages[index];
-    if (!message || typeof message !== "object" || message.role !== "assistant") continue;
-    return isReplayCompatibleXaiMessage(message, model, selectedModelId) &&
+    if (!message || typeof message !== "object" || message.role !== "assistant")
+      continue;
+    return (
+      isReplayCompatibleXaiMessage(message, model, selectedModelId) &&
       message.stopReason === "error" &&
-      message.errorMessage === XAI_ENCRYPTED_CONTENT_MISMATCH_MESSAGE;
+      message.errorMessage === XAI_ENCRYPTED_CONTENT_MISMATCH_MESSAGE
+    );
   }
   return false;
 }
@@ -180,11 +192,14 @@ function omitRejectedEncryptedReasoning(
 ): Record<string, unknown> {
   if (!Array.isArray(payload.input)) return payload;
   const input = payload.input.filter((value) => {
-    if (!value || typeof value !== "object" || Array.isArray(value)) return true;
+    if (!value || typeof value !== "object" || Array.isArray(value))
+      return true;
     const item = value as Record<string, unknown>;
     return item.type !== "reasoning" || !("encrypted_content" in item);
   });
-  return input.length === payload.input.length ? payload : { ...payload, input };
+  return input.length === payload.input.length
+    ? payload
+    : { ...payload, input };
 }
 
 function restoreXaiMessageIdentity<T>(value: T, model: Model<Api>): T {
@@ -208,18 +223,27 @@ function normalizeXaiStreamEvent(
     restoreXaiMessageIdentity(event.partial, model),
     grokNativeToolRoutes,
   );
-  const toolCall = internalizeGrokNativeToolCalls(event.toolCall, grokNativeToolRoutes);
+  const toolCall = internalizeGrokNativeToolCalls(
+    event.toolCall,
+    grokNativeToolRoutes,
+  );
   const message = internalizeGrokNativeToolCalls(
     restoreXaiMessageIdentity(event.message, model),
     grokNativeToolRoutes,
   );
   const restoredError = restoreXaiMessageIdentity(event.error, model);
   const internalized =
-    partial !== event.partial || toolCall !== event.toolCall ||
-      message !== event.message || restoredError !== event.error
+    partial !== event.partial ||
+    toolCall !== event.toolCall ||
+    message !== event.message ||
+    restoredError !== event.error
       ? { ...event, partial, toolCall, message, error: restoredError }
       : event;
-  if (internalized.type !== "error" || !internalized.error || typeof internalized.error !== "object") {
+  if (
+    internalized.type !== "error" ||
+    !internalized.error ||
+    typeof internalized.error !== "object"
+  ) {
     return internalized;
   }
   const error = internalized.error as Record<string, unknown>;
@@ -234,23 +258,25 @@ function normalizeXaiStreamEvent(
         error.errorMessage === XAI_PAYLOAD_CANONICALIZATION_ERROR ||
         error.errorMessage === XAI_VISION_DESCRIPTION_ERROR ||
         error.errorMessage === XAI_VISION_ROUTING_INVALIDATED_ERROR
-        ? error.errorMessage
-        : safeXaiTransportErrorMessage(
-            error.errorMessage,
-            typeof error.status === "number" ? error.status : undefined,
-            "responses-proxy",
-            // Pi 0.84 preserves `response.failed` here; the supported 0.80
-            // boundary does not. In both cases the additional classifier still
-            // requires xAI's invalid_request code plus encrypted-content marker.
-            error.rawStopReason === "failed" || error.rawStopReason === undefined,
-          ),
+          ? error.errorMessage
+          : safeXaiTransportErrorMessage(
+              error.errorMessage,
+              typeof error.status === "number" ? error.status : undefined,
+              "responses-proxy",
+              // Pi 0.84 preserves `response.failed` here; the supported 0.80
+              // boundary does not. In both cases the additional classifier still
+              // requires xAI's invalid_request code plus encrypted-content marker.
+              error.rawStopReason === "failed" ||
+                error.rawStopReason === undefined,
+            ),
     },
   };
 }
 
 function createForwardingAssistantStream() {
   const queue: AssistantStreamEvent[] = [];
-  const waiting: Array<(result: IteratorResult<AssistantStreamEvent>) => void> = [];
+  const waiting: Array<(result: IteratorResult<AssistantStreamEvent>) => void> =
+    [];
   let done = false;
   let resolveResult: (result: any) => void = () => {};
   const resultPromise = new Promise<any>((resolve) => {
@@ -292,7 +318,9 @@ function createForwardingAssistantStream() {
         } else if (done) {
           return;
         } else {
-          const result = await new Promise<IteratorResult<AssistantStreamEvent>>((resolve) => waiting.push(resolve));
+          const result = await new Promise<
+            IteratorResult<AssistantStreamEvent>
+          >((resolve) => waiting.push(resolve));
           if (result.done) return;
           yield result.value;
         }
@@ -317,7 +345,9 @@ function streamErrorMessage(model: Model<Api>, error: unknown) {
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
     },
     stopReason: "error",
-    errorMessage: normalizeXaiErrorText(error instanceof Error ? error.message : String(error)),
+    errorMessage: normalizeXaiErrorText(
+      error instanceof Error ? error.message : String(error),
+    ),
     timestamp: Date.now(),
   };
 }
@@ -385,10 +415,15 @@ function pinXaiPayloadModel(modelId: string, payload: unknown): void {
 }
 
 /** Assert the current authenticated entitlement permits the final Responses payload. */
-export function assertXaiRuntimeModelAcceptsPayload(modelId: string, payload: unknown): void {
+export function assertXaiRuntimeModelAcceptsPayload(
+  modelId: string,
+  payload: unknown,
+): void {
   const runtimeModel = getXaiRuntimeModel(modelId);
   if (!runtimeModel) {
-    throw new Error(`xAI OAuth model ${modelId} is not present in the authenticated model catalog`);
+    throw new Error(
+      `xAI OAuth model ${modelId} is not present in the authenticated model catalog`,
+    );
   }
   if (
     isAuthenticatedXaiInputProvenance(runtimeModel.inputProvenance) &&
@@ -424,39 +459,53 @@ export async function createXaiResponse(
   maxResponseBytes?: number,
 ): Promise<any> {
   const canonicalBody = canonicalizeXaiResponsesPayload(body);
-  const requestedModel = typeof canonicalBody.model === "string" ? canonicalBody.model : undefined;
+  const requestedModel =
+    typeof canonicalBody.model === "string" ? canonicalBody.model : undefined;
   const model = xaiModelForRequest(requestedModel, credential.kind);
-  const usesPackageCatalog = credential.kind === "oauth-session"
-    && credential.catalogScope !== "host";
-  const runtimeModel = usesPackageCatalog ? getXaiRuntimeModel(model.id) : undefined;
+  const usesPackageCatalog =
+    credential.kind === "oauth-session" && credential.catalogScope !== "host";
+  const runtimeModel = usesPackageCatalog
+    ? getXaiRuntimeModel(model.id)
+    : undefined;
   if (usesPackageCatalog && !runtimeModel) {
-    throw new Error(`xAI OAuth model ${model.id} is not present in the authenticated model catalog`);
+    throw new Error(
+      `xAI OAuth model ${model.id} is not present in the authenticated model catalog`,
+    );
   }
   const selectedModelId = runtimeModel?.id ?? model.id;
-  const requestModel = selectedModelId === model.id ? model : { ...model, id: selectedModelId };
+  const requestModel =
+    selectedModelId === model.id ? model : { ...model, id: selectedModelId };
   const route = resolveXaiRoute(credential.kind, "responses");
   if (usesPackageCatalog) {
     assertXaiRuntimeModelAcceptsPayload(selectedModelId, canonicalBody);
   }
   const rewritten = rewriteXaiResponsesPayload(canonicalBody, requestModel);
-  const policyPayload = credential.kind === "oauth-session"
-    ? applyXaiOAuthResponsesPolicy(rewritten as Record<string, unknown>)
-    : rewritten;
+  const policyPayload =
+    credential.kind === "oauth-session"
+      ? applyXaiOAuthResponsesPolicy(rewritten as Record<string, unknown>)
+      : rewritten;
   pinXaiPayloadModel(selectedModelId, policyPayload);
   if (usesPackageCatalog) {
     assertXaiRuntimeModelAcceptsPayload(selectedModelId, policyPayload);
   }
-  const payload = (await compactXaiInlineImages(policyPayload)) as Record<string, unknown>;
+  const payload = (await compactXaiInlineImages(policyPayload)) as Record<
+    string,
+    unknown
+  >;
   if (usesPackageCatalog) {
     assertXaiRuntimeModelAcceptsPayload(selectedModelId, payload);
   }
   beforeSend?.();
   const requestSessionId = randomUUID();
-  const requestHeaders = xaiProxyRequestHeaders(selectedModelId, credential.kind, {
-    conversationId: requestSessionId,
-    requestId: randomUUID(),
-    sessionId: requestSessionId,
-  });
+  const requestHeaders = xaiProxyRequestHeaders(
+    selectedModelId,
+    credential.kind,
+    {
+      conversationId: requestSessionId,
+      requestId: randomUUID(),
+      sessionId: requestSessionId,
+    },
+  );
   return postXaiJson(
     credential.token,
     route.url,
@@ -498,7 +547,9 @@ export function streamSimpleXaiResponses(
     const stream = createForwardingAssistantStream();
     const message = streamErrorMessage(
       model,
-      new Error(`xAI OAuth model ${model.id} is not present in the authenticated model catalog`),
+      new Error(
+        `xAI OAuth model ${model.id} is not present in the authenticated model catalog`,
+      ),
     );
     stream.push({ type: "error", reason: "error", error: message });
     stream.end(message);
@@ -531,24 +582,34 @@ export function streamSimpleXaiResponses(
   // model.input lacks "image". Capture the exact enabled grant so a reset and
   // re-enable cannot authorize an already-started request under a new grant.
   const visionGrantSignal = visionRouting?.signalFor(selectedModelId);
-  const visionEnabled = visionGrantSignal !== undefined && !visionGrantSignal.aborted;
+  const visionEnabled =
+    visionGrantSignal !== undefined && !visionGrantSignal.aborted;
   const modelInputs = [...model.input];
   const streamModel = {
     ...model,
     id: selectedModelId,
     baseUrl: route.baseUrl,
-    headers: scrubXaiReservedHeaders((model as any).headers) as Record<string, string>,
+    headers: scrubXaiReservedHeaders((model as any).headers) as Record<
+      string,
+      string
+    >,
   };
   // Keep the xAI stream model for routing/payload rewriting, but delegate with
   // the API tag expected by pi's OpenAI Responses transport.
   const openAIResponsesModel = {
     ...streamModel,
     ...(visionEnabled && !modelInputs.includes("image")
-      ? { input: [...modelInputs.filter((value) => value !== "image"), "image"] }
+      ? {
+          input: [...modelInputs.filter((value) => value !== "image"), "image"],
+        }
       : {}),
     api: "openai-responses" as const,
   };
-  const delegateContext = prepareXaiDelegateContext(context, model, selectedModelId);
+  const delegateContext = prepareXaiDelegateContext(
+    context,
+    model,
+    selectedModelId,
+  );
   const omitRejectedReasoning = shouldOmitRejectedEncryptedReasoning(
     context,
     model,
@@ -556,15 +617,20 @@ export function streamSimpleXaiResponses(
   );
   // The OAuth bearer comes only from options.apiKey. Required proxy metadata
   // is merged last so callers cannot spoof authentication or attribution.
-  const headers = { ...scrubXaiReservedHeaders(options?.headers), ...requestHeaders };
+  const headers = {
+    ...scrubXaiReservedHeaders(options?.headers),
+    ...requestHeaders,
+  };
   const routedSourceController = new AbortController();
   const transportSignal = AbortSignal.any([
     routedSourceController.signal,
     ...(options?.signal ? [options.signal] : []),
   ]);
   const planForCapturedVisionGrant = (payload: unknown) => {
-    if (!xaiResponsesPayloadContainsImage(payload) || !visionGrantSignal) return undefined;
-    if (visionGrantSignal.aborted) throw new Error(XAI_VISION_ROUTING_INVALIDATED_ERROR);
+    if (!xaiResponsesPayloadContainsImage(payload) || !visionGrantSignal)
+      return undefined;
+    if (visionGrantSignal.aborted)
+      throw new Error(XAI_VISION_ROUTING_INVALIDATED_ERROR);
     const plan = visionRouting?.plan(selectedModelId, payload);
     if (!plan || plan.signal !== visionGrantSignal) {
       throw new Error(XAI_VISION_ROUTING_INVALIDATED_ERROR);
@@ -598,17 +664,30 @@ export function streamSimpleXaiResponses(
           maxRetries: 0,
           async onPayload(payload) {
             const canonicalInput = canonicalizeXaiResponsesPayload(payload);
-            if (xaiResponsesPayloadContainsLocalImageReference(canonicalInput)) {
+            if (
+              xaiResponsesPayloadContainsLocalImageReference(canonicalInput)
+            ) {
               const inputPlan = planForCapturedVisionGrant(canonicalInput);
-              if (!inputPlan) assertXaiRuntimeModelAcceptsPayload(selectedModelId, canonicalInput);
+              if (!inputPlan)
+                assertXaiRuntimeModelAcceptsPayload(
+                  selectedModelId,
+                  canonicalInput,
+                );
             }
-            const rewritten = rewriteXaiResponsesPayload(canonicalInput, streamModel, {
-              ...options,
-              sessionId: sessionId || routingSessionId,
-              preserveCurrentToolImages: visionEnabled,
-              omitConsumedVisionImages: visionEnabled,
-            });
-            const userRewritten = await options?.onPayload?.(rewritten, streamModel);
+            const rewritten = rewriteXaiResponsesPayload(
+              canonicalInput,
+              streamModel,
+              {
+                ...options,
+                sessionId: sessionId || routingSessionId,
+                preserveCurrentToolImages: visionEnabled,
+                omitConsumedVisionImages: visionEnabled,
+              },
+            );
+            const userRewritten = await options?.onPayload?.(
+              rewritten,
+              streamModel,
+            );
             const canonicalPayload = canonicalizeXaiResponsesPayload(
               userRewritten === undefined ? rewritten : userRewritten,
             );
@@ -621,29 +700,48 @@ export function streamSimpleXaiResponses(
             const replaySafePayload = omitRejectedReasoning
               ? omitRejectedEncryptedReasoning(visionSafePayload)
               : visionSafePayload;
-            const policyPayload = applyXaiOAuthResponsesPolicy(replaySafePayload);
-            grokNativeToolRoutes = xaiPayloadGrokNativeToolRoutes(policyPayload);
+            const policyPayload =
+              applyXaiOAuthResponsesPolicy(replaySafePayload);
+            grokNativeToolRoutes =
+              xaiPayloadGrokNativeToolRoutes(policyPayload);
             let exposedPayload = exposeGrokNativeToolNames(policyPayload);
             pinXaiPayloadModel(selectedModelId, exposedPayload);
 
             const plan = planForCapturedVisionGrant(exposedPayload);
             if (plan) {
-              const compactedVisionPayload = await compactXaiInlineImages(exposedPayload) as Record<string, unknown>;
-              if (!visionRouting?.validate(plan)) throw new Error(XAI_VISION_ROUTING_INVALIDATED_ERROR);
+              const compactedVisionPayload = (await compactXaiInlineImages(
+                exposedPayload,
+              )) as Record<string, unknown>;
+              if (!visionRouting?.validate(plan))
+                throw new Error(XAI_VISION_ROUTING_INVALIDATED_ERROR);
               if (typeof options?.apiKey !== "string" || !options.apiKey) {
-                throw new Error("xAI vision routing could not resolve the current OAuth credential; no xAI request was sent");
+                throw new Error(
+                  "xAI vision routing could not resolve the current OAuth credential; no xAI request was sent",
+                );
               }
               const response = await createXaiResponse(
                 { kind: "oauth-session", token: options.apiKey },
-                buildXaiVisionDescriptionPayload(compactedVisionPayload, plan.targetModelId) as Record<string, unknown>,
-                AbortSignal.any([plan.signal, ...(options.signal ? [options.signal] : [])]),
+                buildXaiVisionDescriptionPayload(
+                  compactedVisionPayload,
+                  plan.targetModelId,
+                ) as Record<string, unknown>,
+                AbortSignal.any([
+                  plan.signal,
+                  ...(options.signal ? [options.signal] : []),
+                ]),
                 () => {
-                  if (!visionRouting?.validate(plan)) throw new Error(XAI_VISION_ROUTING_INVALIDATED_ERROR);
+                  if (!visionRouting?.validate(plan))
+                    throw new Error(XAI_VISION_ROUTING_INVALIDATED_ERROR);
                 },
                 256 * 1024,
               );
-              if (!visionRouting?.validate(plan)) throw new Error(XAI_VISION_ROUTING_INVALIDATED_ERROR);
-              plan.signal.addEventListener("abort", () => routedSourceController.abort(), { once: true });
+              if (!visionRouting?.validate(plan))
+                throw new Error(XAI_VISION_ROUTING_INVALIDATED_ERROR);
+              plan.signal.addEventListener(
+                "abort",
+                () => routedSourceController.abort(),
+                { once: true },
+              );
               if (plan.signal.aborted) routedSourceController.abort();
               const description = extractStrictResponsesText(response).trim();
               if (!description) throw new Error(XAI_VISION_DESCRIPTION_ERROR);
@@ -654,7 +752,10 @@ export function streamSimpleXaiResponses(
               pinXaiPayloadModel(selectedModelId, exposedPayload);
             }
 
-            assertXaiRuntimeModelAcceptsPayload(selectedModelId, exposedPayload);
+            assertXaiRuntimeModelAcceptsPayload(
+              selectedModelId,
+              exposedPayload,
+            );
             const finalPayload = await compactXaiInlineImages(exposedPayload);
             assertXaiRuntimeModelAcceptsPayload(selectedModelId, finalPayload);
             return finalPayload;
@@ -662,19 +763,26 @@ export function streamSimpleXaiResponses(
         },
       );
       for await (const event of inner as AsyncIterable<AssistantStreamEvent>) {
-        if (event.type === "done" || event.type === "error") releaseRedirectGuard();
-        stream.push(normalizeXaiStreamEvent(event, grokNativeToolRoutes, model));
+        if (event.type === "done" || event.type === "error")
+          releaseRedirectGuard();
+        stream.push(
+          normalizeXaiStreamEvent(event, grokNativeToolRoutes, model),
+        );
       }
       releaseRedirectGuard();
       stream.end();
     } catch (error) {
       releaseRedirectGuard();
-      const safeError = error instanceof Error && (
-          /Image file does not exist or is not a valid URL:/.test(error.message) ||
-          /\b(?:EACCES|EPERM|EISDIR|ENOENT):\b/.test(error.message)
-        )
-        ? new Error("xAI image input could not be safely resolved; no xAI request was sent")
-        : error;
+      const safeError =
+        error instanceof Error &&
+        (/Image file does not exist or is not a valid URL:/.test(
+          error.message,
+        ) ||
+          /\b(?:EACCES|EPERM|EISDIR|ENOENT):\b/.test(error.message))
+          ? new Error(
+              "xAI image input could not be safely resolved; no xAI request was sent",
+            )
+          : error;
       const message = streamErrorMessage(model, safeError);
       stream.push({ type: "error", reason: "error", error: message });
       stream.end(message);

--- a/extensions/xai/responses.ts
+++ b/extensions/xai/responses.ts
@@ -322,7 +322,19 @@ function streamErrorMessage(model: Model<Api>, error: unknown) {
   };
 }
 
-/** POST a JSON body to an xAI endpoint with bearer authentication. */
+/**
+ * POST a JSON body to a pinned xAI endpoint with protected bearer headers.
+ *
+ * @param authToken OAuth session token or API key selected by the caller's route policy.
+ * @param url Internally selected xAI endpoint; redirects are always rejected.
+ * @param body Canonical JSON-compatible request body.
+ * @param signal Optional cancellation signal forwarded to fetch and bounded body reads.
+ * @param contractHeaders Approved internally owned proxy metadata.
+ * @param maxResponseBytes Optional response bound used by strict auxiliary Responses calls.
+ * @returns The parsed successful JSON response.
+ * @throws {XaiHttpError} For non-success HTTP responses, with only safe route/status detail.
+ * @throws {Error} When a bounded auxiliary response is oversized or malformed.
+ */
 export async function postXaiJson(
   authToken: string,
   url: string,
@@ -389,7 +401,21 @@ export function assertXaiRuntimeModelAcceptsPayload(modelId: string, payload: un
   }
 }
 
-/** Create one xAI Responses result using explicit credential-aware routing. */
+/**
+ * Create one xAI Responses result using explicit credential-aware routing.
+ *
+ * OAuth requests receive the final `store: false` and encrypted-reasoning
+ * include policy after canonicalization, model pinning, entitlement checks,
+ * and inline-image compaction; API-key requests retain their separate route.
+ *
+ * @param credential Explicit OAuth-session or API-key credential and catalog scope.
+ * @param body Caller Responses body, canonicalized before policy checks or transport.
+ * @param signal Optional cancellation signal for transport and bounded response reads.
+ * @param beforeSend Optional final guard invoked after local validation and before network I/O.
+ * @param maxResponseBytes Optional strict response-size bound for auxiliary calls.
+ * @returns The parsed successful Responses JSON result.
+ * @throws {Error} When canonicalization, entitlement, payload policy, or transport validation fails.
+ */
 export async function createXaiResponse(
   credential: XaiCredential,
   body: Record<string, unknown>,
@@ -450,11 +476,15 @@ export async function createXaiResponse(
  * Returned events are forwarded through an assistant stream exposing async
  * iteration and `result()`. Delegate load or stream failures are converted
  * into terminal error events with xAI provider metadata instead of escaping
- * as unstructured promise failures.
+ * as unstructured promise failures. Canonical and persisted delegate-tagged
+ * same-model history are aligned only for internal conversion; after a fixed
+ * encrypted-reasoning mismatch, the next same-model request omits rejected
+ * encrypted reasoning while retaining visible and tool-result history.
  *
  * @param model xAI provider model selected by pi.
  * @param context Conversation messages and tool context to stream.
  * @param options Simple stream options, including OAuth token, session ID, cancellation, and payload hooks.
+ * @param visionRouting Optional session-scoped controller for explicit text-only model routing.
  * @returns A forwarding assistant stream compatible with pi's async iterator and `result()` contract.
  */
 export function streamSimpleXaiResponses(

--- a/extensions/xai/responses.ts
+++ b/extensions/xai/responses.ts
@@ -1,4 +1,10 @@
-import type { Api, Context, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
+import type {
+  Api,
+  AssistantMessage,
+  Context,
+  Model,
+  SimpleStreamOptions,
+} from "@earendil-works/pi-ai";
 import { openAIResponsesApi } from "@earendil-works/pi-ai/compat";
 import { randomUUID } from "crypto";
 import { readBoundedResponseText } from "./bounded-body";
@@ -34,12 +40,21 @@ import {
 import {
   safeXaiTransportErrorMessage,
   scrubXaiReservedHeaders,
+  XAI_ENCRYPTED_CONTENT_MISMATCH_MESSAGE,
   xaiHttpErrorFromResponse,
   xaiJsonPostHeaders,
   xaiProxyRequestHeaders,
 } from "./wire";
 
-type AssistantStreamEvent = Record<string, any>;
+interface AssistantStreamEvent {
+  type: string;
+  partial?: any;
+  toolCall?: any;
+  message?: any;
+  error?: any;
+  reason?: string;
+  [key: string]: unknown;
+}
 
 const streamSimpleOpenAIResponses = openAIResponsesApi().streamSimple;
 const SAFE_TEXT_ONLY_ERROR_PATTERN =
@@ -113,7 +128,66 @@ function normalizeXaiErrorText(value: string): string {
     : value;
 }
 
-function restoreXaiMessageIdentity(value: unknown, model: Model<Api>): unknown {
+const XAI_RESPONSES_DELEGATE_API = "openai-responses";
+
+function isReplayCompatibleXaiMessage(
+  value: unknown,
+  model: Model<Api>,
+  selectedModelId: string,
+): value is AssistantMessage {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const message = value as Record<string, unknown>;
+  return message.role === "assistant" &&
+    message.provider === model.provider &&
+    message.model === selectedModelId &&
+    (message.api === model.api || message.api === XAI_RESPONSES_DELEGATE_API);
+}
+
+function prepareXaiDelegateContext(
+  context: Context,
+  model: Model<Api>,
+  selectedModelId: string,
+): Context {
+  let changed = false;
+  const messages = context.messages.map((message) => {
+    if (
+      !isReplayCompatibleXaiMessage(message, model, selectedModelId) ||
+      message.api === XAI_RESPONSES_DELEGATE_API
+    ) return message;
+    changed = true;
+    return { ...message, api: XAI_RESPONSES_DELEGATE_API };
+  });
+  return changed ? { ...context, messages } : context;
+}
+
+function shouldOmitRejectedEncryptedReasoning(
+  context: Context,
+  model: Model<Api>,
+  selectedModelId: string,
+): boolean {
+  for (let index = context.messages.length - 1; index >= 0; index--) {
+    const message = context.messages[index];
+    if (!message || typeof message !== "object" || message.role !== "assistant") continue;
+    return isReplayCompatibleXaiMessage(message, model, selectedModelId) &&
+      message.stopReason === "error" &&
+      message.errorMessage === XAI_ENCRYPTED_CONTENT_MISMATCH_MESSAGE;
+  }
+  return false;
+}
+
+function omitRejectedEncryptedReasoning(
+  payload: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!Array.isArray(payload.input)) return payload;
+  const input = payload.input.filter((value) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return true;
+    const item = value as Record<string, unknown>;
+    return item.type !== "reasoning" || !("encrypted_content" in item);
+  });
+  return input.length === payload.input.length ? payload : { ...payload, input };
+}
+
+function restoreXaiMessageIdentity<T>(value: T, model: Model<Api>): T {
   if (!value || typeof value !== "object" || Array.isArray(value)) return value;
   const message = value as Record<string, unknown>;
   if (message.role !== "assistant") return value;
@@ -122,7 +196,7 @@ function restoreXaiMessageIdentity(value: unknown, model: Model<Api>): unknown {
     api: model.api,
     provider: model.provider,
     model: model.id,
-  };
+  } as T;
 }
 
 function normalizeXaiStreamEvent(
@@ -148,7 +222,7 @@ function normalizeXaiStreamEvent(
   if (internalized.type !== "error" || !internalized.error || typeof internalized.error !== "object") {
     return internalized;
   }
-  const error = internalized.error as Record<string, any>;
+  const error = internalized.error as Record<string, unknown>;
   if (typeof error.errorMessage !== "string") return internalized;
   return {
     ...internalized,
@@ -165,6 +239,10 @@ function normalizeXaiStreamEvent(
             error.errorMessage,
             typeof error.status === "number" ? error.status : undefined,
             "responses-proxy",
+            // Pi 0.84 preserves `response.failed` here; the supported 0.80
+            // boundary does not. In both cases the additional classifier still
+            // requires xAI's invalid_request code plus encrypted-content marker.
+            error.rawStopReason === "failed" || error.rawStopReason === undefined,
           ),
     },
   };
@@ -248,7 +326,7 @@ function streamErrorMessage(model: Model<Api>, error: unknown) {
 export async function postXaiJson(
   authToken: string,
   url: string,
-  body: Record<string, any>,
+  body: Record<string, unknown>,
   signal?: AbortSignal,
   contractHeaders: Record<string, string> = {},
   maxResponseBytes?: number,
@@ -314,7 +392,7 @@ export function assertXaiRuntimeModelAcceptsPayload(modelId: string, payload: un
 /** Create one xAI Responses result using explicit credential-aware routing. */
 export async function createXaiResponse(
   credential: XaiCredential,
-  body: Record<string, any>,
+  body: Record<string, unknown>,
   signal?: AbortSignal,
   beforeSend?: () => void,
   maxResponseBytes?: number,
@@ -342,7 +420,7 @@ export async function createXaiResponse(
   if (usesPackageCatalog) {
     assertXaiRuntimeModelAcceptsPayload(selectedModelId, policyPayload);
   }
-  const payload = (await compactXaiInlineImages(policyPayload)) as Record<string, any>;
+  const payload = (await compactXaiInlineImages(policyPayload)) as Record<string, unknown>;
   if (usesPackageCatalog) {
     assertXaiRuntimeModelAcceptsPayload(selectedModelId, payload);
   }
@@ -440,6 +518,12 @@ export function streamSimpleXaiResponses(
       : {}),
     api: "openai-responses" as const,
   };
+  const delegateContext = prepareXaiDelegateContext(context, model, selectedModelId);
+  const omitRejectedReasoning = shouldOmitRejectedEncryptedReasoning(
+    context,
+    model,
+    selectedModelId,
+  );
   // The OAuth bearer comes only from options.apiKey. Required proxy metadata
   // is merged last so callers cannot spoof authentication or attribution.
   const headers = { ...scrubXaiReservedHeaders(options?.headers), ...requestHeaders };
@@ -469,7 +553,7 @@ export function streamSimpleXaiResponses(
     try {
       const inner = streamSimpleOpenAIResponses(
         openAIResponsesModel as Model<"openai-responses">,
-        context,
+        delegateContext,
         {
           ...options,
           signal: transportSignal,
@@ -504,7 +588,10 @@ export function streamSimpleXaiResponses(
             const visionSafePayload = visionEnabled
               ? omitConsumedXaiResponsesVisionImages(canonicalPayload)
               : canonicalPayload;
-            const policyPayload = applyXaiOAuthResponsesPolicy(visionSafePayload);
+            const replaySafePayload = omitRejectedReasoning
+              ? omitRejectedEncryptedReasoning(visionSafePayload)
+              : visionSafePayload;
+            const policyPayload = applyXaiOAuthResponsesPolicy(replaySafePayload);
             grokNativeToolRoutes = xaiPayloadGrokNativeToolRoutes(policyPayload);
             let exposedPayload = exposeGrokNativeToolNames(policyPayload);
             pinXaiPayloadModel(selectedModelId, exposedPayload);
@@ -518,7 +605,7 @@ export function streamSimpleXaiResponses(
               }
               const response = await createXaiResponse(
                 { kind: "oauth-session", token: options.apiKey },
-                buildXaiVisionDescriptionPayload(compactedVisionPayload, plan.targetModelId) as Record<string, any>,
+                buildXaiVisionDescriptionPayload(compactedVisionPayload, plan.targetModelId) as Record<string, unknown>,
                 AbortSignal.any([plan.signal, ...(options.signal ? [options.signal] : [])]),
                 () => {
                   if (!visionRouting?.validate(plan)) throw new Error(XAI_VISION_ROUTING_INVALIDATED_ERROR);

--- a/extensions/xai/wire.ts
+++ b/extensions/xai/wire.ts
@@ -41,7 +41,8 @@ const VERSION_GATE_STATUSES = new Set([400, 401, 403, 426]);
 const VERSION_GATE_PATTERN =
   /\b(?:client[-_ ]?version|minimum[-_ ]?version|outdated[-_ ]?client|unsupported[-_ ]?client|update[-_ ]?required|version[-_ ]?gate)\b/i;
 const ENCRYPTED_CONTENT_MISMATCH_PATTERN = /encrypted_content/;
-const ENCRYPTED_CONTENT_MISMATCH_MESSAGE =
+const INVALID_REQUEST_PATTERN = /\binvalid_request\b/i;
+export const XAI_ENCRYPTED_CONTENT_MISMATCH_MESSAGE =
   "xAI could not replay encrypted reasoning for this model. Start a clean session or turn using the same xAI model.";
 
 export type XaiClientMode = "interactive" | "headless";
@@ -237,10 +238,14 @@ function isEncryptedContentMismatch(
   status: number | undefined,
   detail: string,
   routeKind: XaiHttpRouteKind,
+  streamedFailure = false,
 ): boolean {
-  return routeKind === "responses-proxy" &&
-    status === 400 &&
-    ENCRYPTED_CONTENT_MISMATCH_PATTERN.test(detail);
+  if (
+    routeKind !== "responses-proxy" ||
+    !ENCRYPTED_CONTENT_MISMATCH_PATTERN.test(detail)
+  ) return false;
+  if (status !== undefined) return status === 400;
+  return streamedFailure && INVALID_REQUEST_PATTERN.test(detail);
 }
 
 function routeLabel(routeKind: XaiHttpRouteKind): string {
@@ -257,10 +262,11 @@ export function safeXaiTransportErrorMessage(
   detail: string,
   status?: number,
   routeKind: XaiHttpRouteKind = "unknown",
+  streamedFailure = false,
 ): string {
   const resolvedStatus = status ?? statusFromTransportText(detail);
-  if (isEncryptedContentMismatch(resolvedStatus, detail, routeKind)) {
-    return ENCRYPTED_CONTENT_MISMATCH_MESSAGE;
+  if (isEncryptedContentMismatch(resolvedStatus, detail, routeKind, streamedFailure)) {
+    return XAI_ENCRYPTED_CONTENT_MISMATCH_MESSAGE;
   }
   if (routeKind === "responses-proxy" && isProxyVersionGate(resolvedStatus, detail)) {
     const statusText = resolvedStatus ? ` (HTTP ${resolvedStatus})` : "";

--- a/extensions/xai/wire.ts
+++ b/extensions/xai/wire.ts
@@ -282,10 +282,11 @@ function routeLabel(routeKind: XaiHttpRouteKind): string {
 /**
  * Return stable transport text without reflecting raw upstream response bodies.
  *
- * An explicit numeric status wins over status text parsed from `detail`. A
- * status-less streamed failure is classified as an encrypted-reasoning
- * mismatch only when `streamedFailure` is true and the bounded delegate detail
- * contains both the `invalid_request` code and `encrypted_content` marker.
+ * An explicit numeric status takes precedence over one parsed from `detail`.
+ * When either status is available, a Responses-proxy detail containing the
+ * `encrypted_content` marker is classified as a mismatch only for status 400;
+ * `invalid_request` is not required on that path. Only the truly status-less
+ * path additionally requires `streamedFailure` and the `invalid_request` code.
  *
  * @param detail Bounded transport or delegate error text used only for classification.
  * @param status Numeric HTTP status when the transport preserved one.

--- a/extensions/xai/wire.ts
+++ b/extensions/xai/wire.ts
@@ -257,7 +257,20 @@ function routeLabel(routeKind: XaiHttpRouteKind): string {
   return "request";
 }
 
-/** Return stable transport text without reflecting raw upstream response bodies. */
+/**
+ * Return stable transport text without reflecting raw upstream response bodies.
+ *
+ * An explicit numeric status wins over status text parsed from `detail`. A
+ * status-less streamed failure is classified as an encrypted-reasoning
+ * mismatch only when `streamedFailure` is true and the bounded delegate detail
+ * contains both the `invalid_request` code and `encrypted_content` marker.
+ *
+ * @param detail Bounded transport or delegate error text used only for classification.
+ * @param status Numeric HTTP status when the transport preserved one.
+ * @param routeKind Internally selected pinned route classification.
+ * @param streamedFailure Whether the status-less detail came from a terminal streamed failure.
+ * @returns A fixed, non-reflective error message with safe route and status classification.
+ */
 export function safeXaiTransportErrorMessage(
   detail: string,
   status?: number,

--- a/extensions/xai/wire.ts
+++ b/extensions/xai/wire.ts
@@ -87,12 +87,16 @@ export function resolveXaiClientMode(
     }
   }
 
-  if (outputMode === "json" || outputMode === "rpc" || printRequested) return "headless";
+  if (outputMode === "json" || outputMode === "rpc" || printRequested)
+    return "headless";
   return stdinIsTTY && stdoutIsTTY ? "interactive" : "headless";
 }
 
 /** Map pi's client mode onto xAI's OAuth client-surface vocabulary. */
-export function resolveXaiOAuthClientSurface(): Exclude<XaiOAuthClientSurface, "ui"> {
+export function resolveXaiOAuthClientSurface(): Exclude<
+  XaiOAuthClientSurface,
+  "ui"
+> {
   return resolveXaiClientMode() === "interactive" ? "cli" : "headless";
 }
 
@@ -103,7 +107,10 @@ export function scrubXaiReservedHeaders(
   return Object.fromEntries(
     Object.entries(headers ?? {}).filter(([name]) => {
       const normalized = name.trim().toLowerCase();
-      return !RESERVED_HEADER_NAMES.has(normalized) && !normalized.startsWith("x-grok-");
+      return (
+        !RESERVED_HEADER_NAMES.has(normalized) &&
+        !normalized.startsWith("x-grok-")
+      );
     }),
   );
 }
@@ -116,7 +123,8 @@ export function xaiProxyRequestHeaders(
   options: XaiProxyHeaderOptions = {},
 ): Record<string, string> {
   if (credentialKind !== "oauth-session") return {};
-  const normalizedModelId = (modelId || "").toLowerCase().split("/").pop() || "";
+  const normalizedModelId =
+    (modelId || "").toLowerCase().split("/").pop() || "";
 
   return {
     Accept: options.streaming ? "text/event-stream" : "application/json",
@@ -199,12 +207,16 @@ export function xaiJsonPostHeaders(
 }
 
 /** Build the exact protected header contract for direct public media JSON requests. */
-export function xaiDirectMediaJsonHeaders(authToken: string): Record<string, string> {
+export function xaiDirectMediaJsonHeaders(
+  authToken: string,
+): Record<string, string> {
   return xaiJsonPostHeaders(authToken);
 }
 
 /** Build protected JSON GET headers for direct public media status requests. */
-export function xaiDirectMediaJsonGetHeaders(authToken: string): Record<string, string> {
+export function xaiDirectMediaJsonGetHeaders(
+  authToken: string,
+): Record<string, string> {
   return {
     Accept: "application/json",
     Authorization: `Bearer ${authToken}`,
@@ -218,19 +230,27 @@ function routeKindForUrl(url: string): XaiHttpRouteKind {
   if (url === XAI_IMAGES_GENERATIONS_URL) return "image-generation";
   if (url === XAI_IMAGES_EDITS_URL) return "image-edit";
   if (url === XAI_VIDEOS_GENERATIONS_URL) return "video-generation-create";
-  if (url.startsWith(XAI_VIDEOS_STATUS_PREFIX)) return "video-generation-status";
+  if (url.startsWith(XAI_VIDEOS_STATUS_PREFIX))
+    return "video-generation-status";
   return "unknown";
 }
 
 function statusFromTransportText(value: string): number | undefined {
-  const match = value.match(/(?:API error|HTTP|status(?: code)?)\D{0,12}([1-5]\d{2})/i);
+  const match = value.match(
+    /(?:API error|HTTP|status(?: code)?)\D{0,12}([1-5]\d{2})/i,
+  );
   return match ? Number(match[1]) : undefined;
 }
 
-function isProxyVersionGate(status: number | undefined, detail: string): boolean {
+function isProxyVersionGate(
+  status: number | undefined,
+  detail: string,
+): boolean {
   return (
     status === 426 ||
-    (!!status && VERSION_GATE_STATUSES.has(status) && VERSION_GATE_PATTERN.test(detail))
+    (!!status &&
+      VERSION_GATE_STATUSES.has(status) &&
+      VERSION_GATE_PATTERN.test(detail))
   );
 }
 
@@ -243,13 +263,15 @@ function isEncryptedContentMismatch(
   if (
     routeKind !== "responses-proxy" ||
     !ENCRYPTED_CONTENT_MISMATCH_PATTERN.test(detail)
-  ) return false;
+  )
+    return false;
   if (status !== undefined) return status === 400;
   return streamedFailure && INVALID_REQUEST_PATTERN.test(detail);
 }
 
 function routeLabel(routeKind: XaiHttpRouteKind): string {
-  if (routeKind === "responses-proxy" || routeKind === "responses-direct") return "Responses";
+  if (routeKind === "responses-proxy" || routeKind === "responses-direct")
+    return "Responses";
   if (routeKind === "image-generation") return "image generation";
   if (routeKind === "image-edit") return "image editing";
   if (routeKind === "video-generation-create") return "video generation";
@@ -278,10 +300,20 @@ export function safeXaiTransportErrorMessage(
   streamedFailure = false,
 ): string {
   const resolvedStatus = status ?? statusFromTransportText(detail);
-  if (isEncryptedContentMismatch(resolvedStatus, detail, routeKind, streamedFailure)) {
+  if (
+    isEncryptedContentMismatch(
+      resolvedStatus,
+      detail,
+      routeKind,
+      streamedFailure,
+    )
+  ) {
     return XAI_ENCRYPTED_CONTENT_MISMATCH_MESSAGE;
   }
-  if (routeKind === "responses-proxy" && isProxyVersionGate(resolvedStatus, detail)) {
+  if (
+    routeKind === "responses-proxy" &&
+    isProxyVersionGate(resolvedStatus, detail)
+  ) {
     const statusText = resolvedStatus ? ` (HTTP ${resolvedStatus})` : "";
     return `xAI proxy rejected ${XAI_CLIENT_IDENTIFIER}'s reviewed client/version contract${statusText}. Update ${XAI_CLIENT_IDENTIFIER}; if already current, open a compatibility issue with the HTTP status only. Last reviewed Grok Build revision: ${XAI_GROK_BUILD_REVIEWED_REVISION}.`;
   }
@@ -314,6 +346,10 @@ export async function xaiHttpErrorFromResponse(
   url: string,
   signal?: AbortSignal,
 ): Promise<XaiHttpError> {
-  const detail = await readTruncatedResponseText(response, MAX_ERROR_BODY_BYTES, signal);
+  const detail = await readTruncatedResponseText(
+    response,
+    MAX_ERROR_BODY_BYTES,
+    signal,
+  );
   return new XaiHttpError(response.status, routeKindForUrl(url), detail);
 }

--- a/tests/responses/reasoning-recovery.test.ts
+++ b/tests/responses/reasoning-recovery.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CURATED_FALLBACK_MODELS,
+  KNOWN_XAI_MODEL_METADATA,
+  setXaiRuntimeModels,
+} from "../../extensions/xai/models";
+import { streamSimpleXaiResponses } from "../../extensions/xai/responses";
+import { requestBody } from "../fixtures/http";
+import { TEST_MODEL } from "../fixtures/models";
+
+const encryptedContent = "opaque-rejected-reasoning";
+const reasoningItem = {
+  id: "rs_prior",
+  type: "reasoning",
+  summary: [],
+  encrypted_content: encryptedContent,
+  status: "completed",
+};
+const usage = {
+  input: 1,
+  output: 1,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 2,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function model(modelId: string) {
+  return { ...TEST_MODEL, id: modelId } as any;
+}
+
+function priorToolHistory(
+  api: "xai-responses" | "openai-responses",
+  modelId = "grok-4.6",
+) {
+  return [
+    { role: "user", content: "inspect the project", timestamp: 1 },
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "thinking",
+          thinking: "",
+          thinkingSignature: JSON.stringify(reasoningItem),
+        },
+        {
+          type: "text",
+          text: "I will inspect it.",
+          textSignature: "msg_prior",
+        },
+        {
+          type: "toolCall",
+          id: "call_prior|fc_prior",
+          name: "read_file",
+          arguments: { path: "README.md" },
+        },
+      ],
+      api,
+      provider: "xai-auth",
+      model: modelId,
+      usage,
+      stopReason: "toolUse",
+      timestamp: 2,
+    },
+    {
+      role: "toolResult",
+      toolCallId: "call_prior|fc_prior",
+      toolName: "read_file",
+      content: [{ type: "text", text: "visible tool output" }],
+      isError: false,
+      timestamp: 3,
+    },
+  ] as any[];
+}
+
+function sse(events: unknown[]) {
+  return new Response(
+    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
+    { headers: { "content-type": "text/event-stream" } },
+  );
+}
+
+function failedEvent(code: string, message: string) {
+  return {
+    type: "response.failed",
+    response: {
+      status: "failed",
+      error: { code, message },
+    },
+  };
+}
+
+function completedEvent(id: string) {
+  return {
+    type: "response.completed",
+    response: {
+      id,
+      status: "completed",
+      output: [],
+      usage: { input_tokens: 2, output_tokens: 1, total_tokens: 3 },
+    },
+  };
+}
+
+function inputTypes(body: any): string[] {
+  return body.input.map((item: any) => item.type ?? item.role);
+}
+
+function expectVisibleToolHistory(body: any) {
+  expect(inputTypes(body)).toEqual([
+    "user",
+    "message",
+    "function_call",
+    "function_call_output",
+    "user",
+  ]);
+  expect(JSON.stringify(body.input)).toContain("I will inspect it.");
+  expect(JSON.stringify(body.input)).toContain("visible tool output");
+}
+
+beforeEach(() => setXaiRuntimeModels(KNOWN_XAI_MODEL_METADATA));
+afterEach(() => setXaiRuntimeModels(CURATED_FALLBACK_MODELS));
+
+describe("encrypted reasoning stream recovery", () => {
+  it.each(["xai-responses", "openai-responses"] as const)(
+    "classifies a streamed mismatch and recovers same-model history tagged %s",
+    async (sourceApi) => {
+      const requests: any[] = [];
+      const responses = [
+        sse([
+          failedEvent(
+            "invalid_request",
+            "STREAM_SECRET encrypted_content belongs to another model",
+          ),
+        ]),
+        sse([completedEvent("resp_recovered")]),
+      ];
+      const fetchMock = vi.fn(async (_url: any, init: RequestInit = {}) => {
+        requests.push(requestBody(init));
+        return responses.shift()!;
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      const selectedModel = model("grok-4.6");
+      const history = priorToolHistory(sourceApi);
+
+      const first = streamSimpleXaiResponses(
+        selectedModel,
+        { messages: history } as any,
+        { apiKey: "oauth-token", sessionId: "issue-188" } as any,
+      );
+      const failure = await first.result();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(inputTypes(requests[0])).toContain("reasoning");
+      expect(
+        requests[0].input.find((item: any) => item.type === "reasoning"),
+      ).toEqual(reasoningItem);
+      expect(failure).toMatchObject({
+        api: "xai-responses",
+        provider: "xai-auth",
+        model: "grok-4.6",
+        stopReason: "error",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+        },
+      });
+      expect(failure).not.toHaveProperty("responseId");
+      expect(failure.errorMessage).toMatch(
+        /Start a clean session or turn using the same xAI model/,
+      );
+      expect(failure.errorMessage).not.toMatch(
+        /STREAM_SECRET|encrypted_content|invalid_request/,
+      );
+
+      const second = streamSimpleXaiResponses(
+        selectedModel,
+        {
+          messages: [
+            ...history,
+            failure,
+            { role: "user", content: "continue", timestamp: 5 },
+          ],
+        } as any,
+        { apiKey: "oauth-token", sessionId: "issue-188" } as any,
+      );
+      const recovered = await second.result();
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(recovered).toMatchObject({
+        stopReason: "stop",
+        responseId: "resp_recovered",
+      });
+      expectVisibleToolHistory(requests[1]);
+      expect(
+        requests[1].input.some((item: any) => item.type === "reasoning"),
+      ).toBe(false);
+      expect(requests[1]).toMatchObject({
+        store: false,
+        include: ["reasoning.encrypted_content"],
+      });
+    },
+  );
+
+  it.each(["xai-responses", "openai-responses"] as const)(
+    "keeps cross-model replay protection for history tagged %s",
+    async (sourceApi) => {
+      let sent: any;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_url: any, init: RequestInit = {}) => {
+          sent = requestBody(init);
+          return sse([completedEvent("resp_switched")]);
+        }),
+      );
+
+      const result = await streamSimpleXaiResponses(
+        model("grok-4.5"),
+        {
+          messages: [
+            ...priorToolHistory(sourceApi, "grok-4.6"),
+            {
+              role: "user",
+              content: "continue on the other model",
+              timestamp: 4,
+            },
+          ],
+        } as any,
+        { apiKey: "oauth-token", sessionId: "issue-188-switch" } as any,
+      ).result();
+
+      expect(result).toMatchObject({
+        stopReason: "stop",
+        responseId: "resp_switched",
+      });
+      expectVisibleToolHistory(sent);
+      expect(sent.input.some((item: any) => item.type === "reasoning")).toBe(
+        false,
+      );
+    },
+  );
+
+  it("does not clear reasoning after an unrelated streamed failure and preserves numeric status text", async () => {
+    const requests: any[] = [];
+    const responses = [
+      sse([
+        failedEvent(
+          "server_error",
+          "HTTP 429 transient encrypted_content observer STREAM_SECRET",
+        ),
+      ]),
+      sse([completedEvent("resp_after_transient")]),
+    ];
+    const fetchMock = vi.fn(async (_url: any, init: RequestInit = {}) => {
+      requests.push(requestBody(init));
+      return responses.shift()!;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const selectedModel = model("grok-4.6");
+    const history = priorToolHistory("openai-responses");
+
+    const failure = await streamSimpleXaiResponses(
+      selectedModel,
+      { messages: history } as any,
+      { apiKey: "oauth-token", sessionId: "issue-188-transient" } as any,
+    ).result();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(failure.errorMessage).toBe(
+      "xAI API error: Responses failed with status 429",
+    );
+    expect(failure.errorMessage).not.toMatch(
+      /STREAM_SECRET|encrypted_content|server_error/,
+    );
+
+    const result = await streamSimpleXaiResponses(
+      selectedModel,
+      {
+        messages: [
+          ...history,
+          failure,
+          { role: "user", content: "continue", timestamp: 5 },
+        ],
+      } as any,
+      { apiKey: "oauth-token", sessionId: "issue-188-transient" } as any,
+    ).result();
+
+    expect(result).toMatchObject({
+      stopReason: "stop",
+      responseId: "resp_after_transient",
+    });
+    expect(
+      requests[1].input.find((item: any) => item.type === "reasoning"),
+    ).toEqual(reasoningItem);
+  });
+});


### PR DESCRIPTION
## Summary

- classify encrypted-reasoning mismatches delivered as HTTP-200 SSE `response.failed` events without reflecting raw upstream details
- align canonical `xai-responses` and persisted `openai-responses` delegate-tagged history at the internal conversion seam while preserving exact provider/model replay protections
- omit rejected encrypted reasoning on the next same-model turn while retaining visible conversation, function calls, tool results, `store: false`, and encrypted-content include policy
- preserve unrelated/transient failure handling and numeric status classification

Fixes #188.

## Validation

- deterministic pre-fix regression reproduced both identity and streamed-error failures at the real stream seam
- `npm run test:unit -- tests/responses/reasoning-recovery.test.ts tests/responses/routing.test.ts tests/responses/reasoning-replay.test.ts tests/responses/streaming.test.ts tests/responses/payload.test.ts` — 62 passed
- `npm run typecheck` — passed
- `npm test` — 627 passed; loader smoke passed
- `npm run compatibility:check` — passed
- `npm run compatibility:boundaries` — exact Pi/pi-ai 0.80.1 and 0.84.2 packed boundaries passed
- live worktree-only `xai-auth` Herdr smoke — Grok 4.6 tool turn and same-model continue passed; switch to Grok 4.5 and back to Grok 4.6 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of encrypted-reasoning mismatches in streamed responses.
  - Prevented unsafe retries while providing sanitized recovery guidance.
  - Preserved visible messages and tool results during same-model recovery.
  - Continued protecting against cross-model encrypted-reasoning replay.
  - Ensured unrelated failures retain their existing behavior.

- **Documentation**
  - Updated encrypted-reasoning recovery guidance and compatibility details.

- **Tests**
  - Added coverage for streamed failures, recovery, replay protection, and transient errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->