### PR TITLE
fix(grok-native): read and write through checked descriptors

### DIFF
--- a/extensions/xai/tools/grok-native.ts
+++ b/extensions/xai/tools/grok-native.ts
@@ -11,9 +11,7 @@ import {
   lstat,
   open,
   readdir,
-  readFile,
   realpath,
-  writeFile as writeFileUtf8,
 } from "node:fs/promises";
 import { Worker } from "node:worker_threads";
 import { basename, dirname, extname, isAbsolute, join, relative, sep } from "node:path";
@@ -366,17 +364,34 @@ async function toWorkspaceToolPath(cwd: string, absolutePath: string): Promise<s
   return relativePath;
 }
 
+function noFollowFlag(): number {
+  return typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
+}
+
+function nonBlockFlag(): number {
+  return typeof constants.O_NONBLOCK === "number" ? constants.O_NONBLOCK : 0;
+}
+
+/** Open a path without following a leaf symlink. */
+async function openUnfollowedFile(
+  absolutePath: string,
+  flags: number,
+): Promise<Awaited<ReturnType<typeof open>>> {
+  return open(absolutePath, flags | noFollowFlag());
+}
+
 async function readContainedTextFile(
   absolutePath: string,
   requestedPath: string,
   signal?: AbortSignal,
 ): Promise<string> {
   throwIfAborted(signal);
-  const noFollow = typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
-  const nonBlock = typeof constants.O_NONBLOCK === "number" ? constants.O_NONBLOCK : 0;
   let handle: Awaited<ReturnType<typeof open>> | undefined;
   try {
-    handle = await open(absolutePath, constants.O_RDONLY | noFollow | nonBlock);
+    handle = await openUnfollowedFile(
+      absolutePath,
+      constants.O_RDONLY | nonBlockFlag(),
+    );
     const info = await handle.stat();
     if (!info.isFile()) throw new Error(`Not a file: ${requestedPath}`);
     if (info.size > MAX_GROK_NATIVE_TEXT_FILE_BYTES) {
@@ -404,6 +419,28 @@ async function readContainedTextFile(
     }
     throwIfAborted(signal);
     return Buffer.concat(chunks, totalBytes).toString("utf8");
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
+async function writeContainedTextFile(
+  absolutePath: string,
+  content: string,
+  requestedPath: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  throwIfAborted(signal);
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    handle = await openUnfollowedFile(
+      absolutePath,
+      constants.O_WRONLY | constants.O_TRUNC,
+    );
+    const info = await handle.stat();
+    if (!info.isFile()) throw new Error(`Not a file: ${requestedPath}`);
+    throwIfAborted(signal);
+    await handle.writeFile(content, "utf8");
   } finally {
     await handle?.close().catch(() => undefined);
   }
@@ -627,14 +664,27 @@ async function runLocalGrep(
       limitReached = true;
       break;
     }
-    const info = await lstat(filePath).catch(skipUnreadableSearchEntry);
-    if (!info?.isFile() || info.size > MAX_GROK_GREP_FILE_BYTES) continue;
-    if (totalScannedBytes + info.size > MAX_GROK_GREP_TOTAL_BYTES) {
-      scanLimitReached = true;
-      break;
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    let rawContent: string | undefined;
+    try {
+      handle = await openUnfollowedFile(
+        filePath,
+        constants.O_RDONLY | nonBlockFlag(),
+      );
+      const info = await handle.stat();
+      if (!info.isFile() || info.size > MAX_GROK_GREP_FILE_BYTES) continue;
+      if (totalScannedBytes + info.size > MAX_GROK_GREP_TOTAL_BYTES) {
+        scanLimitReached = true;
+        break;
+      }
+      totalScannedBytes += info.size;
+      rawContent = await handle.readFile("utf8");
+    } catch (error) {
+      skipUnreadableSearchEntry(error);
+      continue;
+    } finally {
+      await handle?.close().catch(() => undefined);
     }
-    totalScannedBytes += info.size;
-    const rawContent = await readFile(filePath, "utf8").catch(skipUnreadableSearchEntry);
     if (rawContent === undefined) continue;
     checkGrepBudget(signal, deadline);
     const content = rawContent.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
@@ -842,7 +892,7 @@ async function executeSearchReplace(
           normalized.path,
         );
         throwIfAborted(signal);
-        await writeFileUtf8(queuedPath, replacementContent, "utf8");
+        await writeContainedTextFile(queuedPath, replacementContent, normalized.path, signal);
       },
     },
   }).execute(

--- a/tests/tools/grok-native-path-races.test.ts
+++ b/tests/tools/grok-native-path-races.test.ts
@@ -1,0 +1,136 @@
+import { constants, symlinkSync, unlinkSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import { join, sep } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { XAI_GROK_NATIVE_TOOL_NAME_MAP } from "../../extensions/xai/constants";
+import {
+  CURATED_FALLBACK_MODELS,
+  KNOWN_XAI_MODEL_METADATA,
+  setXaiRuntimeModels,
+} from "../../extensions/xai/models";
+import { registerGrokNativeTools } from "../../extensions/xai/tools/grok-native";
+import { createExtensionHarness, toolExecutionContext } from "../fixtures/extension-api";
+import { createTempDir } from "../fixtures/temp";
+
+const openHooks = vi.hoisted(() => ({
+  beforeOpen: undefined as ((path: string, flags: number | string | undefined) => void) | undefined,
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    open: async (...args: any[]) => {
+      const path = String(args[0]);
+      const flags = args[1] as number | string | undefined;
+      openHooks.beforeOpen?.(path, flags);
+      return await (actual.open as any)(...args);
+    },
+    // Old grep used pathname readFile, whose internal open does not go through
+    // the mocked `open`. Hook it so a revert still loses the race.
+    readFile: async (...args: any[]) => {
+      openHooks.beforeOpen?.(String(args[0]), "r");
+      return await (actual.readFile as any)(...args);
+    },
+  };
+});
+
+function isWriteOpen(flags: number | string | undefined): boolean {
+  if (typeof flags === "number") {
+    return (
+      (flags & constants.O_WRONLY) === constants.O_WRONLY ||
+      (flags & constants.O_RDWR) === constants.O_RDWR
+    );
+  }
+  return typeof flags === "string" && flags.includes("w");
+}
+
+describe.runIf(process.platform !== "win32")("Grok-native leaf-symlink races", () => {
+  let temp: Awaited<ReturnType<typeof createTempDir>>;
+  let outside: Awaited<ReturnType<typeof createTempDir>>;
+  let h: ReturnType<typeof createExtensionHarness>;
+
+  beforeEach(async () => {
+    temp = await createTempDir("pi-xai-grok-race-");
+    outside = await createTempDir("pi-xai-grok-race-outside-");
+    h = createExtensionHarness();
+    setXaiRuntimeModels(KNOWN_XAI_MODEL_METADATA);
+    registerGrokNativeTools(h.api);
+  });
+
+  afterEach(async () => {
+    openHooks.beforeOpen = undefined;
+    setXaiRuntimeModels(CURATED_FALLBACK_MODELS);
+    await Promise.all([temp.cleanup(), outside.cleanup()]);
+  });
+
+  function tool(name: string) {
+    const dispatchName =
+      Object.entries(XAI_GROK_NATIVE_TOOL_NAME_MAP).find(([, publicName]) => publicName === name)?.[0] ??
+      name;
+    return h.tools.get(dispatchName);
+  }
+
+  async function run(name: string, params: any) {
+    return tool(name).execute(
+      "call",
+      params,
+      new AbortController().signal,
+      () => {},
+      toolExecutionContext(temp.path),
+    );
+  }
+
+  it("still reads and replaces a regular workspace file", async () => {
+    await writeFile(join(temp.path, "ok.txt"), "find-me old");
+    const grepped = await run("grep", { pattern: "find-me", path: "." });
+    expect(grepped.content[0].text).toMatch(/find-me/);
+    await run("search_replace", {
+      file_path: "ok.txt",
+      old_string: "old",
+      new_string: "new",
+    });
+    expect(await readFile(join(temp.path, "ok.txt"), "utf8")).toBe("find-me new");
+  });
+
+  it("refuses a search_replace write after the leaf is swapped for an outward symlink", async () => {
+    const target = join(temp.path, "replace-target.txt");
+    const leaked = join(outside.path, "secret.txt");
+    await writeFile(target, "old");
+    await writeFile(leaked, "OUTSIDE_SECRET");
+
+    openHooks.beforeOpen = (path, flags) => {
+      if (!path.endsWith(`${sep}replace-target.txt`) || !isWriteOpen(flags)) return;
+      openHooks.beforeOpen = undefined;
+      unlinkSync(path);
+      symlinkSync(leaked, path);
+    };
+
+    await expect(
+      run("search_replace", {
+        file_path: "replace-target.txt",
+        old_string: "old",
+        new_string: "replacement",
+      }),
+    ).rejects.toThrow(/ELOOP|symbolic link/i);
+    expect(await readFile(leaked, "utf8")).toBe("OUTSIDE_SECRET");
+  });
+
+  it("skips a grep read after the leaf is swapped for an outward symlink", async () => {
+    const target = join(temp.path, "grep-target.txt");
+    const leaked = join(outside.path, "secret.txt");
+    await writeFile(target, "workspace-visible");
+    await writeFile(leaked, "OUTSIDE_SECRET");
+
+    openHooks.beforeOpen = (path) => {
+      if (!path.endsWith(`${sep}grep-target.txt`)) return;
+      openHooks.beforeOpen = undefined;
+      unlinkSync(path);
+      symlinkSync(leaked, path);
+    };
+
+    const result = await run("grep", { pattern: "OUTSIDE_SECRET", path: "." });
+    expect(result.content[0].text).toBe("No matches found");
+    expect(await readFile(leaked, "utf8")).toBe("OUTSIDE_SECRET");
+  });
+});


### PR DESCRIPTION
## Description

#165 is a closed checklist. Six of its seven bullets do not hold (unreachable, invalid/regressing, overstated, no threat model, or already covered by an allowlist). The one survivor was already split to **#200**.

This PR implements #200 only.

`search_replace` wrote with `writeFile(queuedPath, …)` and grep read with `lstat` + `readFile(filePath)` after validation. A leaf symlink swapped in between those steps is followed.

Both paths now open with `O_NOFOLLOW` and do I/O through the descriptor, using a helper extracted from the already-safe `readContainedTextFile` contract (unchanged).

Fixes #200

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] `npm run test:unit -- tests/tools/grok-native*.test.ts` (39 passed)
- [x] `npm test` (policy + 696 unit tests + loader smoke)
- [x] `npm run typecheck`
- [x] `npm run compatibility:check`
- [x] `npm run compatibility:boundaries` (exact Pi 0.80.1 and 0.84.2 packed jobs)

New POSIX-only suite `tests/tools/grok-native-path-races.test.ts`:

1. `search_replace` write: swap the leaf for an outward symlink after the read open and before the write open → `ELOOP`, outside file unchanged.
2. grep read: same swap before the file open → `No matches found`, outside secret not reflected.
3. Happy path still greps and replaces a regular workspace file.

Mutation-checked: restoring pathname `writeFile` / `readFile` fails only the corresponding race test. Existing sibling-hunk and queue suites stay green.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes