### PR TITLE
test: pin streamed mismatch classification via extracted HTTP 400

### DIFF
--- a/tests/responses/reasoning-recovery.test.ts
+++ b/tests/responses/reasoning-recovery.test.ts
@@ -5,6 +5,7 @@ import {
   setXaiRuntimeModels,
 } from "../../extensions/xai/models";
 import { streamSimpleXaiResponses } from "../../extensions/xai/responses";
+import { XAI_ENCRYPTED_CONTENT_MISMATCH_MESSAGE } from "../../extensions/xai/wire";
 import { requestBody } from "../fixtures/http";
 import { TEST_MODEL } from "../fixtures/models";
 
@@ -242,6 +243,92 @@ describe("encrypted reasoning stream recovery", () => {
       );
     },
   );
+
+  it("classifies a streamed mismatch from text-extracted HTTP 400 without an invalid_request code", async () => {
+    const requests: any[] = [];
+    const responses = [
+      sse([
+        failedEvent(
+          "server_error",
+          "HTTP 400 STREAM_SECRET encrypted_content belongs to another model",
+        ),
+      ]),
+      sse([completedEvent("resp_recovered_400")]),
+      sse([completedEvent("resp_reasoning_restored")]),
+    ];
+    const fetchMock = vi.fn(async (_url: any, init: RequestInit = {}) => {
+      requests.push(requestBody(init));
+      return responses.shift()!;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const selectedModel = model("grok-4.6");
+    const history = priorToolHistory("openai-responses");
+
+    const failure = await streamSimpleXaiResponses(
+      selectedModel,
+      { messages: history } as any,
+      { apiKey: "oauth-token", sessionId: "issue-191" } as any,
+    ).result();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(
+      requests[0].input.find((item: any) => item.type === "reasoning"),
+    ).toEqual(reasoningItem);
+    expect(failure).toMatchObject({
+      provider: "xai-auth",
+      model: "grok-4.6",
+      stopReason: "error",
+    });
+    expect(failure.errorMessage).toBe(XAI_ENCRYPTED_CONTENT_MISMATCH_MESSAGE);
+    expect(failure.errorMessage).not.toMatch(
+      /STREAM_SECRET|encrypted_content|server_error|400/,
+    );
+
+    const recovered = await streamSimpleXaiResponses(
+      selectedModel,
+      {
+        messages: [
+          ...history,
+          failure,
+          { role: "user", content: "continue", timestamp: 5 },
+        ],
+      } as any,
+      { apiKey: "oauth-token", sessionId: "issue-191" } as any,
+    ).result();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(recovered).toMatchObject({
+      stopReason: "stop",
+      responseId: "resp_recovered_400",
+    });
+    expectVisibleToolHistory(requests[1]);
+    expect(
+      requests[1].input.some((item: any) => item.type === "reasoning"),
+    ).toBe(false);
+
+    const restored = await streamSimpleXaiResponses(
+      selectedModel,
+      {
+        messages: [
+          ...history,
+          failure,
+          { role: "user", content: "continue", timestamp: 5 },
+          recovered,
+          { role: "user", content: "keep going", timestamp: 7 },
+        ],
+      } as any,
+      { apiKey: "oauth-token", sessionId: "issue-191" } as any,
+    ).result();
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(restored).toMatchObject({
+      stopReason: "stop",
+      responseId: "resp_reasoning_restored",
+    });
+    expect(
+      requests[2].input.find((item: any) => item.type === "reasoning"),
+    ).toEqual(reasoningItem);
+  });
 
   it("does not clear reasoning after an unrelated streamed failure and preserves numeric status text", async () => {
     const requests: any[] = [];


### PR DESCRIPTION
## Description

Follow-up from PR #190 review. `isEncryptedContentMismatch` classifies encrypted-reasoning mismatches on the pinned Responses-proxy route. When a numeric status is available — passed explicitly **or extracted from the error text** by `statusFromTransportText` — classification requires only `status === 400` plus the `encrypted_content` marker. The `invalid_request` code check applies only to the truly status-less streamed path.

That contract is documented in the `safeXaiTransportErrorMessage` JSDoc but was not pinned by a test. This adds focused Vitest coverage so the heuristic stays explicit across Pi 0.80.x / 0.84.x boundary versions where delegate error shapes differ.

Fixes #191

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test-only pinning of existing classification behavior

## How Has This Been Tested?

- [x] `npm run test:unit -- tests/responses/reasoning-recovery.test.ts` (6 passed, including the new case)
- [x] `npm test` (policy + 693 unit tests + loader smoke)
- [x] `npm run typecheck`
- [x] `npm run compatibility:check`
- [x] `npm run compatibility:boundaries` (exact Pi 0.80.1 and 0.84.2 packed jobs)

New test in `tests/responses/reasoning-recovery.test.ts`:

1. Streamed `response.failed` with code `server_error` (not `invalid_request`) and detail containing extractable `HTTP 400` + `encrypted_content` is classified as a mismatch.
2. Asserts the fixed `XAI_ENCRYPTED_CONTENT_MISMATCH_MESSAGE` and that secret-looking content stays redacted. The inverse non-400 case (`HTTP 429`) remains covered by the existing transient-failure test.
3. Same-model turn 2 omits the `reasoning` item; turn 3 after a successful assistant message restores it.

Mutation-checked: re-adding `&& INVALID_REQUEST_PATTERN.test(detail)` to the status-known branch failed only the new test.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when streamed encrypted content is rejected with a server error.
  * Prevented unnecessary reasoning replay during recovery.
  * Ensured reasoning is restored correctly for subsequent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->