### PR TITLE
test: cover vision image shapes, catalog cancel-after-write, and media-tool redaction (rebase of #189)

### DIFF
--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,35 +1,38 @@
-# Execution Progress — Issue #188
+# Execution Progress — coverage pass (rebased 2026-08-22)
 
-**Branch:** `release/v1.5.1`
+**Branch:** `chore/rebase-189` (rebase of `cursor/missing-test-coverage-7872` onto `main`)
 
-## Completed
+## Previously landed on `main`
 
-- [x] Confirmed the clean feature branch before edits.
-- [x] Read AGENTS.md, README.md, setup/entrypoint code, scaffold state, and the full issue (no comments were present).
-- [x] Read the Responses, payload, and wire implementations plus reasoning replay, routing, streaming, and payload tests.
-- [x] Inspected Pi/pi-ai 0.84.2's real OpenAI Responses conversion and `response.failed` stream seam.
-- [x] Established the working diagnosis: streamed failures lose HTTP status and are generically redacted; canonical `xai-responses` history is not replayed through the temporary `openai-responses` delegate identity, while persisted delegate-tagged history is.
-- [x] Added deterministic real stream-seam regressions and proved both pre-fix failures.
-- [x] Implemented bounded `response.failed` mismatch classification with fixed redacted guidance and no immediate retry.
-- [x] Aligned canonical and persisted delegate-tagged history at the conversion seam while retaining exact provider/model replay checks.
-- [x] Made the next same-model turn omit rejected encrypted reasoning only, preserving visible conversation/tool history and leaving unrelated failures unchanged.
-- [x] Passed 62 focused Responses tests across recovery, routing, replay, streaming, and payload suites.
-- [x] Passed local LSP diagnostics and `npm run typecheck`.
-- [x] Passed `npm test`: compatibility policy, 627 unit tests, and the real Pi loader smoke.
-- [x] Passed `npm run compatibility:check`, including packed-manifest and registry/mirror policy checks.
-- [x] Found and fixed a Pi 0.80.1 compatibility gap where the delegate does not retain `rawStopReason: failed`; the classifier remains bounded by `invalid_request` plus `encrypted_content`.
-- [x] Passed exact packed boundaries for Pi/pi-ai 0.80.1 and 0.84.2, including each packed package's tests, loader smoke, and typecheck.
-- [x] Ran a live Herdr smoke against the worktree-only extension with authenticated `xai-auth`: Grok 4.6 completed a tool turn and same-model continuation, Grok 4.5 completed the switched-model turn, and Grok 4.6 completed the switch-back turn without a Responses failure.
-- [x] Reviewed and committed the final delta, pushed the feature branch, and opened PR #190.
+- [x] PR #190 (issue #188 streamed reasoning-mismatch recovery) merged as `8eaf274`.
+- [x] v1.5.1 released via PR #192.
+- [x] PR #195 merged: combined `vitest` + `@vitest/coverage-v8` 4.1.11 bump and Dependabot
+      `groups` for the vitest packages and both Pi peers, superseding the split PRs #193/#194.
 
-- [x] Merged PR #190 to `main` as `8eaf274`.
-- [x] Prepared the v1.5.1 package/lock metadata, release changelog, and README release references.
-- [x] Passed `npm test` (664 tests), `npm run typecheck`, `npm run compatibility:check`, both exact Pi 0.80.1/0.84.2 packed boundaries, `npm pack --dry-run --json`, and `git diff --check` for v1.5.1.
+## Completed (this branch)
 
-## In Progress
+- [x] Inspected recent merges (#186/#187 coverage PRs already on main) and leftover gaps from the 2026-08-20 pass.
+- [x] Added vision-routing image-shape normalization, computer-call association, and description-bound tests.
+- [x] Added catalog post-rename `commitAllowed` restore plus 408/425/429/400 fetch classification.
+- [x] Added image-edit validation/wire/session/network/JSON redaction tests.
+- [x] Added custom media-tool generic catch redaction and missing-credential refusals.
+- [x] Added OAuth already-aborted callback wait and cancel-during-catalog-handoff tests.
+- [x] Rebased onto `main` after #190/#192/#195; only `.scaffold/progress.md` conflicted, all seven test
+      files applied clean.
+- [x] Re-verified on rebased `main`: `npm test` 55 files / 692 tests passed plus the real Pi loader
+      smoke, and `npm run typecheck` passed.
+- [x] Re-measured coverage against the current baseline: 90.93 / 84.89 / 93.30 / 94.14 on `main`
+      rises to 92.17 / 86.87 / 93.30 / 95.41 with this branch.
 
-- [ ] Publish v1.5.1 through the release PR and GitHub Release workflow.
+## Notes
+
+- The pre-rebase run reported 687 tests and 92.17 / 86.82 / 93.23 / 95.51; the deltas are #190's tests
+  landing on `main` since the branch was cut, not a behavior change here.
+- Packed `compatibility:boundaries` failed twice in the original cloud image on isolated `npm install`
+  (`Cannot read properties of null (reading 'edgesOut')`) before tests ran — environment/npm installer,
+  not a test flake. The hosted Pi 0.80.1 and 0.84.2 boundary jobs passed in CI.
 
 ## Next
 
-Run all documented release gates, merge the release PR, publish GitHub Release `v1.5.1`, and monitor both registry publish steps.
+Land the rebased coverage branch, then resume the regular coverage cadence against the remaining
+`extensions/xai-oauth.ts` and `media/output-storage.ts` gaps.

--- a/tests/catalog/cache.test.ts
+++ b/tests/catalog/cache.test.ts
@@ -345,6 +345,26 @@ describe("catalog cache selection", () => {
     expect(await readFile(path, "utf8")).toBe(before);
   });
 
+  it("restores the previous cache when the commit guard flips after a successful rename", async () => {
+    const path = join(temp.path, "post-write-guard", "models-v2.json");
+    await writeCache(path, now - XAI_MODEL_CATALOG_FRESH_TTL_MS);
+    let checks = 0;
+    await expect(
+      selectXaiModelCatalog({
+        credential: { access: token },
+        cachePath: path,
+        now,
+        commitAllowed: () => ++checks < 3,
+        fetchImpl: async () => jsonResponse(removalsPayload),
+      }),
+    ).rejects.toBeInstanceOf(XaiCatalogCancelledError);
+    expect(
+      JSON.parse(await readFile(path, "utf8")).models.map(
+        (model: any) => model.id,
+      ),
+    ).toEqual(additions.map(({ id }) => id));
+  });
+
   it("restores the previous cache when the commit guard changes", async () => {
     const path = join(temp.path, "guard", "models-v2.json");
     await writeCache(path, now - XAI_MODEL_CATALOG_FRESH_TTL_MS);
@@ -561,5 +581,23 @@ describe("catalog cache selection", () => {
         { fetchImpl: async () => jsonResponse(additionsPayload) },
       ),
     ).resolves.toMatchObject({ kind: "success" });
+  });
+
+  it.each([408, 425, 429, 503])("classifies HTTP %s catalog responses as transient", async (status) => {
+    await expect(
+      fetchXaiModelCatalog(
+        { access: token },
+        { fetchImpl: async () => jsonResponse({}, status) },
+      ),
+    ).resolves.toEqual({ kind: "transient" });
+  });
+
+  it("classifies other non-success catalog HTTP statuses as permanent", async () => {
+    await expect(
+      fetchXaiModelCatalog(
+        { access: token },
+        { fetchImpl: async () => jsonResponse({}, 400) },
+      ),
+    ).resolves.toEqual({ kind: "permanent" });
   });
 });

