### PR TITLE
feat(usage): add explicit privacy-safe CSV export

### DIFF
--- a/.scaffold/progress.md
+++ b/.scaffold/progress.md
@@ -1,4 +1,24 @@
-# Execution Progress — v1.5.2 release
+# Execution Progress — xAI usage CSV export
+
+**Active branch:** `feature/xai-usage-csv-export`
+
+- Read AGENTS.md, provider entrypoint, usage implementation/tests, setup, README, and Pi command docs.
+- Keep `/xai-usage csv` explicit: reuse the bounded identity-first lookup and display copyable CSV without automatic file writes, cached snapshots, or status opt-in.
+- Export only allowlisted normalized current/history fields; cents remain numeric, missing values stay blank, and spreadsheet formulas are neutralized.
+- Preserve existing cancellation/reset guards, OAuth-only authentication, redacted errors, and off-by-default status.
+- Implemented allowlisted CSV renderer and `/xai-usage csv`; documented the schema, copy/save workflow, cents, blanks, and formula protection in README.md.
+- Focused validation: all 66 usage tests pass, including CSV schema/escaping/privacy, both OAuth providers, identity-first transport, error redaction, API-key rejection, invalid arguments, cancellation, reset, and supersession.
+- Full gates passed: `npm test` (731 tests plus loader), `npm run typecheck`, `npm run test:coverage` (all floors met), and `npm run compatibility:check` (policy/registry/pack/unsupported peers/mirror). Primary LSP diagnostics: no findings in four changed TypeScript files.
+- Added command guidance to AGENTS.md and an Unreleased changelog entry.
+- Exact clean packed boundaries passed at Pi 0.80.1 and 0.84.4: each ran 730 tests (one Git-only pack test intentionally skipped), loader smoke, and typecheck.
+- Final diff review: scoped changes only; `git diff --check` passed. Session diagnostics contain no blocking errors; existing README/AGENTS code-fence warnings are unchanged.
+- Implementation and validation complete; no live authenticated request performed.
+- Delivery: commit the scoped CSV changes on `feature/xai-usage-csv-export`, push, and open a PR for review. Do not merge.
+- Leave the pre-existing untracked `IDEA.md` untouched; no whole-file reformatting.
+
+## Previous release progress
+
+### Execution Progress — v1.5.2 release
 
 **Branch:** `release/v1.5.2`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ Core flow: `bin/setup.js` → `pi install` → bounded catalog selection in `ext
 
 - Install / setup: `node bin/setup.js` or `npm run setup`
 - Install as pi extension: `pi install npm:pi-xai-oauth`
+- Explicit usage CSV export in Pi TUI/RPC: `/xai-usage csv` (normalized fields only, copyable output, no automatic file writes or status opt-in)
 - Full policy/unit/loader gate: `npm test`
 - Focused Vitest suite: `npm run test:unit -- tests/oauth/browser-login.test.ts`
 - V8 coverage: `npm run test:coverage`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Dates below are npm publication dates. The earliest rapid-release series is grou
 
 ## Unreleased
 
+### Added
+
+- Added `/xai-usage csv` to display copyable current/history usage CSV with exact cent values, blank missing fields, and spreadsheet-formula protection. It reuses the explicit bounded OAuth-only lookup, exports no identity, headers, or raw bodies, writes no files, and leaves status opt-in unchanged.
+
 ## 1.5.2 - 2026-08-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -299,6 +299,16 @@ The command displays only validated fields that xAI actually returned, such as i
 
 The billing surface is **not a stable public xAI API**. This implementation is pinned to [`xai-org/grok-build@b189869`](https://github.com/xai-org/grok-build/blob/b189869b7755d2b482969acf6c92da3ecfeffd36/crates/codegen/xai-grok-shell/src/extensions/billing.rs): it first makes authenticated `GET /v1/user`, uses the returned validated `userId` only for the immediately following `GET /v1/billing?format=credits`, then discards it. The command accepts a current Pi-stored OAuth credential under this package's `xai-auth` provider or Pi's built-in `xai` SuperGrok/X Premium provider, and rejects stored, environment, or runtime API-key provenance. Account identity, bearer/authenticated headers, and raw response bodies are never logged, displayed, cached, or persisted. If identity cannot be resolved safely, billing is not requested.
 
+To export a fresh usage snapshot as copyable CSV in the Pi TUI or RPC UI:
+
+```text
+/xai-usage csv
+```
+
+Copy the CSV notification into a `.csv` file or spreadsheet import. This command does not write a file, cache a snapshot, or enable status. It uses the same bounded, OAuth-only identity-first lookup as `/xai-usage`, without pagination or extra requests. Output contains a header, one `current` row, and up to 24 validated `history` rows in response order, with comma-separated fields and CRLF record endings.
+
+Columns are `record_type`, `period_type`, `period_start`, `period_end`, `billing_year`, `billing_month`, `subscription_tier`, `credit_usage_percent`, `monthly_limit_cents`, `included_used_cents`, `on_demand_cap_cents`, `on_demand_used_cents`, `total_used_cents`, `prepaid_balance_cents`, `on_demand_enabled`, and `is_unified_billing_user`. Credit amounts remain integer **cents**, percentages remain numbers on the 0–100 scale, and booleans are `true`/`false`. Missing or inapplicable values are blank, not zero; current `usedCents` maps to `included_used_cents`. Percentages are not inferred, nor are current subscription settings copied into history rows. Quoted cells escape commas and double quotes; formula-like text beginning with `=`, `+`, `-`, or `@` (including after whitespace) is prefixed with an apostrophe for spreadsheet safety. Only allowlisted normalized usage fields are exported—never identity, bearer headers, or raw usage bodies. Any CSV you save contains billing information; handle it accordingly.
+
 The compact footer status is off by default and requires a separate per-session opt-in while an `xai-auth` or built-in `xai` model is active with Pi-managed OAuth:
 
 ```text
