### PR TITLE
chore: stop agent formatter churn and pin the packed-test requirement

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,6 +10,7 @@ coverage/
 .vscode/
 .omp/
 .pi-subagents/
+.pi-lens.json
 .scaffold/
 .claude/
 CLAUDE.md

--- a/.pi-lens.json
+++ b/.pi-lens.json
@@ -1,0 +1,5 @@
+{
+  "format": { "enabled": false },
+  "autofix": { "enabled": false },
+  "actionableWarnings": { "autoFix": { "enabled": false } }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ Core flow: `bin/setup.js` → `pi install` → bounded catalog selection in `ext
 - Keep both Pi peers aligned to the checked-in bounded range in `compatibility/pi-versions.json`
 - Keep npmjs `pi-xai-oauth` canonical and publish GitHub Packages only as the exact scoped mirror `@blockedpath/pi-xai-oauth`; setup must treat both names as aliases and prevent duplicate registration
 - Install/report exact Pi matrix versions from a clean packed package; never reuse the repository lockfile for boundary jobs
+- Keep `tests/`, its fixtures, `vitest.config.mts`, and `tsconfig.json` inside the packed tarball; `scripts/run-compatibility-matrix.js` extracts the pack and runs `npm test` plus `npm run typecheck` inside it, so excluding them silently breaks both exact-Pi boundary jobs
 - Keep normal Pi dev dependencies exact at the policy's latest tested release and review candidate releases before widening support
 - Resolve `x-userid` transiently from the pinned authenticated CLI-proxy `/user` endpoint before any billing request
 - Keep `/xai-usage` explicit, and keep its optional status off by default, session-scoped, bounded, and inactive outside xAI models
@@ -100,6 +101,7 @@ pi-xai-oauth/
 │   └── ci.yml           # PR/main policy and exact Pi boundary matrix
 ├── package.json
 ├── tsconfig.json
+├── .pi-lens.json         # Disables agent formatter/autofix mutations (no repo formatter)
 ├── README.md
 ├── AGENTS.md             # This file
 └── .scaffold/            # Persistent agent state (auto-generated on init)
@@ -120,6 +122,7 @@ Start any task by reading:
 ## Style & Quality Rules
 
 - Use TypeScript strict mode
+- This repository runs no formatter or linter; `npm run typecheck` is the static gate. `.pi-lens.json` disables pi-lens format/autofix mutations because its defaults reflow files to a narrower width than the checked-in style, which buries real changes in unrelated churn. Do not commit whole-file reformatting, and do not adopt a formatter as a drive-by change
 - Prefer async/await for OAuth and API calls
 - Add JSDoc for all exported functions
 - Keep OAuth callback server minimal and secure


### PR DESCRIPTION
Two small guards, each preventing a problem that actually occurred while landing #195 through #198. Config and docs only; no production or test changes.

## 1. Agent formatter churn

pi-lens's post-write pipeline reformatted whole files on any edit, including pre-existing content it did not author. A one-line change to `scripts/verify-compatibility.js` arrived as a 219-line diff. I discarded it manually on every PR this session; a less careful run would have committed it.

This affects only agent sessions — the repository has no prettier config, no prettier dependency, and no git hooks, and AGENTS.md is explicit that there is no linter and `npm run typecheck` is the static gate.

The obvious fix — add a `.prettierrc` matching the repo so the autofix agrees — does not work. Measured churn against the committed files:

| File | width 80 | 100 | 120 | 140 |
| --- | ---: | ---: | ---: | ---: |
| `scripts/verify-compatibility.js` | 219 | 95 | **40** | 60 |
| `extensions/xai/oauth.ts` | 191 | 103 | **72** | 127 |
| `extensions/xai/catalog.ts` | 387 | 171 | **81** | 87 |
| `tests/tools/custom-tools.test.ts` | 409 | 251 | **250** | 316 |
| `bin/setup.js` | 229 | 91 | **36** | 36 |

Best fit is around 120, but every width still rewrites 36 to 250 lines per file, because the repo has never been formatter-managed. A config would legitimize the churn without removing it.

So this disables the mutating paths instead, via `.pi-lens.json`. Read-only diagnostics are unaffected — only the file rewriting stops.

Verified in place — the same one-line edit that previously produced 219 changed lines:

```text
$ git diff --numstat -- scripts/verify-compatibility.js
1	1	scripts/verify-compatibility.js
```

The file is npmignored alongside the other agent-tooling artifacts (`.scaffold/`, `.claude/`, `.pi-subagents/`), so the packed manifest stays at 146 files rather than shipping agent config to consumers.

Adopting prettier properly — config, one mass-reformat commit, CI check — remains a reasonable option, but it should be a deliberate decision rather than something the repo backs into via agent churn.

## 2. Packed tests are load-bearing

AGENTS.md said to run boundary jobs "from a clean packed package" but never stated that tests must be *inside* that pack. `scripts/run-compatibility-matrix.js` extracts the tarball and runs `npm test` plus `npm run typecheck` inside it:

```js
run("npm", ["test"],             { cwd: packageRoot, env: matrixEnv });
run("npm", ["run", "typecheck"], { cwd: packageRoot, env: matrixEnv });
```

So `tests/`, its fixtures, `vitest.config.mts`, and `tsconfig.json` are shipped payload by design, which is why `verify-compatibility.js` requires every `tests/` file in the pack.

Without that written down, trimming the published surface reads as harmless cleanup. I raised exactly that idea earlier in this session; acting on it would have broken both exact-Pi boundary jobs. This adds one MUST line so the next reader does not have to rediscover it.

## Verification

- `npm run typecheck` — pass
- `npm test` — 55 files / 692 tests pass, loader smoke ok
- `npm run compatibility:check` — packed manifest unchanged at 146 files, mirror parity pass