--- a/tests/images/image-edit.test.ts
+++ b/tests/images/image-edit.test.ts
@@ -14,6 +14,7 @@ import type { ImageCodec } from "../../extensions/xai/media/compression";
 import {
   IMAGE_EDIT_MAX_OUTPUT_BYTES,
   IMAGE_EDIT_MAX_OUTPUT_PIXELS,
+  IMAGE_EDIT_MAX_PROMPT_CHARS,
   IMAGE_EDIT_MAX_REQUEST_JSON_BYTES,
   MEDIA_REFERENCE_PASSTHROUGH_MAX_BYTES,
 } from "../../extensions/xai/media/constants";
@@ -51,6 +52,14 @@ describe("image-edit validation and wire payload", () => {
       { prompt: "edit", image: [{ data_url: dataUrl }], aspect_ratio: 1 },
       { prompt: "edit", image: [{ data_url: dataUrl }, { data_url: dataUrl }] },
       { prompt: "edit", image: [{ data_url: dataUrl }, { data_url: dataUrl }], aspect_ratio: "bad" },
+      null,
+      [],
+      "edit",
+      { prompt: "edit", image: [{ data_url: dataUrl }], seed: 1 },
+      { prompt: "a".repeat(IMAGE_EDIT_MAX_PROMPT_CHARS + 1), image: [{ data_url: dataUrl }] },
+      { prompt: "edit", image: [{ path: "" }] },
+      { prompt: "edit", image: [{ data_url: "   " }] },
+      { prompt: "edit", image: ["not-an-object"] },
     ]) {
       expect(() => validateXaiEditImageInput(input)).toThrow(ImageEditOperationError);
     }
