### PR TITLE
fix: correct stale default-model copy and pack/doc contract drift

### DIFF
--- a/bin/setup.js
+++ b/bin/setup.js
@@ -278,7 +278,7 @@ function printNextSteps(nonInteractive = false) {
     console.log(`   ${color("3.", "bold")} Use package tools and subscription usage on either provider:`);
     console.log("      /xai-tools   — opt-in network tools (web/X search, images, etc.)");
     console.log("      /xai-usage   — SuperGrok subscription usage\n");
-    console.log(`   ${color("4.", "bold")} Start chatting with Grok 4.5 (default model)`);
+    console.log(`   ${color("4.", "bold")} Start chatting with ${DEFAULT_XAI_MODEL} (default model)`);
     console.log(`      ${color("pi", "cyan")}\n`);
   } else {
     console.log("Package tools and /xai-usage are installed. Chat defaults to Pi's built-in xAI provider when unset.\n");
@@ -388,7 +388,7 @@ Update this file frequently.`,
 **Date:** ${date}
 
 ## Key Context
-- This project provides xAI OAuth + Grok 4.5 for pi agents.
+- This project provides xAI OAuth + ${DEFAULT_XAI_MODEL} for pi agents.
 - Use subagent tool for delegation.
 - Persistent state lives in .scaffold/.
 

--- a/extensions/xai/responses.ts
+++ b/extensions/xai/responses.ts
@@ -439,9 +439,10 @@ export function assertXaiRuntimeModelAcceptsPayload(
 /**
  * Create one xAI Responses result using explicit credential-aware routing.
  *
- * OAuth requests receive the final `store: false` and encrypted-reasoning
- * include policy after canonicalization, model pinning, entitlement checks,
- * and inline-image compaction; API-key requests retain their separate route.
+ * OAuth requests receive the encrypted-reasoning include policy and default to
+ * `store: false` (a caller payload hook may supply its own `store`) after
+ * canonicalization, model pinning, entitlement checks, and inline-image
+ * compaction; API-key requests retain their separate route.
  *
  * @param credential Explicit OAuth-session or API-key credential and catalog scope.
  * @param body Caller Responses body, canonicalized before policy checks or transport.

--- a/scripts/verify-compatibility.js
+++ b/scripts/verify-compatibility.js
@@ -226,6 +226,7 @@ function verifyPackedPackage() {
       "scripts/verify-github-package.js",
       "scripts/verify-extension-loader.mjs",
       "vitest.config.mts",
+      "tsconfig.json",
       ...listGitVisibleFiles(path.join(repoRoot, "tests")),
     ];
     for (const file of required) assert.ok(packed.files.includes(file), `Packed package is missing ${file}`);


### PR DESCRIPTION
## Summary

Three one-line fixes. All behavior-free; no runtime logic changes.

These are the survivors of a **validity audit** over a 27-finding automated review pass. 24 findings were closed as invalid, moot, or overstated — in nearly every case the "missing" guard was already enforced by the sole caller, or the flagged behavior was deliberately pinned by a named test.

## Changes

| File | Change |
|---|---|
| `bin/setup.js` | Interpolate `DEFAULT_XAI_MODEL` in the next-steps line and the generated `context.md` template. Setup printed **"Start chatting with Grok 4.5"** in the same run that sets and reports `defaultModel: grok-4.6`. |
| `scripts/verify-compatibility.js` | Add `tsconfig.json` to the packed-manifest `required[]`. `run-compatibility-matrix.js` runs `npm run typecheck` inside the extracted pack, and AGENTS.md names `tsconfig.json` a must-pack artifact — without this, dropping it surfaces as a confusing `tsc` error in boundary jobs instead of a clear "missing from tarball" failure. |
| `extensions/xai/responses.ts` | `createXaiResponse` JSDoc claimed OAuth requests receive "the final `store: false`". A caller payload hook may supply its own `store`, which `payload.test.ts:488-491` and `streaming.test.ts:86-108` deliberately pin. Reworded to describe the default. Doc-only. |

## Notable findings deliberately **not** acted on

Each of these had a prescribed fix that would have caused a regression:

- Treating unknown credential expiry as expired sends the legacy `refresh: ""` shape into `refreshXaiCredentials`, converting a handled 401 into an **uncaught tool crash**.
- Forcing catalog revalidation on the stale-cache path **invalidates a good entitlement set on a network blip** and force-switches the user's active model mid-session.
- Blanket-scrubbing the stream catch path breaks `vision-routing.test.ts:733`, which asserts an exact message through it.
- Enforcing entitlement inside `xaiModelForRequest` breaks Pi's built-in `xai` provider (`grok-native.test.ts:807`).
- A reported SSRF gap ("blocklist misses TEST-NET-1") was a misread: `(a === 192 && b === 0)` never inspects the third octet, so it is a **/16** that already contains `192.0.2.0/24` — pinned by `video-download.test.ts:90`.

## Verification

- `npm test` — **696 passed / 56 files**
- `npm run typecheck` — clean
- `npm run test:loader` — `verify-extension-loader: ok`
- `npm run compatibility:check` — policy, registry, 144-file pack, both unsupported-peer negatives, GitHub mirror parity
- `npm pack --dry-run` confirms `tsconfig.json` is packed, so the new `required[]` entry asserts something true rather than passing vacuously
