### PR TITLE
chore(release): prepare v1.5.2

### DIFF
--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,38 +1,28 @@
-# Execution Progress — coverage pass (rebased 2026-08-22)
+# Execution Progress — v1.5.2 release
 
-**Branch:** `chore/rebase-189` (rebase of `cursor/missing-test-coverage-7872` onto `main`)
+**Branch:** `release/v1.5.2`
 
 ## Previously landed on `main`
 
-- [x] PR #190 (issue #188 streamed reasoning-mismatch recovery) merged as `8eaf274`.
-- [x] v1.5.1 released via PR #192.
-- [x] PR #195 merged: combined `vitest` + `@vitest/coverage-v8` 4.1.11 bump and Dependabot
-      `groups` for the vitest packages and both Pi peers, superseding the split PRs #193/#194.
+- [x] v1.5.1 released via PR #192 and GitHub Release `v1.5.1`.
+- [x] PR #195 merged: combined `vitest` + `@vitest/coverage-v8` 4.1.11 bump.
+- [x] PR #196 / #197: coverage regressions plus quieter Vitest output.
+- [x] PR #198: raised V8 coverage floors to the measured baseline.
+- [x] PR #199: stopped agent formatter churn and pinned the packed-test requirement.
+- [x] PR #201: pinned streamed HTTP 400 mismatch classification.
+- [x] PR #202 (issue #200): Grok-native reads/writes through checked descriptors.
 
 ## Completed (this branch)
 