@@ -124,6 +133,26 @@ describe("image-edit validation and wire payload", () => {
       height: 1,
       wasCompressed: false,
     }])).toThrow(/aggregate request-byte limit/);
+  });
+
+  it("rejects a prepared-reference count mismatch and multi-image payloads without aspect_ratio", () => {
+    const singular = validateXaiEditImageInput({
+      prompt: "edit",
+      image: [{ data_url: dataUrl }],
+    });
+    const reference = {
+      dataUrl,
+      mimeType: "image/png" as const,
+      byteLength: png.length,
+      width: 1,
+      height: 1,
+      wasCompressed: false,
+    };
+    expect(() => buildXaiImageEditPayload(singular, [])).toThrow(/does not match the request/);
+    expect(() => buildXaiImageEditPayload(
+      { prompt: "combine", image: [{ data_url: dataUrl }, { data_url: dataUrl }] } as XaiEditImageInput,
+      [reference, reference],
+    )).toThrow(/require a supported aspect_ratio/);
   });
 });
 
@@ -212,6 +241,59 @@ describe("bounded xAI image-edit execution", () => {
     controller.abort();
     await expect(pending).rejects.toMatchObject({ code: "cancelled" });
     await expect(lstat(imageEditOutputRoot(sessionManager()))).rejects.toThrow();
+  });
+
+  it("maps session-directory failures, network throws, and invalid JSON without reflecting secrets", async () => {
+    const secret = "SESSION_SECRET_TOKEN";
+    await expect(executeXaiImageEdit({
+      credential: { kind: "oauth-session", token: "token" },
+      input: input(),
+      workspaceRoot,
+      sessionManager: {
+        getSessionDir: () => {
+          throw new Error(`unavailable ${secret}`);
+        },
+        getSessionId: () => "image-edit-session",
+      },
+    }, dependencies())).rejects.toMatchObject({
+      code: "output_failure",
+      message: /safe Pi session output directory is unavailable/,
+    });
+
+    const network = await executeXaiImageEdit({
+      credential: { kind: "oauth-session", token: "token" },
+      input: input(),
+      workspaceRoot,
+      sessionManager: sessionManager(),
+    }, {
+      codec,
+      fetch: vi.fn(async () => {
+        throw new TypeError(`fetch failed ${secret}`);
+      }),
+    }).then(() => undefined, (error: unknown) => error);
+    expect(network).toMatchObject({
+      code: "network_failure",
+      message: /request failed\. Check the network/,
+    });
+    expect(JSON.stringify(network)).not.toContain(secret);
+
+    const invalidJson = await executeXaiImageEdit({
+      credential: { kind: "oauth-session", token: "token" },
+      input: input(),
+      workspaceRoot,
+      sessionManager: sessionManager(),
+    }, {
+      codec,
+      fetch: vi.fn(async () => new Response(`not-json ${secret}`, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })),
+    }).then(() => undefined, (error: unknown) => error);
+    expect(invalidJson).toMatchObject({
+      code: "invalid_response",
+      message: /invalid JSON response/,
+    });
+    expect(JSON.stringify(invalidJson)).not.toContain(secret);
   });
 
   it("rejects pre-cancellation before session, codec, filesystem, or network access", async () => {

--- a/tests/oauth/browser-cancellation.test.ts
+++ b/tests/oauth/browser-cancellation.test.ts
@@ -52,6 +52,31 @@ describe("browser OAuth cancellation cleanup", () => {
     ).rejects.toThrow(/cancelled/i);
     expect(requestSignal?.aborted).toBe(true);
   });
+  it("treats an already-aborted signal as cancelled before waiting for the callback", async () => {
+    const controller = new AbortController();
+    let redirect = "";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: any, init: RequestInit) => {
+        if (String(input).startsWith("http://127.0.0.1:"))
+          return nativeFetch(input, init);
+        return jsonResponse(discovery());
+      }),
+    );
+    await expect(
+      createXaiOAuth({ getExistingCredentials: () => null }).login({
+        ...base,
+        signal: controller.signal,
+        onAuth(auth: any) {
+          redirect = new URL(auth.url).searchParams.get("redirect_uri")!;
+          controller.abort();
+        },
+      }),
+    ).rejects.toThrow(/cancelled/i);
+    expect(redirect).toMatch(/^http:\/\/127\.0\.0\.1:/);
+    await expect(nativeFetch(redirect)).rejects.toThrow();
+  });
+
   it("closes the callback listener when cancelled while waiting", async () => {
     const controller = new AbortController();
     let redirect = "";

--- a/tests/oauth/device-login.test.ts
+++ b/tests/oauth/device-login.test.ts
@@ -187,6 +187,38 @@ describe("OAuth login method and device integration", () => {
     ).rejects.toThrow("Login cancelled");
   });
 
+  it("does not keep credentials when the catalog handoff throws after cancellation", async () => {
+    const controller = new AbortController();
+    const clock = makeClock();
+    const progress: string[] = [];
+    const oauth = createXaiOAuth({
+      getExistingCredentials: () => null,
+      deviceAuth: {
+        now: clock.now,
+        sleep: clock.sleep,
+        fetchImpl: async (url) =>
+          String(url) === XAI_OAUTH_DEVICE_URL
+            ? jsonResponse(devicePayload({ interval: 1 }))
+            : jsonResponse(tokenPayload()),
+      },
+      onLoginCredentials: async () => {
+        controller.abort();
+        throw new Error("catalog failure included secret-access-token");
+      },
+    });
+    await expect(
+      oauth.login({
+        onPrompt: async () => "n",
+        onAuth: () => {},
+        onDeviceCode: () => {},
+        onSelect: async () => XAI_DEVICE_LOGIN_METHOD,
+        onProgress: (message: string) => progress.push(message),
+        signal: controller.signal,
+      } as any),
+    ).rejects.toThrow("Login cancelled");
+    expect(progress.join("\n")).not.toMatch(/curated fallback|secret-access-token/);
+  });
+
   it("keeps a valid login without reflecting the catalog handoff error", async () => {
     const clock = makeClock();
     const progress: string[] = [];

--- a/tests/responses/vision-routing.test.ts
+++ b/tests/responses/vision-routing.test.ts
@@ -11,7 +11,11 @@ import {
 } from "../../extensions/xai/models";
 import { createXaiResponse, streamSimpleXaiResponses } from "../../extensions/xai/responses";
 import {
+  buildXaiVisionDescriptionPayload,
   createXaiVisionRoutingController,
+  replaceXaiPayloadImagesWithDescription,
+  XAI_VISION_DESCRIPTION_ERROR,
+  XAI_VISION_PAYLOAD_ERROR,
   XAI_VISION_ROUTING_INVALIDATED_ERROR,
 } from "../../extensions/xai/vision-routing";
 import { jsonResponse, requestBody } from "../fixtures/http";
@@ -786,5 +790,92 @@ describe("opt-in vision routing", () => {
     expect(controller.plan(target.id, {
       input: [{ type: "input_image", image_url: "https://example.test/x.png" }],
     })).toBeUndefined();
+  });
+
+  it("refuses grants when the source is missing or already vision-capable", () => {
+    const controller = createXaiVisionRoutingController();
+    controller.replaceCatalog([source, target]);
+    expect(controller.enable({ ...sourceModel, id: "unknown-source" })).toMatchObject({
+      state: "unavailable",
+      reason: expect.stringMatching(/not an exact member/),
+    });
+    expect(controller.enable({ ...TEST_MODEL, id: target.id, input: ["text", "image"] } as any)).toMatchObject({
+      state: "unavailable",
+      reason: expect.stringMatching(/already accepts images/),
+    });
+  });
+
+  it("normalizes recognized image shapes into one image-only description request", () => {
+    const payload = buildXaiVisionDescriptionPayload({
+      input: [
+        { type: "input_image", image_url: { url: "https://example.test/object.png" }, detail: "high" },
+        { type: "input_image", file_id: "file_fallback" },
+        { type: "image", image_url: "https://example.test/string.png" },
+        { type: "image", image_url: { url: "https://example.test/nested.png" } },
+        { type: "image", data: "AAA", mimeType: "image/png" },
+        { type: "image", source: { type: "base64", data: "BBB", media_type: "image/jpeg" } },
+        { type: "computer_screenshot", image_url: "https://example.test/shot.png" },
+        { type: "computer_screenshot", file_id: "file_shot" },
+      ],
+    }, target.id);
+
+    expect(payload).toMatchObject({
+      model: target.id,
+      store: false,
+    });
+    const images = (payload.input as any)[0].content.slice(1);
+    expect(images).toEqual([
+      { type: "input_image", image_url: "https://example.test/object.png", detail: "high" },
+      { type: "input_image", file_id: "file_fallback" },
+      { type: "input_image", image_url: "https://example.test/string.png", detail: "auto" },
+      { type: "input_image", image_url: "https://example.test/nested.png", detail: "auto" },
+      { type: "input_image", image_url: "data:image/png;base64,AAA", detail: "auto" },
+      { type: "input_image", image_url: "data:image/jpeg;base64,BBB", detail: "auto" },
+      { type: "input_image", image_url: "https://example.test/shot.png", detail: "auto" },
+      { type: "input_image", file_id: "file_shot" },
+    ]);
+  });
+
+  it("replaces computer screenshots with a bounded labeled description and call association", () => {
+    const replaced = replaceXaiPayloadImagesWithDescription({
+      model: source.id,
+      input: [
+        {
+          type: "computer_call_output",
+          call_id: "computer_secret",
+          output: {
+            type: "computer_screenshot",
+            image_url: "https://example.test/private-screen.png",
+          },
+        },
+        { role: "user", content: [{ type: "input_text", text: "what is on screen?" }] },
+      ],
+    }, "A terminal showing a stack trace.");
+
+    expect(JSON.stringify(replaced)).not.toMatch(/private-screen/);
+    expect(replaced.input).toEqual(expect.arrayContaining([
+      {
+        type: "computer_call_output",
+        call_id: "computer_secret",
+        output: "[computer screenshot described in the following user message]",
+      },
+    ]));
+    expect(JSON.stringify(replaced)).toMatch(
+      /\[xAI-generated visual description\] \(from computer output computer_secret\)/,
+    );
+    expect(JSON.stringify(replaced)).toMatch(/terminal showing a stack trace/);
+  });
+
+  it("rejects empty, oversized, or fully-stripped vision descriptions without leaking image URLs", () => {
+    const imaged = {
+      type: "input_image",
+      image_url: "https://example.test/SECRET-private.png",
+    };
+    expect(() => replaceXaiPayloadImagesWithDescription({ input: [imaged] }, "   "))
+      .toThrow(XAI_VISION_DESCRIPTION_ERROR);
+    expect(() => replaceXaiPayloadImagesWithDescription({ input: [imaged] }, "x".repeat(32_769)))
+      .toThrow(XAI_VISION_DESCRIPTION_ERROR);
+    expect(() => replaceXaiPayloadImagesWithDescription(imaged as any, "ok"))
+      .toThrow(XAI_VISION_PAYLOAD_ERROR);
   });
 });

--- a/tests/tools/custom-tools-media-errors.test.ts
+++ b/tests/tools/custom-tools-media-errors.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerCustomXaiTools } from "../../extensions/xai/tools/custom-tools";
+import { setXaiNetworkToolActive } from "../../extensions/xai/tools/model-scope";
+import { createExtensionHarness } from "../fixtures/extension-api";
+import { tinyPngBytes } from "../fixtures/images";
+import { authContext, TEST_MODEL } from "../fixtures/models";
+
+const mediaErrors = vi.hoisted(() => ({
+  editValidate: undefined as Error | undefined,
+  editExecute: undefined as Error | undefined,
+  videoValidate: undefined as Error | undefined,
+  videoExecute: undefined as Error | undefined,
+}));
+
+vi.mock("../../extensions/xai/image-edit", async () => {
+  const actual = await vi.importActual<typeof import("../../extensions/xai/image-edit")>(
+    "../../extensions/xai/image-edit",
+  );
+  return {
+    ...actual,
+    validateXaiEditImageInput: (...args: Parameters<typeof actual.validateXaiEditImageInput>) => {
+      if (mediaErrors.editValidate) throw mediaErrors.editValidate;
+      return actual.validateXaiEditImageInput(...args);
+    },
+    executeXaiImageEdit: (...args: Parameters<typeof actual.executeXaiImageEdit>) => {
+      if (mediaErrors.editExecute) return Promise.reject(mediaErrors.editExecute);
+      return actual.executeXaiImageEdit(...args);
+    },
+  };
+});
+
+vi.mock("../../extensions/xai/image-to-video", async () => {
+  const actual = await vi.importActual<typeof import("../../extensions/xai/image-to-video")>(
+    "../../extensions/xai/image-to-video",
+  );
+  return {
+    ...actual,
+    validateXaiImageToVideoInput: (...args: Parameters<typeof actual.validateXaiImageToVideoInput>) => {
+      if (mediaErrors.videoValidate) throw mediaErrors.videoValidate;
+      return actual.validateXaiImageToVideoInput(...args);
+    },
+    executeXaiImageToVideo: (...args: Parameters<typeof actual.executeXaiImageToVideo>) => {
+      if (mediaErrors.videoExecute) return Promise.reject(mediaErrors.videoExecute);
+      return actual.executeXaiImageToVideo(...args);
+    },
+  };
+});
+
+describe("custom media tool error redaction", () => {
+  const dataUrl = `data:image/png;base64,${tinyPngBytes().toString("base64")}`;
+  let harness: ReturnType<typeof createExtensionHarness>;
+
+  beforeEach(() => {
+    mediaErrors.editValidate = undefined;
+    mediaErrors.editExecute = undefined;
+    mediaErrors.videoValidate = undefined;
+    mediaErrors.videoExecute = undefined;
+    harness = createExtensionHarness();
+    registerCustomXaiTools(harness.api);
+    setXaiNetworkToolActive(harness.api, TEST_MODEL, "xai_edit_image", true);
+    setXaiNetworkToolActive(harness.api, TEST_MODEL, "xai_image_to_video", true);
+  });
+
+  afterEach(() => {
+    mediaErrors.editValidate = undefined;
+    mediaErrors.editExecute = undefined;
+    mediaErrors.videoValidate = undefined;
+    mediaErrors.videoExecute = undefined;
+  });
+
+  it("maps unexpected image-edit validator throws to a generic invalid-input error", async () => {
+    mediaErrors.editValidate = new Error("SECRET_PATH /tmp/private.png");
+    const result = await harness.tools.get("xai_edit_image").execute(
+      "call",
+      { prompt: "edit", image: [{ data_url: dataUrl }] },
+      undefined,
+      () => {},
+      authContext(TEST_MODEL),
+    );
+    expect(result.content[0].text).toBe("Error: Image edit input is invalid.");
+    expect(result.details).toMatchObject({ error: true, code: "invalid_input" });
+    expect(JSON.stringify(result)).not.toMatch(/SECRET_PATH|private\.png/);
+  });
+
+  it("maps unexpected image-edit execution throws to a generic safe failure", async () => {
+    mediaErrors.editExecute = new Error("SECRET_STACK /tmp/private.png oauth-token");
+    const result = await harness.tools.get("xai_edit_image").execute(
+      "call",
+      { prompt: "edit", image: [{ data_url: dataUrl }] },
+      undefined,
+      () => {},
+      authContext(TEST_MODEL),
+    );
+    expect(result.content[0].text).toBe("Error: xAI image edit failed safely.");
+    expect(result.details).toMatchObject({ error: true, code: "output_failure" });
+    expect(JSON.stringify(result)).not.toMatch(/SECRET_STACK|private\.png|oauth-token/);
+  });
+
+  it("maps unexpected image-to-video validator throws to a generic invalid-input error", async () => {
+    mediaErrors.videoValidate = new Error("SECRET_PATH /tmp/private.png");
+    const result = await harness.tools.get("xai_image_to_video").execute(
+      "call",
+      { image: { data_url: dataUrl } },
+      undefined,
+      () => {},
+      authContext(TEST_MODEL),
+    );
+    expect(result.content[0].text).toBe("Error: Image-to-video input is invalid.");
+    expect(result.details).toMatchObject({ error: true, code: "invalid_input" });
+    expect(JSON.stringify(result)).not.toMatch(/SECRET_PATH|private\.png/);
+  });
+
+  it("maps unexpected image-to-video execution throws to a generic safe failure", async () => {
+    mediaErrors.videoExecute = new Error("SECRET_STACK /tmp/private.png oauth-token");
+    const result = await harness.tools.get("xai_image_to_video").execute(
+      "call",
+      { image: { data_url: dataUrl } },
+      undefined,
+      () => {},
+      authContext(TEST_MODEL),
+    );
+    expect(result.content[0].text).toBe("Error: xAI image-to-video generation failed safely.");
+    expect(result.details).toMatchObject({ error: true, code: "output_failure" });
+    expect(JSON.stringify(result)).not.toMatch(/SECRET_STACK|private\.png|oauth-token/);
+  });
+
+  it("rejects remote image-to-video paths before credentials, cwd, or network", async () => {
+    let credentialReads = 0;
+    const result = await harness.tools.get("xai_image_to_video").execute(
+      "call",
+      { image: { path: "https://example.test/SECRET-private.png" } },
+      undefined,
+      () => {},
+      {
+        model: TEST_MODEL,
+        get modelRegistry() {
+          credentialReads += 1;
+          throw new Error("must not resolve");
+        },
+        get cwd() {
+          throw new Error("must not inspect cwd");
+        },
+      },
+    );
+    expect(result.content[0].text).toMatch(/do not accept URL schemes/);
+    expect(result.details).toMatchObject({ error: true, code: "invalid_input" });
+    expect(JSON.stringify(result)).not.toMatch(/SECRET-private/);
+    expect(credentialReads).toBe(0);
+  });
+});