@@ -676,6 +686,7 @@ Opt-in research using the active xAI model plus native web and X search tools. E
 | Set default model | `/model grok-4.6` (in TUI) |
 | Set thinking level | `/think high` (in TUI) |
 | Show subscription usage | `/xai-usage` (unofficial, explicit request) |
+| Export copyable usage CSV | `/xai-usage csv` (no automatic file writes) |
 | Manage optional usage status | `/xai-usage status on\|off` (off by default) |
 | Manage outbound xAI tools | `/xai-tools` (in TUI) |
 | Recreate extension/catalog state | `/reload` (respects the 15-minute cache TTL) |

--- a/extensions/xai/usage.ts
+++ b/extensions/xai/usage.ts
@@ -27,7 +27,7 @@ import type { XaiCredential } from "./routing";
 import { xaiUsageHeaders } from "./wire";
 
 const XAI_USAGE_STATUS_KEY = "xai-usage";
-const XAI_USAGE_COMMAND_HELP = "Usage: /xai-usage [status [on|off]]";
+const XAI_USAGE_COMMAND_HELP = "Usage: /xai-usage [csv|status [on|off]]";
 const MAX_USER_ID_LENGTH = 256;
 const MAX_LABEL_LENGTH = 80;
 const MAX_TIMESTAMP_LENGTH = 64;
@@ -476,6 +476,42 @@ export function renderXaiUsage(usage: XaiUsageSnapshot): string {
   return lines.join("\n");
 }
 