-- [x] Inspected recent merges (#186/#187 coverage PRs already on main) and leftover gaps from the 2026-08-20 pass.
-- [x] Added vision-routing image-shape normalization, computer-call association, and description-bound tests.
-- [x] Added catalog post-rename `commitAllowed` restore plus 408/425/429/400 fetch classification.
-- [x] Added image-edit validation/wire/session/network/JSON redaction tests.
-- [x] Added custom media-tool generic catch redaction and missing-credential refusals.
-- [x] Added OAuth already-aborted callback wait and cancel-during-catalog-handoff tests.
-- [x] Rebased onto `main` after #190/#192/#195; only `.scaffold/progress.md` conflicted, all seven test
-      files applied clean.
-- [x] Re-verified on rebased `main`: `npm test` 55 files / 692 tests passed plus the real Pi loader
-      smoke, and `npm run typecheck` passed.
-- [x] Re-measured coverage against the current baseline: 90.93 / 84.89 / 93.30 / 94.14 on `main`
-      rises to 92.17 / 86.87 / 93.30 / 95.41 with this branch.
+- [x] Bumped package and lock metadata to 1.5.2.
+- [x] Finalized the Grok-native descriptor-I/O changelog entry.
+- [x] Updated README latest-release and Updating version references.
+- [x] Passed `npm test` (696 tests), `npm run typecheck`, `npm run compatibility:check`, both exact Pi 0.80.1/0.84.2 packed boundaries, `npm pack --dry-run --json` (147 files), and `git diff --check` for v1.5.2.
 
-## Notes
+## In Progress
 
-- The pre-rebase run reported 687 tests and 92.17 / 86.82 / 93.23 / 95.51; the deltas are #190's tests
-  landing on `main` since the branch was cut, not a behavior change here.
-- Packed `compatibility:boundaries` failed twice in the original cloud image on isolated `npm install`
-  (`Cannot read properties of null (reading 'edgesOut')`) before tests ran — environment/npm installer,
-  not a test flake. The hosted Pi 0.80.1 and 0.84.2 boundary jobs passed in CI.
+- [ ] Merge the release PR, publish GitHub Release `v1.5.2`, and monitor both registry publish steps.
 
 ## Next
 
-Land the rebased coverage branch, then resume the regular coverage cadence against the remaining
-`extensions/xai-oauth.ts` and `media/output-storage.ts` gaps.
+Publish v1.5.2 through the GitHub Release workflow (`publish.yml`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 
 ## Unreleased
 
+## 1.5.2 - 2026-08-23
+
+### Fixed
+
+- Closed the remaining Grok-native leaf-symlink race by opening `search_replace` writes and `grep` reads with `O_NOFOLLOW` and performing I/O through the checked descriptor, without changing the already-safe contained text-file read contract.
+
 ## 1.5.1 - 2026-08-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ pi --model grok-4.6:low "Quick status check"   # fast mode
 
 This package adds xAI's **account-specific OAuth model catalog** to pi, with **Grok 4.6** as the offline fallback/default, proper OAuth login, automatic token refresh, and a suite of custom xAI tools (`xai_generate_text`, `web_search`, `xai_x_search`, etc.). The normalized cache remains exact; registration may additionally expose narrowly verified compatibility routes such as Grok 4.3 and Composer only while their required authenticated entitlement source is present. Entitled accounts that still receive `grok-4.5` keep that model as a first-class catalog entry.
 
-> **Latest release:** `pi-xai-oauth` **1.5.1** recovers same-model turns after streamed encrypted-reasoning mismatches while keeping rejected reasoning and upstream details redacted. It publishes the canonical `pi-xai-oauth` package on npmjs and a scoped `@blockedpath/pi-xai-oauth` mirror on GitHub Packages from the same validated GitHub Release. Setup treats both registry names as one extension and removes duplicate aliases before they can register conflicting tools. Existing npmjs installs should run `pi update npm:pi-xai-oauth`; GitHub Packages installs should run `pi update npm:@blockedpath/pi-xai-oauth`.
+> **Latest release:** `pi-xai-oauth` **1.5.2** closes the remaining Grok-native leaf-symlink race by reading and writing through checked descriptors. It publishes the canonical `pi-xai-oauth` package on npmjs and a scoped `@blockedpath/pi-xai-oauth` mirror on GitHub Packages from the same validated GitHub Release. Setup treats both registry names as one extension and removes duplicate aliases before they can register conflicting tools. Existing npmjs installs should run `pi update npm:pi-xai-oauth`; GitHub Packages installs should run `pi update npm:@blockedpath/pi-xai-oauth`.
 >
-> **Compatibility:** 1.5.1 supports aligned `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` versions `>=0.80.1 <0.85.0`. The exact tested boundaries are 0.80.1 and 0.84.2.
+> **Compatibility:** 1.5.2 supports aligned `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` versions `>=0.80.1 <0.85.0`. The exact tested boundaries are 0.80.1 and 0.84.2.
 
 See [CHANGELOG.md](CHANGELOG.md) for the complete version-by-version feature and fix history.
 
@@ -813,7 +813,7 @@ pi update npm:pi-xai-oauth
 
 This pulls the latest version from npm and updates your installed extension.
 
-Version 1.5.1 requires aligned Pi runtime packages in `>=0.80.1 <0.85.0`, with exact packed-package validation at 0.80.1 and 0.84.2. It preserves Pi 0.84.2 OAuth refresh and model-catalog lifecycle compatibility while publishing identical release contents to npmjs as `pi-xai-oauth` and GitHub Packages as `@blockedpath/pi-xai-oauth`. See [CHANGELOG.md](CHANGELOG.md) for the complete release notes. Update the registry distribution you installed; if you are testing a local checkout instead, reinstall the checkout:
+Version 1.5.2 requires aligned Pi runtime packages in `>=0.80.1 <0.85.0`, with exact packed-package validation at 0.80.1 and 0.84.2. It preserves Pi 0.84.2 OAuth refresh and model-catalog lifecycle compatibility while publishing identical release contents to npmjs as `pi-xai-oauth` and GitHub Packages as `@blockedpath/pi-xai-oauth`. See [CHANGELOG.md](CHANGELOG.md) for the complete release notes. Update the registry distribution you installed; if you are testing a local checkout instead, reinstall the checkout:
 
 ```bash
 pi remove npm:pi-xai-oauth && pi install .

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-xai-oauth",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-xai-oauth",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "bin": {
         "pi-xai-oauth": "bin/setup.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-xai-oauth",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "xAI OAuth provider with an authenticated account-specific Grok model catalog for pi",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
## Summary
- bump npm package and lock metadata to 1.5.2
- finalize the Grok-native descriptor-I/O changelog entry
- update release and exact Pi boundary references in README
- record release validation in scaffold progress

## Validation
- `npm test` (696 tests passed)
- `npm run typecheck`
- `npm run compatibility:check`
- `npm run compatibility:boundaries` (Pi 0.80.1 and 0.84.2)
- `npm pack --dry-run --json` (147 files)
- `git diff --check`

## Publish
Merging this PR and publishing GitHub Release `v1.5.2` triggers `.github/workflows/publish.yml` for npmjs `pi-xai-oauth` and GitHub Packages `@blockedpath/pi-xai-oauth`.