--- a/tests/tools/custom-tools.test.ts
+++ b/tests/tools/custom-tools.test.ts
@@ -137,6 +137,30 @@ describe("custom xAI tools", () => {
     expect(result.content[0].text).toMatch(/No xAI OAuth credentials/);
     expect(requests).toHaveLength(0);
   });
+  it.each([
+    ["xai_x_search", { query: "guard" }],
+    ["xai_multi_agent", { query: "guard" }],
+    ["xai_code_execution", { code: "print(1)" }],
+    ["xai_generate_image", { prompt: "guard" }],
+    ["xai_edit_image", { prompt: "edit", image: [{ data_url: `data:image/png;base64,${tinyPngBytes().toString("base64")}` }] }],
+    ["xai_image_to_video", { image: { data_url: `data:image/png;base64,${tinyPngBytes().toString("base64")}` } }],
+    ["xai_critique", { content: "guard" }],
+    ["xai_analyze_image", { image: "https://example.test/a.png" }],
+    ["xai_deep_research", { topic: "guard" }],
+  ] as const)("refuses %s without OAuth credentials before network", async (name, params) => {
+    vi.stubEnv("XAI_API_KEY", "must-not-use");
+    setXaiNetworkToolActive(h.api, TEST_MODEL, name, true);
+    const result = await h.tools.get(name).execute(
+      "call",
+      params,
+      undefined,
+      () => {},
+      { model: TEST_MODEL, modelRegistry: { find: () => undefined } },
+    );
+    expect(result.content[0].text).toMatch(/No xAI OAuth credentials/);
+    expect(JSON.stringify(result)).not.toContain("must-not-use");
+    expect(requests).toHaveLength(0);
+  });
   it("uses Grok 4.5 and high reasoning by default", async () => {
     await run("xai_generate_text", { prompt: "hi", model: "grok-4.5" });
     expect(requests.at(-1)?.body).toMatchObject({


### PR DESCRIPTION
Rebase of #189 (`cursor/missing-test-coverage-7872`) onto current `main`. Test-only; no production behavior changes.

PR #189 was cut from #186 and went stale behind #190, #192, and #195, ending up `CONFLICTING`. This is the same commit replayed on `main` with the conflict resolved and the gate re-run.

## Why this is still needed

Verified against current `main` rather than taken from the original description:

| Check | Result |
| --- | --- |
| `tests/tools/custom-tools-media-errors.test.ts` on `main` | absent — never landed |
| Coverage on `main` today | 90.93 / 84.89 / 93.30 / 94.14 |
| Coverage with this branch | **92.17 / 86.87 / 93.30 / 95.41** |
| Overlap with #186 / #187 | none — both are ancestors of the original branch |

## Conflict resolution

The only conflict was `.scaffold/progress.md`, agent bookkeeping. All seven test files applied clean. Resolved by merging both sides: `main`'s landed-work record (#190, #192, #195) is preserved, and the coverage-pass entry is restated with today's re-measured numbers instead of the pre-rebase ones.

## Coverage added

- Vision routing: alternate image-shape normalization (`input_image` object URLs / `file_id`, `image` data/base64/source, computer screenshots), computer-call association when replacing screenshots, grant refusals for missing or already-vision sources, and empty/oversized description rejection without leaking image URLs.
- Catalog: restore the previous entitlement cache when `commitAllowed` flips after a successful rename; 408/425/429/503 classified transient, 400 permanent.
- Image edit: input bounds, prepared-payload mismatches, session-directory failure, network throws, and invalid JSON — without reflecting secrets.
- Custom media tools: unexpected validator/execute throws stay generic; remote image-to-video paths and missing OAuth credentials refused before network.
- OAuth: already-aborted signal before waiting on the callback listener; catalog handoff that throws after cancel does not retain credentials or reflect the handoff error.

These are parsing, cancellation, permission, and redaction seams — the assertions target the AGENTS.md invariants directly, e.g. `rejects remote image-to-video paths before credentials, cwd, or network` uses throwing getters on `modelRegistry`/`cwd` and asserts zero credential reads, proving refusal precedes credential resolution.

## Verification (local, on the rebased branch)

- `npm run typecheck` — pass
- `npm test` — 55 files / 692 tests pass, loader smoke ok
- `npm run test:coverage` — 92.17 / 86.87 / 93.30 / 95.41, floors met
- `npm run compatibility:check` — policy, registry, packed manifest, unsupported-peer, and GitHub mirror parity all pass

The pre-rebase run reported 687 tests and 92.17 / 86.82 / 93.23 / 95.51; the deltas are #190's tests landing on `main` since the branch was cut, not a behavior change here.

The original PR noted packed `compatibility:boundaries` failing twice in the Cursor cloud image on isolated `npm install` (`Cannot read properties of null (reading 'edgesOut')`). That is the known environment/npm-installer failure — the hosted Pi 0.80.1 and 0.84.2 boundary jobs passed on #189 and run again here.

Closes #189
