### PR TITLE
chore(test): silence passing-test console output and load vitest config as ESM

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ pi-xai-oauth/
 │   ├── pi-versions.json # Peer range plus exact minimum/latest matrix policy
 │   └── grok-build-wire-protocol.md # Pinned xAI route/header review procedure
 ├── tests/                    # Focused typed Vitest domain suites + isolated fixtures
-├── vitest.config.ts          # Node isolation and measured V8 coverage floors
+├── vitest.config.mts         # Node isolation and measured V8 coverage floors
 ├── scripts/
 │   ├── verify-extension-loader.mjs # Small real Pi loader smoke
 │   ├── verify-compatibility.js # Policy/range/registry/pack/unsupported-peer checks

--- a/README.md
+++ b/README.md
@@ -999,7 +999,7 @@ pi-xai-oauth/
 │   ├── decisions/            # Package-scope and constrained-sampling ADRs
 │   ├── bridge-xai-tools.md   # xAI tools menu bridge protocol v1
 │   └── model-input-modalities.md
-├── vitest.config.ts          # Node isolation and measured V8 coverage floors
+├── vitest.config.mts         # Node isolation and measured V8 coverage floors
 ├── .scaffold/                # Persistent agent state (plan, progress, etc.)
 ├── AGENTS.md                 # AI agent operations manual
 ├── package.json

--- a/scripts/verify-compatibility.js
+++ b/scripts/verify-compatibility.js
@@ -225,7 +225,7 @@ function verifyPackedPackage() {
       "scripts/prepare-github-package.js",
       "scripts/verify-github-package.js",
       "scripts/verify-extension-loader.mjs",
-      "vitest.config.ts",
+      "vitest.config.mts",
       ...listGitVisibleFiles(path.join(repoRoot, "tests")),
     ];
     for (const file of required) assert.ok(packed.files.includes(file), `Packed package is missing ${file}`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,12 +2,12 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
-    "moduleResolution": "bundler",  // changed from node10
+    "moduleResolution": "bundler",
     "strict": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "types": ["node"]
   },
-  "include": ["extensions/**/*.ts", "tests/**/*.ts", "vitest.config.ts"]
+  "include": ["extensions/**/*.ts", "tests/**/*.ts", "vitest.config.mts"]
 }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -3,6 +3,9 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
+    // Keep console output from the real installer/provider code paths out of
+    // passing runs; it is still printed in full for any failing test.
+    silent: "passed-only",
     include: ["tests/**/*.test.ts"],
     setupFiles: ["./tests/setup.ts"],
     isolate: true,


### PR DESCRIPTION
Removes two independent sources of noise from `npm test` output. No production or test behavior changes.

## 1. Console leakage from passing tests

`bin/setup.js` has 69 `console.*` calls and `tests/setup/settings.test.ts` exercises the real installer without stubbing console, so every green run echoed the full settings-seeding transcript.

Set `silent: "passed-only"` in the vitest config. Console output is suppressed for passing tests and **retained in full for failing ones**, so debugging output survives where it matters.

Verified with a temporary probe test (added, run, removed — not part of this diff):

| Marker | Test outcome | In output? |
| --- | --- | --- |
| `HIDDEN_MARKER_SHOULD_NOT_APPEAR` | passing | no |
| `VISIBLE_MARKER_MUST_APPEAR` | failing | yes |

Incidentally, the alarming-looking ordering in that transcript — `Could not write settings.json` printed *before* `Configuring pi settings...` — was only stdout/stderr buffering in the reporter, not a fault in the error path.

## 2. ESM-as-CommonJS config warning

Every run also emitted:

```text
ESM syntax in a file loaded as CommonJS (vitest.config.ts:1:1).
Use a `.mjs` extension or set "type": "module" in the closest package.json
```

`package.json` has no top-level `"type"` field (the `"type": "git"` is inside `repository`). **This is longstanding, not introduced by the 4.1.11 bump in #195** — it appears in CI logs on 4.1.10 too (2x in run `32471382907`, 3x in run `32614123024`).

Renamed `vitest.config.ts` to `vitest.config.mts` so it loads as ESM. This avoids changing the package's module type (which would affect `bin/setup.js` and the `.js` scripts) and avoids papering over it with `VITE_CONFIG_NATIVE_IGNORE_WARNING`.

Updated every reference that would otherwise break:

- `tsconfig.json` `include` — keeps the config type-checked
- `scripts/verify-compatibility.js` required packed-file list — this gate would have failed loudly had it been missed
- `README.md` and `AGENTS.md` file trees

## Unrelated tidy-up, called out explicitly

Dropped a stale `// changed from node10` comment from `tsconfig.json:5`. It is valid JSONC and TypeScript parses it fine, but it trips generic JSON linters; since this PR already edits that file, it seemed better to remove it than leave a recurring false positive.

## Verification

- `npm run typecheck` — pass
- `npm test` — 54 files / 664 tests pass, loader smoke ok
- `npm run test:coverage` — 90.93 / 84.89 / 93.30 / 94.14, **unchanged**, floors met
- `npm run compatibility:check` — 145 packed files, policy/registry/unsupported-peer/mirror parity all pass

Independent of #196; the two touch disjoint files and can merge in either order.