+function usageCsvCell(value: string | number | boolean | undefined): string {
+  if (value === undefined) return "";
+  let text = String(value);
+  // CSV quoting alone does not prevent spreadsheet formula execution.
+  if (typeof value === "string" && /^\s*[=+@-]/.test(text)) text = `'${text}`;
+  return /[",\r\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+}
+
+/** Render a parsed, bounded usage snapshot as CSV, without identity or raw response fields. */
+export function renderXaiUsageCsv(usage: XaiUsageSnapshot): string {
+  // Keep an explicit allowlist: never enumerate properties from authenticated data.
+  const rows: Array<Array<string | number | boolean | undefined>> = [
+    [
+      "record_type", "period_type", "period_start", "period_end", "billing_year", "billing_month",
+      "subscription_tier", "credit_usage_percent", "monthly_limit_cents", "included_used_cents",
+      "on_demand_cap_cents", "on_demand_used_cents", "total_used_cents", "prepaid_balance_cents",
+      "on_demand_enabled", "is_unified_billing_user",
+    ],
+    [
+      "current", usage.currentPeriod?.type, usage.currentPeriod?.start, usage.currentPeriod?.end,
+      undefined, undefined, usage.subscriptionTier, usage.creditUsagePercent,
+      usage.monthlyLimitCents, usage.usedCents, usage.onDemandCapCents, usage.onDemandUsedCents,
+      undefined, usage.prepaidBalanceCents, usage.onDemandEnabled, usage.isUnifiedBillingUser,
+    ],
+  ];
+  for (const entry of usage.history) {
+    rows.push([
+      "history", entry.period?.type, entry.period?.start, entry.period?.end,
+      entry.billingCycle?.year, entry.billingCycle?.month, undefined, undefined,
+      undefined, entry.includedUsedCents, undefined, entry.onDemandUsedCents,
+      entry.totalUsedCents, undefined, undefined, undefined,
+    ]);
+  }
+  return rows.map((row) => row.map(usageCsvCell).join(",")).join("\r\n") + "\r\n";
+}
+
 /** Render a compact footer value without account identity. */
 export function renderXaiUsageStatus(usage: XaiUsageSnapshot): string {
   const percent = effectivePercent(usage);
@@ -570,6 +606,9 @@ export function registerXaiUsage(
         "xAI OAuth credentials are required. Run /login xai or /login xai-auth first.",
       );
     }
+    if (signal?.aborted) {
+      throw new XaiUsageError("cancelled", "xAI usage request was cancelled.");
+    }
     return dependencies.fetchUsage(credential, signal);
   };
 
@@ -627,10 +666,11 @@ export function registerXaiUsage(
   };
 
   pi.registerCommand("xai-usage", {
-    description: "Show xAI subscription usage or manage the optional session status",
+    description: "Show xAI subscription usage, export CSV, or manage the optional session status",
     handler: async (args: string, ctx: ExtensionCommandContext) => {
       const parts = args.trim().split(/\s+/).filter(Boolean).map((part) => part.toLowerCase());
-      if (parts.length === 0) {
+      const csv = parts.length === 1 && parts[0] === "csv";
+      if (parts.length === 0 || csv) {
         oneShotController?.abort();
         const controller = new AbortController();
         oneShotController = controller;
@@ -640,12 +680,14 @@ export function registerXaiUsage(
         ctx.signal?.addEventListener("abort", forwardAbort, { once: true });
         if (ctx.signal?.aborted) controller.abort();
         try {
+          if (controller.signal.aborted) return;
           const usage = await resolveUsage(ctx, controller.signal);
           if (
             requestGeneration === oneShotGeneration
             && sessionGeneration === generation
+            && !controller.signal.aborted
           ) {
-            ctx.ui.notify(renderXaiUsage(usage), "info");
+            ctx.ui.notify(csv ? renderXaiUsageCsv(usage) : renderXaiUsage(usage), "info");
           }
         } catch (error) {
           if (

--- a/tests/usage/csv-command.test.ts
+++ b/tests/usage/csv-command.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerXaiUsage } from "../../extensions/xai/usage";
+import { XAI_CLI_BILLING_URL, XAI_CLI_USER_URL } from "../../extensions/xai/constants";
+import { commandContext, createExtensionHarness } from "../fixtures/extension-api";
+import { BUILTIN_XAI_TEST_MODEL, TEST_MODEL } from "../fixtures/models";
+import { headerValue, jsonResponse } from "../fixtures/http";
+import newCredits from "../fixtures/usage/credits-new.json";
+
+function setup(model = TEST_MODEL, oauth = true) {
+  const harness = createExtensionHarness();
+  const notifications: Array<{ message: string; type?: string }> = [];
+  const setStatus = vi.fn();
+  const feature = registerXaiUsage(harness.api);
+  const ctx = commandContext(model, notifications, {
+    modelRegistry: {
+      authStorage: {
+        get: () => oauth
+          ? { type: "oauth", access: "PRIVATE_TOKEN", refresh: "PRIVATE_REFRESH", expires: Date.now() + 60_000 }
+          : { type: "api_key", key: "PRIVATE_API_KEY" },
+      },
+      find: () => model,
+      isUsingOAuth: () => oauth,
+      getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "PRIVATE_TOKEN" }),
+    },
+  });
+  ctx.ui.setStatus = setStatus;
+  return {
+    notifications,
+    run: () => harness.commands.get("xai-usage").handler("csv", ctx),
+    refresh: () => feature.refreshStatus(ctx as any),
+    setStatus,
+  };
+}
+
+describe("CSV command through real usage resolution and transport", () => {
+  it.each([TEST_MODEL, BUILTIN_XAI_TEST_MODEL])("exports only normalized fields on $provider", async (model) => {
+    const state = setup(model);
+    const fetchMock = vi.fn(async (input: string | URL | Request, _init?: RequestInit) =>
+      String(input) === XAI_CLI_USER_URL
+        ? jsonResponse({ userId: "PRIVATE_ID", email: "PRIVATE_EMAIL" })
+        : jsonResponse({ ...newCredits, rawBody: "PRIVATE_BODY", token: "PRIVATE_TOKEN" }));
+    vi.stubGlobal("fetch", fetchMock);
+    const log = vi.spyOn(console, "log");
+    const error = vi.spyOn(console, "error");
+    const warn = vi.spyOn(console, "warn");
+
+    await state.refresh();
+    expect(fetchMock).not.toHaveBeenCalled();
+    await state.run();
+    expect(fetchMock.mock.calls.map(([input]) => String(input)))
+      .toEqual([XAI_CLI_USER_URL, XAI_CLI_BILLING_URL]);
+    expect(headerValue(fetchMock.mock.calls[0][1]?.headers, "x-userid")).toBeUndefined();
+    expect(headerValue(fetchMock.mock.calls[1][1]?.headers, "x-userid")).toBe("PRIVATE_ID");
+    expect(state.notifications).toHaveLength(1);
+    expect(state.notifications[0].type).toBe("info");
+    expect(state.notifications[0].message).toMatch(/^record_type,/);
+    expect(state.notifications[0].message).toContain(",SuperGrok,42.5,");
+    expect(JSON.stringify(state.notifications)).not.toMatch(/PRIVATE_|Bearer|rawBody|userId/);
+    expect(log).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+    expect(state.setStatus).not.toHaveBeenCalled();
+    await state.refresh();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([TEST_MODEL, BUILTIN_XAI_TEST_MODEL])("rejects API-key provenance on $provider without requests", async (model) => {
+    const state = setup(model, false);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    await state.run();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(state.notifications).toEqual([{
+      message: "xAI OAuth credentials are required. Run /login xai or /login xai-auth first.",
+      type: "error",
+    }]);
+  });
+
+  it.each(["missing identity", "billing error", "oversized billing", "excess history"])(
+    "exports no CSV and reports only a safe error for %s",
+    async (failure) => {
+      const state = setup();
+      const fetchMock = vi.fn(async (input: string | URL | Request) => {
+        if (String(input) === XAI_CLI_USER_URL) {
+          return jsonResponse(failure === "missing identity" ? { email: "PRIVATE_EMAIL" } : { userId: "PRIVATE_ID" });
+        }
+        if (failure === "billing error") return jsonResponse({ error: "PRIVATE_BODY" }, 500);
+        if (failure === "oversized billing") return new Response("PRIVATE_BODY".repeat(10_000));
+        return jsonResponse({ config: { history: Array.from({ length: 25 }, () => ({})) } });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      await state.run();
+      expect(fetchMock).toHaveBeenCalledTimes(failure === "missing identity" ? 1 : 2);
+      expect(state.notifications).toHaveLength(1);
+      expect(state.notifications[0].type).toBe("error");
+      expect(state.notifications[0].message).not.toMatch(/PRIVATE_|record_type|Bearer/);
+    },
+  );
+});

--- a/tests/usage/csv.test.ts
+++ b/tests/usage/csv.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { parseXaiUsage, renderXaiUsageCsv } from "../../extensions/xai/usage";
+import { XAI_USAGE_MAX_HISTORY_PERIODS } from "../../extensions/xai/constants";
+import newCredits from "../fixtures/usage/credits-new.json";
+import legacyCredits from "../fixtures/usage/credits-legacy.json";
+
+const header = "record_type,period_type,period_start,period_end,billing_year,billing_month,"
+  + "subscription_tier,credit_usage_percent,monthly_limit_cents,included_used_cents,"
+  + "on_demand_cap_cents,on_demand_used_cents,total_used_cents,prepaid_balance_cents,"
+  + "on_demand_enabled,is_unified_billing_user";
+
+describe("xAI usage CSV rendering", () => {
+  it("exports current and historical normalized fields with stable headers and CRLF records", () => {
+    expect(renderXaiUsageCsv(parseXaiUsage(newCredits))).toBe([
+      header,
+      "current,USAGE_PERIOD_TYPE_WEEKLY,2026-07-13T00:00:00Z,2026-07-20T00:00:00Z,,,SuperGrok,42.5,,,5000,300,,1250,true,true",
+      "history,USAGE_PERIOD_TYPE_WEEKLY,2026-07-06T00:00:00Z,2026-07-13T00:00:00Z,,,,,,,,120,,,,",
+      "",
+    ].join("\r\n"));
+  });
+
+  it("keeps legacy cents exact and does not invent a percentage or historical subscription", () => {
+    expect(renderXaiUsageCsv(parseXaiUsage(legacyCredits))).toBe([
+      header,
+      "current,,2026-07-01T00:00:00Z,2026-08-01T00:00:00Z,,,,,2000,500,500,0,,,,",
+      "history,,,,2026,6,,,,1800,,0,1800,,,",
+      "",
+    ].join("\r\n"));
+  });
+
+  it("leaves missing values blank but preserves zero and false", () => {
+    const empty = renderXaiUsageCsv(parseXaiUsage({}));
+    expect(empty).toBe(`${header}\r\ncurrent${",".repeat(15)}\r\n`);
+    const usage = parseXaiUsage({
+      config: { creditUsagePercent: 0, used: {}, isUnifiedBillingUser: false },
+      onDemandEnabled: false,
+    });
+    const cells = renderXaiUsageCsv(usage).split("\r\n")[1].split(",");
+    expect(cells).toHaveLength(16);
+    expect(cells[7]).toBe("0");
+    expect(cells[9]).toBe("0");
+    expect(cells.slice(14)).toEqual(["false", "false"]);
+  });
+
+  it("quotes commas, doubles quotes, and preserves Unicode labels", () => {
+    const usage = parseXaiUsage({ subscriptionTier: 'Super, "Grok" 日本語' });
+    expect(renderXaiUsageCsv(usage)).toContain('"Super, ""Grok"" 日本語"');
+  });
+
+  it.each(["=1+1", "+1+1", "-1+1", "@SUM(1,2)", "  =1+1", "\u00a0+1+1"])(
+    "neutralizes spreadsheet formulas in all free-text columns: %s",
+    (label) => {
+      const usage = parseXaiUsage({
+        subscriptionTier: label,
+        config: { currentPeriod: { type: label }, history: [{ period: { type: label } }] },
+      });
+      const csv = renderXaiUsageCsv(usage);
+      expect(csv.split(`'${label.trim()}`)).toHaveLength(4);
+      expect(csv).not.toContain(`,${label.trim()},`);
+    },
+  );
+
+  it("escapes record delimiters defensively while the parser rejects control-bearing labels", () => {
+    expect(renderXaiUsageCsv({ history: [], subscriptionTier: "one\r\ntwo" }))
+      .toContain('"one\r\ntwo"');
+    expect(renderXaiUsageCsv(parseXaiUsage({ subscriptionTier: "one\r\ntwo" })))
+      .not.toContain("one");
+  });
+
+  it("never enumerates identity, headers, unknown fields, or raw bodies", () => {
+    const extra = {
+      userId: "PRIVATE_ID",
+      email: "PRIVATE_EMAIL",
+      headers: { Authorization: "Bearer PRIVATE_TOKEN" },
+      rawBody: "PRIVATE_RAW_BODY",
+    };
+    const parsed = parseXaiUsage({
+      ...extra,
+      ...newCredits,
+      config: { ...newCredits.config, ...extra },
+    });
+    const usage = {
+      ...parsed,
+      ...extra,
+      currentPeriod: { ...parsed.currentPeriod, ...extra },
+      history: parsed.history.map((entry) => ({ ...entry, ...extra })),
+    };
+    expect(renderXaiUsageCsv(usage)).toBe(renderXaiUsageCsv(parseXaiUsage(newCredits)));
+    expect(renderXaiUsageCsv(usage)).not.toMatch(/PRIVATE_|Bearer|userId|headers|rawBody/);
+  });
+
+  it("exports at most the parser's bounded history without pagination or truncation", () => {
+    const history = Array.from({ length: XAI_USAGE_MAX_HISTORY_PERIODS }, (_, index) => ({
+      totalUsed: { val: index },
+    }));
+    const csv = renderXaiUsageCsv(parseXaiUsage({ config: { history } }));
+    const records = csv.trimEnd().split("\r\n");
+    expect(records).toHaveLength(XAI_USAGE_MAX_HISTORY_PERIODS + 2);
+    expect(records.every((record) => record.split(",").length === 16)).toBe(true);
+    expect(records.slice(2).map((record) => record.split(",")[12]))
+      .toEqual(history.map((entry) => String(entry.totalUsed.val)));
+    expect(() => parseXaiUsage({ config: { history: [...history, {}] } }))
+      .toThrow(/too many billing periods/);
+  });
+});

--- a/tests/usage/status.test.ts
+++ b/tests/usage/status.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   registerXaiUsage,
+  renderXaiUsageCsv,
   type XaiUsageSnapshot,
 } from "../../extensions/xai/usage";
 import { commandContext, createExtensionHarness } from "../fixtures/extension-api";
@@ -82,6 +83,34 @@ describe("/xai-usage command and status lifecycle", () => {
     expect(notifications.at(-1)?.message).toMatch(/status is off/);
   });
 
+  it.each([TEST_MODEL, BUILTIN_XAI_TEST_MODEL])("exports CSV explicitly on $provider without enabling status", async (model) => {
+    const state = setup(model);
+    await state.feature.refreshStatus(state.ctx as any);
+    expect(state.fetchUsage).not.toHaveBeenCalled();
+    await state.run("  CSV  ");
+    expect(state.fetchUsage).toHaveBeenCalledTimes(1);
+    expect(state.notifications).toEqual([{ message: renderXaiUsageCsv(usage), type: "info" }]);
+    expect(state.statuses).toEqual([]);
+    await state.run("status");
+    expect(state.notifications.at(-1)?.message).toMatch(/status is off/);
+    await state.feature.refreshStatus(state.ctx as any);
+    expect(state.fetchUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["csv extra", "csv status on", "status csv", "--csv", "export csv"])(
+    "rejects unsupported CSV arguments without fetching: %s",
+    async (args) => {
+      const state = setup();
+      await state.run(args);
+      expect(state.resolveCredential).not.toHaveBeenCalled();
+      expect(state.fetchUsage).not.toHaveBeenCalled();
+      expect(state.notifications).toEqual([{
+        message: "Usage: /xai-usage [csv|status [on|off]]",
+        type: "error",
+      }]);
+    },
+  );
+
   it("keeps status off for non-xAI models and validates command arguments", async () => {
     const { fetchUsage, notifications, run, statuses } = setup({ provider: "anthropic", id: "claude" });
     await run("status on");
@@ -89,7 +118,7 @@ describe("/xai-usage command and status lifecycle", () => {
     expect(notifications.at(-1)?.message).toMatch(/Select an xAI\/Grok model/);
     expect(statuses.at(-1)).toEqual({ key: "xai-usage", text: undefined });
     await run("enable");
-    expect(notifications.at(-1)?.message).toBe("Usage: /xai-usage [status [on|off]]");
+    expect(notifications.at(-1)?.message).toBe("Usage: /xai-usage [csv|status [on|off]]");
   });
   it("enables status for a built-in xAI model with SuperGrok OAuth", async () => {
     const state = setup(BUILTIN_XAI_TEST_MODEL);
@@ -186,7 +215,7 @@ describe("/xai-usage command and status lifecycle", () => {
     expect(state.notifications.at(-1)?.message).toMatch(/status is off/);
   });
 
-  it("suppresses a stale one-shot completion after an account or session reset", async () => {
+  it.each(["", "csv"])("suppresses stale one-shot errors after a reset (%s)", async (args) => {
     const state = setup();
     state.fetchUsage.mockImplementationOnce(async (_credential: any, signal?: AbortSignal) =>
       new Promise<XaiUsageSnapshot>((_resolve, reject) => {
@@ -196,11 +225,75 @@ describe("/xai-usage command and status lifecycle", () => {
           { once: true },
         );
       }));
-    const pending = state.run("");
+    const pending = state.run(args);
     await vi.waitFor(() => expect(state.fetchUsage).toHaveBeenCalledTimes(1));
     state.feature.reset(state.ctx as any);
     await pending;
     expect(state.notifications).toEqual([]);
+  });
+
+  it.each(["cancel", "reset", "supersede"])("suppresses late CSV success after %s", async (action) => {
+    const state = setup();
+    const controller = new AbortController();
+    state.ctx.signal = controller.signal;
+    let complete!: (value: XaiUsageSnapshot) => void;
+    state.fetchUsage.mockImplementationOnce(() => new Promise((resolve) => { complete = resolve; }));
+    const pending = state.run("csv");
+    await vi.waitFor(() => expect(state.fetchUsage).toHaveBeenCalledTimes(1));
+    if (action === "cancel") controller.abort();
+    else if (action === "reset") state.feature.reset(state.ctx as any);
+    else await state.run("csv");
+    expect(state.fetchUsage.mock.calls[0][1]?.aborted).toBe(true);
+    const before = [...state.notifications];
+    complete({ subscriptionTier: "STALE_ACCOUNT", history: [] });
+    await pending;
+    expect(state.notifications).toEqual(before);
+    expect(JSON.stringify(state.notifications)).not.toContain("STALE_ACCOUNT");
+  });
+
+  it("does not resolve credentials for an already-cancelled export", async () => {
+    const state = setup();
+    state.ctx.signal = AbortSignal.abort();
+    await state.run("csv");
+    expect(state.resolveCredential).not.toHaveBeenCalled();
+    expect(state.fetchUsage).not.toHaveBeenCalled();
+    expect(state.notifications).toEqual([]);
+  });
+
+  it("does not fetch after cancellation during credential resolution", async () => {
+    const state = setup();
+    const controller = new AbortController();
+    state.ctx.signal = controller.signal;
+    state.resolveCredential.mockImplementationOnce(async () => {
+      controller.abort();
+      return { kind: "oauth-session", token: "SECRET" };
+    });
+    await state.run("csv");
+    expect(state.fetchUsage).not.toHaveBeenCalled();
+    expect(state.notifications).toEqual([{
+      message: "xAI usage request was cancelled.", type: "error",
+    }]);
+  });
+
+  it("redacts CSV credential and fetch errors without changing an enabled status", async () => {
+    const state = setup();
+    await state.run("status on");
+    const before = [...state.statuses];
+    state.resolveCredential.mockRejectedValueOnce(new Error("PRIVATE_AUTH"));
+    await state.run("csv");
+    expect(state.notifications.at(-1)).toEqual({
+      message: "xAI OAuth credentials could not be resolved. Run /login xai or /login xai-auth first.",
+      type: "error",
+    });
+    state.fetchUsage.mockRejectedValueOnce(new Error("PRIVATE_BODY"));
+    await state.run("csv");
+    expect(state.notifications.at(-1)).toEqual({ message: "xAI usage request failed.", type: "error" });
+    await state.run("csv");
+    expect(state.notifications.at(-1)).toEqual({ message: renderXaiUsageCsv(usage), type: "info" });
+    expect(state.statuses).toEqual(before);
+    await state.run("status");
+    expect(state.notifications.at(-1)?.message).toMatch(/status is on/);
+    expect(JSON.stringify(state.notifications)).not.toContain("PRIVATE_");
   });
 
   it("aborts an in-flight status refresh without a late footer write", async () => {


### PR DESCRIPTION
## Summary
- Add `/xai-usage csv` for copyable current and historical usage CSV, with no automatic file writes.
- Export only allowlisted normalized fields, preserving integer cents, blank missing values, CSV escaping, and spreadsheet-formula protection.
- Reuse the bounded OAuth-only identity-first lookup; preserve redacted errors, cancellation/reset protection, and off-by-default status.
- Add renderer, real command/transport, privacy, argument, and lifecycle tests; update README, AGENTS, CHANGELOG, and scaffold progress.

## Validation
- `npm test`: 731 tests passed, plus real Pi loader smoke.
- `npm run typecheck`: passed.
- `npm run test:coverage`: passed all coverage thresholds.
- `npm run compatibility:check`: passed policy, registry, pack, unsupported-peer, and mirror checks.
- `npm run compatibility:boundaries`: passed exact Pi 0.80.1 and 0.84.4 packed tests, loader, and typecheck (730 tests passed and one Git-only test intentionally skipped per boundary).
- LSP diagnostics and `git diff --check`: no blocking errors.

## Notes
- No live authenticated xAI requests were made during validation.
- Pre-existing `IDEA.md` remains untracked and is not included.
- Ready for review; do not merge as part of this delivery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `/xai-usage csv` command for displaying copyable current and historical usage data in CSV format.
  - CSV output includes normalized fields, exact cent values, bounded history, safe spreadsheet handling, and blank values for missing data.
  - Export remains available in both TUI and RPC interfaces without writing files or exposing sensitive response data.

- **Bug Fixes**
  - Improved cancellation handling to prevent stale results and notifications after requests are cancelled or superseded.

- **Documentation**
  - Added command details, output format, and quick-reference guidance to the documentation and changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->